### PR TITLE
Fix/#13 branch create 404

### DIFF
--- a/.github/workflows/jira-issue-create.yml
+++ b/.github/workflows/jira-issue-create.yml
@@ -63,7 +63,7 @@ jobs:
           AUTH=$(echo -n "$JIRA_USER_EMAIL:$JIRA_API_TOKEN" | base64 -w 0)
 
           PAYLOAD=$(jq -n \
-            --arg summary    "$GH_ISSUE_TITLE" \
+            --arg summary    "[백] $GH_ISSUE_TITLE" \
             --arg itype      "$GH_ISSUE_TYPE" \
             --arg gh_url     "$GH_ISSUE_URL" \
             --arg author     "$GH_ISSUE_AUTHOR" \
@@ -128,8 +128,8 @@ jobs:
           BRANCH="${{ steps.meta.outputs.branch_prefix }}/${JIRA_KEY}-${{ steps.meta.outputs.slug }}"
           echo "branch_name=$BRANCH" >> "$GITHUB_OUTPUT"
 
-          # 기본 브랜치(main)의 최신 SHA 조회
-          SHA=$(gh api "repos/${{ github.repository }}/git/ref/heads/main" --jq '.object.sha')
+          # 베이스 브랜치(dev)의 최신 SHA 조회
+          SHA=$(gh api "repos/${{ github.repository }}/git/ref/heads/dev" --jq '.object.sha')
 
           # 브랜치 생성
           gh api \


### PR DESCRIPTION
## 요약
- Jira 이슈 생성 워크플로우가 존재하지 않는 `main` 브랜치를 참조해 404로 실패하던 문제를 `dev` 기준으로 수정하고, 프론트 `[프]` 컨벤션에 맞춰 Jira summary에 `[백]` 프리픽스를 추가.

## 변경 사항
- [ ] 기능
- [x] 버그 수정
- [ ] 리팩토링
- [ ] 문서
- [ ] 테스트
- [x] 기타  <!-- CI 워크플로우 설정 변경 -->

## 테스트
- 이 워크플로우는 `on: issues.opened` 트리거라 로컬 실행 불가.
- 테스트 방법:
    - 이 PR 머지 후 테스트용 GitHub 이슈를 1건 생성한다.
    - Actions 탭에서 `GitHub Issue → Jira 이슈 생성 + 브랜치 생성` 워크플로우가 전 스텝을 통과하는지 확인.
    - Jira `GRT` 프로젝트에 `[백] <원제목>` 형식으로 이슈가 생성되었는지 확인.
    - 원격 레포에 `<prefix>/<JIRA_KEY>-<slug>` 브랜치가 **`dev` HEAD 기준**으로 생성되었는지 확인.

## 스크린샷/로그 (선택)
- 수정 전 실패 로그:
    ```
    gh: Not Found (HTTP 404)
    Error: Process completed with exit code 1.
    ```
- 실패 지점: `gh api repos/<org>/<repo>/git/ref/heads/main` (해당 레포에 `main` 브랜치 없음. `master`로 이름 변경 미반영.)

## 롤백/리스크
- 리스크 포인트:
    - `[백]` 프리픽스가 Jira 필터/자동화 룰과 충돌할 가능성 (사용 중인 JQL이 summary 접두사에 의존한다면 확인 필요).
    - 변경 범위는 워크플로우 1개 파일, 3줄이라 코드 런타임 영향은 없음.
- 롤백 방법:
    - 이 PR을 revert 하거나, `.github/workflows/jira-issue-create.yml`의 두 지점을 원복:
        - `summary`: `"[백] $GH_ISSUE_TITLE"` → `"$GH_ISSUE_TITLE"`
        - `gh api .../git/ref/heads/dev` → `.../git/ref/heads/<대체 기준 브랜치>`

## 관련 이슈
Closes #13