### PR TITLE
chore: Swagger 공통 설정 구성 (#17)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,6 +5,7 @@
 - `1. Workflow 개요` — 전체적인 워크플로우 이해용
 - `2. Git Convention` — 실제 작업 시 컨벤션 확인용
 - `3. 프로젝트 폴더 구조` — 아키텍처 기반 디렉터리 규칙
+- `4. Swagger 작성 가이드` — API 작업 시 Swagger 어노테이션 규칙
 
 ---
 
@@ -253,3 +254,67 @@ src/main/java/com/groute/groute_server/
 - 단순 CRUD 성격 → **Layered** 구조로 추가
 - 외부 의존성이 다수이거나 도메인 규칙이 복잡 → **Hexagonal** 구조로 추가
 - 구조 결정이 모호할 경우 PR 전에 팀 내 논의를 거쳐 결정합니다.
+
+---
+
+## 4. Swagger 작성 가이드
+
+API 작업 시 프론트엔드가 Swagger UI에서 스펙을 바로 확인할 수 있도록 아래 어노테이션을 반드시 작성합니다.
+
+> **자동으로 처리되는 것** (직접 설정 불필요)
+> - 도메인별 그룹화 — `GroupedOpenApi`가 패키지 기준으로 자동 분리
+> - JWT 인증 — 글로벌 `@SecurityScheme` 적용 완료
+> - 서버 URL — 환경별(local/stg/prod) 자동 적용
+
+### 4.1 Controller 레벨
+
+| 어노테이션 | 용도 |
+| --- | --- |
+| `@Tag(name = "...", description = "...")` | 컨트롤러 그룹 이름 및 설명. Swagger UI에서 그룹 제목으로 표시 |
+
+```java
+@Tag(name = "회원", description = "온보딩·마이페이지 API")
+@RestController
+@RequestMapping("/api/v1/users")
+public class UserController { }
+```
+
+### 4.2 엔드포인트 레벨
+
+| 어노테이션 | 용도 |
+| --- | --- |
+| `@Operation(summary = "...", description = "...")` | API 한 줄 요약 + 상세 설명 |
+| `@ApiResponse(responseCode = "...", description = "...")` | 응답 코드별 설명 |
+
+```java
+@Operation(summary = "닉네임 변경", description = "마이페이지에서 닉네임을 변경합니다.")
+@ApiResponse(responseCode = "200", description = "변경 성공")
+@ApiResponse(responseCode = "400", description = "유효하지 않은 닉네임")
+@PutMapping("/nickname")
+public ApiResponse<Void> updateNickname(...) { }
+```
+
+**인증이 불필요한 엔드포인트**의 경우에만 `@SecurityRequirement`를 빈 값으로 설정하여 글로벌 인증을 제외합니다.
+
+```java
+@Operation(summary = "소셜 로그인")
+@SecurityRequirement(name = "")
+@PostMapping("/auth/login")
+public ApiResponse<LoginResponse> login(...) { }
+```
+
+### 4.3 DTO 레벨
+
+| 어노테이션 | 용도 |
+| --- | --- |
+| `@Schema(description = "...", example = "...")` | 필드 설명 + 예시값 |
+
+```java
+public record CreateUserRequest(
+        @Schema(description = "닉네임", example = "겨레")
+        String nickname,
+
+        @Schema(description = "직군", example = "DEVELOPER")
+        String jobGroup
+) { }
+```

--- a/src/main/java/com/groute/groute_server/common/config/SecurityConfig.java
+++ b/src/main/java/com/groute/groute_server/common/config/SecurityConfig.java
@@ -1,0 +1,28 @@
+package com.groute.groute_server.common.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+@EnableWebSecurity
+public class SecurityConfig {
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        http
+                .csrf(csrf -> csrf.disable())
+                .authorizeHttpRequests(auth -> auth
+                        .requestMatchers(
+                                "/swagger-ui/**",
+                                "/swagger-ui.html",
+                                "/v3/api-docs/**"
+                        ).permitAll()
+                        .anyRequest().authenticated()
+                );
+
+        return http.build();
+    }
+}

--- a/src/main/java/com/groute/groute_server/common/config/SwaggerConfig.java
+++ b/src/main/java/com/groute/groute_server/common/config/SwaggerConfig.java
@@ -1,0 +1,68 @@
+package com.groute.groute_server.common.config;
+
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import org.springdoc.core.models.GroupedOpenApi;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class SwaggerConfig {
+
+    @Bean
+    public OpenAPI openAPI() {
+        return new OpenAPI()
+                .info(new Info()
+                        .title("GLIT API")
+                        .description("GLIT 백엔드 API 문서")
+                        .version("v1.0.0"));
+    }
+
+    @Bean
+    public GroupedOpenApi authApi() {
+        return GroupedOpenApi.builder()
+                .group("Auth")
+                .packagesToScan("com.groute.groute_server.auth")
+                .build();
+    }
+
+    @Bean
+    public GroupedOpenApi calendarApi() {
+        return GroupedOpenApi.builder()
+                .group("Calendar")
+                .packagesToScan("com.groute.groute_server.calendar")
+                .build();
+    }
+
+    @Bean
+    public GroupedOpenApi homeApi() {
+        return GroupedOpenApi.builder()
+                .group("Home")
+                .packagesToScan("com.groute.groute_server.home")
+                .build();
+    }
+
+    @Bean
+    public GroupedOpenApi recordApi() {
+        return GroupedOpenApi.builder()
+                .group("Record")
+                .packagesToScan("com.groute.groute_server.record")
+                .build();
+    }
+
+    @Bean
+    public GroupedOpenApi reportApi() {
+        return GroupedOpenApi.builder()
+                .group("Report")
+                .packagesToScan("com.groute.groute_server.report")
+                .build();
+    }
+
+    @Bean
+    public GroupedOpenApi userApi() {
+        return GroupedOpenApi.builder()
+                .group("User")
+                .packagesToScan("com.groute.groute_server.user")
+                .build();
+    }
+}

--- a/src/main/java/com/groute/groute_server/common/config/SwaggerConfig.java
+++ b/src/main/java/com/groute/groute_server/common/config/SwaggerConfig.java
@@ -1,12 +1,23 @@
 package com.groute.groute_server.common.config;
 
+import io.swagger.v3.oas.annotations.enums.SecuritySchemeIn;
+import io.swagger.v3.oas.annotations.enums.SecuritySchemeType;
+import io.swagger.v3.oas.annotations.security.SecurityScheme;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
 import org.springdoc.core.models.GroupedOpenApi;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 @Configuration
+@SecurityScheme(
+        name = "bearerAuth",
+        type = SecuritySchemeType.HTTP,
+        scheme = "bearer",
+        bearerFormat = "JWT",
+        in = SecuritySchemeIn.HEADER
+)
 public class SwaggerConfig {
 
     @Bean
@@ -15,7 +26,8 @@ public class SwaggerConfig {
                 .info(new Info()
                         .title("GLIT API")
                         .description("GLIT 백엔드 API 문서")
-                        .version("v1.0.0"));
+                        .version("v1.0.0"))
+                .addSecurityItem(new SecurityRequirement().addList("bearerAuth"));
     }
 
     @Bean

--- a/src/main/java/com/groute/groute_server/common/config/SwaggerConfig.java
+++ b/src/main/java/com/groute/groute_server/common/config/SwaggerConfig.java
@@ -6,7 +6,9 @@ import io.swagger.v3.oas.annotations.security.SecurityScheme;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Info;
 import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.servers.Server;
 import org.springdoc.core.models.GroupedOpenApi;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -20,6 +22,12 @@ import org.springframework.context.annotation.Configuration;
 )
 public class SwaggerConfig {
 
+    @Value("${app.swagger.server-url}")
+    private String serverUrl;
+
+    @Value("${app.swagger.server-description}")
+    private String serverDescription;
+
     @Bean
     public OpenAPI openAPI() {
         return new OpenAPI()
@@ -27,7 +35,8 @@ public class SwaggerConfig {
                         .title("GLIT API")
                         .description("GLIT 백엔드 API 문서")
                         .version("v1.0.0"))
-                .addSecurityItem(new SecurityRequirement().addList("bearerAuth"));
+                .addSecurityItem(new SecurityRequirement().addList("bearerAuth"))
+                .addServersItem(new Server().url(serverUrl).description(serverDescription));
     }
 
     @Bean

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -78,6 +78,11 @@ springdoc:
     path: /v3/api-docs
     enabled: true
 
+app:
+  swagger:
+    server-url: http://localhost:8080
+    server-description: Local
+
 ---
 # ===== 로컬 개발 환경 =====
 spring:
@@ -110,6 +115,11 @@ spring:
   flyway:
     baseline-on-migrate: false
 
+app:
+  swagger:
+    server-url: https://stg.api.glit.today
+    server-description: Staging
+
 logging:
   level:
     com.groute: INFO
@@ -133,6 +143,11 @@ springdoc:
     enabled: false
   api-docs:
     enabled: false
+
+app:
+  swagger:
+    server-url: https://api.glit.today
+    server-description: Production
 
 logging:
   level:

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -74,6 +74,11 @@ springdoc:
   swagger-ui:
     path: /swagger-ui.html
     enabled: true
+    try-it-out-enabled: true
+    operations-sorter: method
+    deep-linking: true
+    default-models-expand-depth: 2
+    doc-expansion: list
   api-docs:
     path: /v3/api-docs
     enabled: true


### PR DESCRIPTION
## 요약
- 프론트엔드가 Swagger UI에서 API 스펙을 편리하게 확인할 수 있도록 공통 Swagger 설정을 구성

## 변경 사항
- [ ] 기능
- [ ] 버그 수정
- [ ] 리팩토링
- [x] 문서
- [ ] 테스트
- [x] 기타

### 참고해주세요
- SwaggerConfig 생성 및 도메인별(Auth, Calendar, Home, Record, Report, User) GroupedOpenApi 등록
  - 프론트에서 조회 시 우측 상단에서 그룹 이동해 조회 가능
- JWT SecurityScheme(Bearer) 및 글로벌 SecurityRequirement 설정
  - 기본적으로 보호 + 필요할 경우 풀 수 있음
- SecurityConfig 생성 및 Swagger 경로(`/swagger-ui/**`, `/v3/api-docs/**`) permitAll 설정
- 환경별 Swagger 서버 URL 설정 (local: `localhost:8080`, stg: `stg.api.glit.today`, prod: `api.glit.today`)
- Swagger UI 편의 옵션 설정 (tryItOut 기본 활성화, HTTP 메서드순 정렬, deepLinking, docExpansion)
  - deepLinking은 특정 API URL 복사해서 공유 가능하도록 함
  - docExpansion은 list 레벨로 설정, API 목록이 접히지 않고 펼쳐져 있도록 함
- CONTRIBUTING.md에 Swagger 작성 가이드(Controller/엔드포인트/DTO 레벨 어노테이션 규칙) 추가

## 테스트
- [x] 로컬 테스트 완료
- 테스트 방법:
    - `./gradlew compileJava` 빌드 성공 확인
    - 로컬 서버 기동 후 `/swagger-ui.html` 접속하여 확인

## 스크린샷/로그 (선택)
- X

## 롤백/리스크
- 리스크 포인트: 없음 (신규 설정 파일 추가만 포함)
- 롤백 방법: 해당 커밋 revert

## 관련 이슈
Closes #17