### PR TITLE
chore: 공통 API 응답 및 예외 처리 세팅 (#18)

### DIFF
--- a/src/main/java/com/groute/groute_server/common/exception/BusinessException.java
+++ b/src/main/java/com/groute/groute_server/common/exception/BusinessException.java
@@ -1,0 +1,19 @@
+package com.groute.groute_server.common.exception;
+
+import lombok.Getter;
+
+@Getter
+public class BusinessException extends RuntimeException {
+
+    private final ErrorCode errorCode;
+
+    public BusinessException(ErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+    }
+
+    public BusinessException(ErrorCode errorCode, String message) {
+        super(message);
+        this.errorCode = errorCode;
+    }
+}

--- a/src/main/java/com/groute/groute_server/common/exception/BusinessException.java
+++ b/src/main/java/com/groute/groute_server/common/exception/BusinessException.java
@@ -2,6 +2,17 @@ package com.groute.groute_server.common.exception;
 
 import lombok.Getter;
 
+/**
+ * 비즈니스 로직 예외의 베이스 클래스.
+ *
+ * <p>도메인 규칙 위반 시 {@link ErrorCode}와 함께 던지면
+ * {@link GlobalExceptionHandler}가 일관된 에러 응답으로 변환한다.</p>
+ *
+ * <pre>{@code
+ * throw new BusinessException(ErrorCode.RESOURCE_NOT_FOUND);
+ * throw new BusinessException(ErrorCode.RESOURCE_NOT_FOUND, "게시글을 찾을 수 없습니다.");
+ * }</pre>
+ */
 @Getter
 public class BusinessException extends RuntimeException {
 

--- a/src/main/java/com/groute/groute_server/common/exception/ErrorCode.java
+++ b/src/main/java/com/groute/groute_server/common/exception/ErrorCode.java
@@ -4,6 +4,17 @@ import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 
+/**
+ * 애플리케이션 에러 코드 정의.
+ *
+ * <p>공통 에러는 {@code COMMON_} 프리픽스를 사용하며,
+ * 도메인별 에러 코드는 각 도메인 패키지에서 추가한다.</p>
+ *
+ * <pre>
+ * // 도메인 에러 코드 추가 예시
+ * USER_NOT_FOUND(HttpStatus.NOT_FOUND, "USER_001", "사용자를 찾을 수 없습니다."),
+ * </pre>
+ */
 @Getter
 @RequiredArgsConstructor
 public enum ErrorCode {

--- a/src/main/java/com/groute/groute_server/common/exception/ErrorCode.java
+++ b/src/main/java/com/groute/groute_server/common/exception/ErrorCode.java
@@ -1,0 +1,23 @@
+package com.groute.groute_server.common.exception;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum ErrorCode {
+
+    // Common
+    INVALID_INPUT(HttpStatus.BAD_REQUEST, "COMMON_001", "잘못된 입력값입니다."),
+    RESOURCE_NOT_FOUND(HttpStatus.NOT_FOUND, "COMMON_002", "요청한 리소스를 찾을 수 없습니다."),
+    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "COMMON_003", "서버 내부 오류가 발생했습니다."),
+    INVALID_REQUEST_BODY(HttpStatus.BAD_REQUEST, "COMMON_004", "요청 본문을 파싱할 수 없습니다."),
+    UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "COMMON_005", "인증이 필요합니다."),
+    FORBIDDEN(HttpStatus.FORBIDDEN, "COMMON_006", "접근 권한이 없습니다."),
+    ;
+
+    private final HttpStatus httpStatus;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/com/groute/groute_server/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/groute/groute_server/common/exception/GlobalExceptionHandler.java
@@ -11,6 +11,11 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 
 import java.util.List;
 
+/**
+ * 전역 예외 처리기.
+ *
+ * <p>모든 예외를 {@link ErrorResponse} 형식으로 변환하여 일관된 에러 응답을 보장한다.</p>
+ */
 @Slf4j
 @RestControllerAdvice
 public class GlobalExceptionHandler {

--- a/src/main/java/com/groute/groute_server/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/groute/groute_server/common/exception/GlobalExceptionHandler.java
@@ -1,0 +1,70 @@
+package com.groute.groute_server.common.exception;
+
+import com.groute.groute_server.common.response.ErrorResponse;
+import jakarta.validation.ConstraintViolationException;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import java.util.List;
+
+@Slf4j
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(BusinessException.class)
+    protected ResponseEntity<ErrorResponse> handleBusinessException(BusinessException e) {
+        log.warn("BusinessException: {}", e.getMessage());
+        ErrorCode errorCode = e.getErrorCode();
+        return ResponseEntity
+                .status(errorCode.getHttpStatus())
+                .body(ErrorResponse.of(errorCode));
+    }
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    protected ResponseEntity<ErrorResponse> handleMethodArgumentNotValidException(MethodArgumentNotValidException e) {
+        log.warn("MethodArgumentNotValidException: {}", e.getMessage());
+        List<ErrorResponse.FieldError> fieldErrors = e.getBindingResult().getFieldErrors().stream()
+                .map(error -> ErrorResponse.FieldError.of(
+                        error.getField(),
+                        error.getRejectedValue() == null ? "" : error.getRejectedValue().toString(),
+                        error.getDefaultMessage()))
+                .toList();
+        return ResponseEntity
+                .badRequest()
+                .body(ErrorResponse.of(ErrorCode.INVALID_INPUT, fieldErrors));
+    }
+
+    @ExceptionHandler(ConstraintViolationException.class)
+    protected ResponseEntity<ErrorResponse> handleConstraintViolationException(ConstraintViolationException e) {
+        log.warn("ConstraintViolationException: {}", e.getMessage());
+        List<ErrorResponse.FieldError> fieldErrors = e.getConstraintViolations().stream()
+                .map(violation -> ErrorResponse.FieldError.of(
+                        violation.getPropertyPath().toString(),
+                        violation.getInvalidValue() == null ? "" : violation.getInvalidValue().toString(),
+                        violation.getMessage()))
+                .toList();
+        return ResponseEntity
+                .badRequest()
+                .body(ErrorResponse.of(ErrorCode.INVALID_INPUT, fieldErrors));
+    }
+
+    @ExceptionHandler(HttpMessageNotReadableException.class)
+    protected ResponseEntity<ErrorResponse> handleHttpMessageNotReadableException(HttpMessageNotReadableException e) {
+        log.warn("HttpMessageNotReadableException: {}", e.getMessage());
+        return ResponseEntity
+                .badRequest()
+                .body(ErrorResponse.of(ErrorCode.INVALID_REQUEST_BODY));
+    }
+
+    @ExceptionHandler(Exception.class)
+    protected ResponseEntity<ErrorResponse> handleException(Exception e) {
+        log.error("Unhandled Exception: ", e);
+        return ResponseEntity
+                .internalServerError()
+                .body(ErrorResponse.of(ErrorCode.INTERNAL_SERVER_ERROR));
+    }
+}

--- a/src/main/java/com/groute/groute_server/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/groute/groute_server/common/exception/GlobalExceptionHandler.java
@@ -26,7 +26,7 @@ public class GlobalExceptionHandler {
         ErrorCode errorCode = e.getErrorCode();
         return ResponseEntity
                 .status(errorCode.getHttpStatus())
-                .body(ErrorResponse.of(errorCode));
+                .body(ErrorResponse.of(errorCode, e.getMessage()));
     }
 
     @ExceptionHandler(MethodArgumentNotValidException.class)

--- a/src/main/java/com/groute/groute_server/common/response/ApiResponse.java
+++ b/src/main/java/com/groute/groute_server/common/response/ApiResponse.java
@@ -1,6 +1,7 @@
 package com.groute.groute_server.common.response;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -29,9 +30,16 @@ import lombok.Getter;
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class ApiResponse<T> {
 
+    @Schema(description = "요청 성공 여부", example = "true")
     private final boolean success;
+
+    @Schema(description = "HTTP 상태 코드", example = "200")
     private final String code;
+
+    @Schema(description = "응답 메시지", example = "조회 성공")
     private final String message;
+
+    @Schema(description = "응답 데이터")
     private final T data;
 
     public static <T> ApiResponse<T> ok(String message, T data) {

--- a/src/main/java/com/groute/groute_server/common/response/ApiResponse.java
+++ b/src/main/java/com/groute/groute_server/common/response/ApiResponse.java
@@ -1,0 +1,41 @@
+package com.groute.groute_server.common.response;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class ApiResponse<T> {
+
+    private final boolean success;
+    private final String code;
+    private final String message;
+    private final T data;
+
+    public static <T> ApiResponse<T> ok(String message, T data) {
+        return new ApiResponse<>(true, "200", message, data);
+    }
+
+    public static <T> ApiResponse<T> ok(T data) {
+        return new ApiResponse<>(true, "200", null, data);
+    }
+
+    public static ApiResponse<Void> ok(String message) {
+        return new ApiResponse<>(true, "200", message, null);
+    }
+
+    public static <T> ApiResponse<T> created(String message, T data) {
+        return new ApiResponse<>(true, "201", message, data);
+    }
+
+    public static ApiResponse<Void> created(String message) {
+        return new ApiResponse<>(true, "201", message, null);
+    }
+
+    public static ApiResponse<Void> fail(String code, String message) {
+        return new ApiResponse<>(false, code, message, null);
+    }
+}

--- a/src/main/java/com/groute/groute_server/common/response/ApiResponse.java
+++ b/src/main/java/com/groute/groute_server/common/response/ApiResponse.java
@@ -5,6 +5,25 @@ import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
+/**
+ * 공통 API 응답 래퍼.
+ *
+ * <p>모든 API 엔드포인트는 이 클래스를 통해 일관된 형식으로 응답을 반환한다.
+ * null 필드는 JSON 직렬화 시 생략된다.</p>
+ *
+ * <pre>{@code
+ * // 데이터 + 메시지
+ * ApiResponse.ok("조회 성공", userDto);
+ *
+ * // 데이터만
+ * ApiResponse.ok(userDto);
+ *
+ * // 메시지만
+ * ApiResponse.ok("삭제 완료");
+ * }</pre>
+ *
+ * @param <T> 응답 데이터 타입
+ */
 @Getter
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @JsonInclude(JsonInclude.Include.NON_NULL)

--- a/src/main/java/com/groute/groute_server/common/response/ErrorResponse.java
+++ b/src/main/java/com/groute/groute_server/common/response/ErrorResponse.java
@@ -2,9 +2,9 @@ package com.groute.groute_server.common.response;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.groute.groute_server.common.exception.ErrorCode;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
-import lombok.Builder;
 import lombok.Getter;
 
 import java.util.List;
@@ -23,9 +23,16 @@ import java.util.List;
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class ErrorResponse {
 
+    @Schema(description = "요청 성공 여부", example = "false")
     private final boolean success;
+
+    @Schema(description = "커스텀 에러 코드", example = "COMMON_001")
     private final String code;
+
+    @Schema(description = "에러 메시지", example = "잘못된 입력값입니다.")
     private final String message;
+
+    @Schema(description = "필드별 상세 에러 목록 (Validation 에러 시)")
     private final List<FieldError> errors;
 
     public static ErrorResponse of(ErrorCode errorCode) {
@@ -44,8 +51,13 @@ public class ErrorResponse {
     @AllArgsConstructor(access = AccessLevel.PRIVATE)
     public static class FieldError {
 
+        @Schema(description = "에러 발생 필드명", example = "nickname")
         private final String field;
+
+        @Schema(description = "입력된 값", example = "")
         private final String value;
+
+        @Schema(description = "에러 사유", example = "닉네임은 필수입니다.")
         private final String reason;
 
         public static FieldError of(String field, String value, String reason) {

--- a/src/main/java/com/groute/groute_server/common/response/ErrorResponse.java
+++ b/src/main/java/com/groute/groute_server/common/response/ErrorResponse.java
@@ -9,6 +9,15 @@ import lombok.Getter;
 
 import java.util.List;
 
+/**
+ * 공통 에러 응답 DTO.
+ *
+ * <p>{@code success}는 항상 {@code false}이며, Validation 에러 시
+ * {@code errors} 필드에 필드별 상세 정보가 포함된다.</p>
+ *
+ * @see ErrorCode
+ * @see FieldError
+ */
 @Getter
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @JsonInclude(JsonInclude.Include.NON_NULL)

--- a/src/main/java/com/groute/groute_server/common/response/ErrorResponse.java
+++ b/src/main/java/com/groute/groute_server/common/response/ErrorResponse.java
@@ -1,0 +1,46 @@
+package com.groute.groute_server.common.response;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.groute.groute_server.common.exception.ErrorCode;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class ErrorResponse {
+
+    private final boolean success;
+    private final String code;
+    private final String message;
+    private final List<FieldError> errors;
+
+    public static ErrorResponse of(ErrorCode errorCode) {
+        return new ErrorResponse(false, errorCode.getCode(), errorCode.getMessage(), null);
+    }
+
+    public static ErrorResponse of(ErrorCode errorCode, String message) {
+        return new ErrorResponse(false, errorCode.getCode(), message, null);
+    }
+
+    public static ErrorResponse of(ErrorCode errorCode, List<FieldError> errors) {
+        return new ErrorResponse(false, errorCode.getCode(), errorCode.getMessage(), errors);
+    }
+
+    @Getter
+    @AllArgsConstructor(access = AccessLevel.PRIVATE)
+    public static class FieldError {
+
+        private final String field;
+        private final String value;
+        private final String reason;
+
+        public static FieldError of(String field, String value, String reason) {
+            return new FieldError(field, value, reason);
+        }
+    }
+}


### PR DESCRIPTION
## 요약
- 모든 API에서 일관된 응답/에러 형식을 사용하기 위한 공통 응답 래퍼 및 예외 처리 인프라 구축

## 변경 사항
- [ ] 기능
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 문서
- [ ] 테스트
- [x] 기타

### 세부 설명
- `ApiResponse<T>` 공통 응답 래퍼 생성 (success, code, message, data)
- `ErrorCode` enum 정의 (COMMON_001 ~ COMMON_006)
- `BusinessException` 커스텀 예외 베이스 클래스 생성
- `ErrorResponse` 에러 응답 DTO 생성 (Validation 에러 시 필드별 상세 목록 지원)
- `GlobalExceptionHandler` 구현 (Business, Validation, JSON 파싱, fallback)
- 응답 DTO에 Swagger `@Schema` 적용
- 공통 응답/예외 클래스에 Javadoc 추가

## 테스트
- [x] 로컬 테스트 완료
- 테스트 방법:
    - `./gradlew compileJava` 빌드 성공 확인

## 스크린샷/로그 (선택)
- X

## 롤백/리스크
- 리스크 포인트: 없음 (신규 클래스 추가만 포함, 기존 코드 변경 없음)
- 롤백 방법: 해당 커밋 revert

## 관련 이슈
Closes #18 

> **Note**: Stacked PR입니다. 현재 base 브랜치는 `chore/GRT-45-swagger-config-setup`이며, 해당 PR이 `dev`에 머지되면 이 PR의 base를 `dev`로 변경할 예정입니다.