### PR TITLE
Chore/#9 add deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,116 @@
+name: Deploy
+
+on:
+  workflow_run:
+    workflows: ["CI - Build & Push to ECR"]
+    types:
+      - completed
+    branches:
+      - dev
+      - master
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  deploy:
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: 환경 설정 (브랜치 → stg/prod)
+        run: |
+          if [ "${{ github.event.workflow_run.head_branch }}" = "dev" ]; then
+            echo "DEPLOY_ENV=stg"                         >> $GITHUB_ENV
+            echo "ROLE_ARN=${{ secrets.STG_ROLE_ARN }}"  >> $GITHUB_ENV
+            echo "SSM_PATH=/groute/stg"                   >> $GITHUB_ENV
+          else
+            echo "DEPLOY_ENV=prod"                        >> $GITHUB_ENV
+            echo "ROLE_ARN=${{ secrets.PROD_ROLE_ARN }}" >> $GITHUB_ENV
+            echo "SSM_PATH=/groute/prod"                  >> $GITHUB_ENV
+          fi
+          echo "IMAGE_TAG=sha-${{ github.event.workflow_run.head_sha }}" >> $GITHUB_ENV
+
+      - name: Configure AWS credentials (OIDC)
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ env.ROLE_ARN }}
+          aws-region: ap-northeast-2
+
+      - name: ECR 이미지 URI 구성
+        run: |
+          ACCOUNT_ID=$(aws sts get-caller-identity --query Account --output text)
+          ECR_REGISTRY="${ACCOUNT_ID}.dkr.ecr.ap-northeast-2.amazonaws.com"
+          echo "ECR_REGISTRY=${ECR_REGISTRY}"                               >> $GITHUB_ENV
+          echo "FULL_IMAGE=${ECR_REGISTRY}/groute-ecr:${IMAGE_TAG}"         >> $GITHUB_ENV
+
+      - name: SSM SendCommand로 EC2 배포
+        run: |
+          # shell 변수와 jq 변수 충돌 방지를 위해 파일로 분리
+          cat << 'JQ_EOF' > /tmp/jq-deploy.jq
+          {
+            Targets: [{ Key: "tag:Env", Values: [$env_val] }],
+            DocumentName: "AWS-RunShellScript",
+            Parameters: {
+              commands: [
+                "set -e",
+                ("aws ecr get-login-password --region ap-northeast-2 | docker login --username AWS --password-stdin " + $reg),
+                "docker stop groute-server 2>/dev/null || true",
+                "docker rm   groute-server 2>/dev/null || true",
+                ("docker pull " + $image),
+                ("aws ssm get-parameters-by-path --region ap-northeast-2 --path " + $ssmpath + " --recursive --with-decryption --query 'Parameters[*].[Name,Value]' --output text | awk -F'\\t' '{n=$1; sub(/.*\\//, \"\", n); print n\"=\"$2}' > /tmp/groute.env"),
+                ("docker run -d --name groute-server --restart unless-stopped --env-file /tmp/groute.env -e SPRING_PROFILES_ACTIVE=" + $env_val + " -p 8080:8080 " + $image),
+                "rm -f /tmp/groute.env"
+              ]
+            },
+            TimeoutSeconds: 300
+          }
+          JQ_EOF
+
+          jq -n \
+            --arg env_val "$DEPLOY_ENV" \
+            --arg reg     "$ECR_REGISTRY" \
+            --arg image   "$FULL_IMAGE" \
+            --arg ssmpath "$SSM_PATH" \
+            -f /tmp/jq-deploy.jq > /tmp/ssm-input.json
+
+          COMMAND_ID=$(aws ssm send-command \
+            --region ap-northeast-2 \
+            --cli-input-json file:///tmp/ssm-input.json \
+            --query "Command.CommandId" \
+            --output text)
+
+          echo "SSM Command ID: $COMMAND_ID"
+          echo "COMMAND_ID=$COMMAND_ID" >> $GITHUB_ENV
+
+      - name: 배포 결과 확인 (최대 5분 대기)
+        run: |
+          for i in $(seq 1 20); do
+            STATUS=$(aws ssm list-command-invocations \
+              --region ap-northeast-2 \
+              --command-id "$COMMAND_ID" \
+              --details \
+              --query "CommandInvocations[0].Status" \
+              --output text 2>/dev/null || echo "Pending")
+            echo "[$i/20] $STATUS"
+            case "$STATUS" in
+              Success)
+                echo "배포 완료: $FULL_IMAGE"
+                exit 0
+                ;;
+              Failed|Cancelled|TimedOut|DeliveryTimedOut)
+                echo "배포 실패: $STATUS"
+                aws ssm list-command-invocations \
+                  --region ap-northeast-2 \
+                  --command-id "$COMMAND_ID" \
+                  --details \
+                  --query "CommandInvocations[0].CommandPlugins[0].Output" \
+                  --output text
+                exit 1
+                ;;
+            esac
+            sleep 15
+          done
+          echo "배포 타임아웃 (5분)"
+          exit 1

--- a/README.md
+++ b/README.md
@@ -1,2 +1,2 @@
-# 2026-KUSITMS-GROUTE-BACK
-KUSITMS 33기 밋업프로젝트 GROUTE의 백엔드 레포지토리입니다
+# 2026-KUSITMS-GLIT-BACK
+KUSITMS 33기 밋업프로젝트 GLIT의 백엔드 레포지토리입니다

--- a/build.gradle
+++ b/build.gradle
@@ -20,8 +20,7 @@ repositories {
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-actuator'
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
-	implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
+implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-web'

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -4,9 +4,9 @@ spring:
     name: groute-server
 
   datasource:
-    url: ${DB_URL:jdbc:postgresql://localhost:5432/groute_local}
-    username: ${DB_USERNAME:postgres}
-    password: ${DB_PASSWORD:postgres}
+    url: ${SPRING_DATASOURCE_URL:jdbc:postgresql://localhost:5432/groute_local}
+    username: ${SPRING_DATASOURCE_USERNAME:postgres}
+    password: ${SPRING_DATASOURCE_PASSWORD:postgres}
     driver-class-name: org.postgresql.Driver
     hikari:
       maximum-pool-size: 10

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -1,3 +1,140 @@
+# ===== 공통 설정 (모든 환경) =====
 spring:
   application:
     name: groute-server
+
+  datasource:
+    url: ${DB_URL:jdbc:postgresql://localhost:5432/groute_local}
+    username: ${DB_USERNAME:postgres}
+    password: ${DB_PASSWORD:postgres}
+    driver-class-name: org.postgresql.Driver
+    hikari:
+      maximum-pool-size: 10
+      minimum-idle: 5
+      connection-timeout: 30000
+
+  jpa:
+    hibernate:
+      ddl-auto: none
+    properties:
+      hibernate:
+        dialect: org.hibernate.dialect.PostgreSQLDialect
+    open-in-view: false
+
+  flyway:
+    enabled: true
+    locations: classpath:db/migration
+    baseline-on-migrate: true
+
+  security:
+    oauth2:
+      client:
+        registration:
+          kakao:
+            client-name: Kakao
+            client-id: ${KAKAO_CLIENT_ID}
+            client-secret: ${KAKAO_CLIENT_SECRET}
+            redirect-uri: ${KAKAO_REDIRECT_URI}
+            client-authentication-method: client_secret_post
+            authorization-grant-type: authorization_code
+            scope:
+              - profile_nickname
+              - account_email
+          naver:
+            client-name: Naver
+            client-id: ${NAVER_CLIENT_ID}
+            client-secret: ${NAVER_CLIENT_SECRET}
+            redirect-uri: ${NAVER_REDIRECT_URI}
+            client-authentication-method: client_secret_post
+            authorization-grant-type: authorization_code
+            scope:
+              - name
+              - email
+              - profile_image
+        provider:
+          kakao:
+            authorization-uri: https://kauth.kakao.com/oauth/authorize
+            token-uri: https://kauth.kakao.com/oauth/token
+            user-info-uri: https://kapi.kakao.com/v2/user/me
+            user-name-attribute: id
+          naver:
+            authorization-uri: https://nid.naver.com/oauth2.0/authorize
+            token-uri: https://nid.naver.com/oauth2.0/token
+            user-info-uri: https://openapi.naver.com/v1/nid/me
+            user-name-attribute: response
+
+server:
+  port: 8080
+
+jwt:
+  secret: ${JWT_SECRET:local-dev-secret-key-must-be-changed-in-production-env}
+  expiration: ${JWT_EXPIRATION:86400000}
+
+springdoc:
+  swagger-ui:
+    path: /swagger-ui.html
+    enabled: true
+  api-docs:
+    path: /v3/api-docs
+    enabled: true
+
+---
+# ===== 로컬 개발 환경 =====
+spring:
+  config:
+    activate:
+      on-profile: local
+
+  jpa:
+    show-sql: true
+    properties:
+      hibernate:
+        format_sql: true
+
+logging:
+  level:
+    com.groute: DEBUG
+    org.hibernate.SQL: DEBUG
+    org.hibernate.orm.jdbc.bind: TRACE
+
+---
+# ===== Staging 환경 =====
+spring:
+  config:
+    activate:
+      on-profile: stg
+
+  jpa:
+    show-sql: false
+
+  flyway:
+    baseline-on-migrate: false
+
+logging:
+  level:
+    com.groute: INFO
+    root: WARN
+
+---
+# ===== Production 환경 =====
+spring:
+  config:
+    activate:
+      on-profile: prod
+
+  jpa:
+    show-sql: false
+
+  flyway:
+    baseline-on-migrate: false
+
+springdoc:
+  swagger-ui:
+    enabled: false
+  api-docs:
+    enabled: false
+
+logging:
+  level:
+    com.groute: WARN
+    root: ERROR


### PR DESCRIPTION
## 요약
- CI/CD 파이프라인 구축 및 서버 환경별 설정 추가, Redis 의존성 제거

## 변경 사항
- [x] 기능
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 문서
- [ ] 테스트
- [x] 기타

주요 변경:
- `deploy.yml` 추가: CI 성공 시 SSM SendCommand로 stg/prod EC2 자동 배포
- `application.yaml` 추가: JPA, OAuth2(Kakao/Naver), Flyway, JWT 환경변수 기반 설정 및 local/stg/prod 프로필 분리
  - redis는 인프라 미확정으로 제외
  - 엔티티 세팅 전으로, ddl-auto를 validate 아닌 none으로 설정
  - google의 경우 기획 측에서 전달해주는 구글 계정 받아서 관련 세팅 예정이라 제외함
- `build.gradle`: Redis 의존성 제거 (인프라 미확정)

## 테스트
- [ ] 로컬 테스트 완료
- 테스트 방법:
    - `./gradlew build -x test` 빌드 성공 여부 확인
    - dev 브랜치 push 후 CI → Deploy 워크플로우 순차 실행 확인

## 스크린샷/로그 (선택)
- 해당 없음

## 롤백/리스크
- 리스크 포인트: SSM Parameter Store 값 미등록 시 앱 기동 실패 (DB_URL, JWT_SECRET 등 11개)
  - 추가는 해두었으나, 빠뜨린 게 있을 시 수정 예정
- 롤백 방법: deploy.yml 제거 후 기존 ci.yml만 유지, application.yaml 초기화

## 관련 이슈
Closes #9 