### PR TITLE
chore: JaCoCo 기반 테스트 커버리지 환경 셋업 (#23)

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -15,6 +15,11 @@
     - 예) ./gradlew test
     - 예) Postman 컬렉션 실행
 
+### 커버리지 (JaCoCo)
+- 라인 커버리지: __%  (기준: 60% 이상)
+- [ ] `./gradlew test` 실행 후 `build/reports/jacoco/index.html`에서 수치 확인
+- (선택) 리포트 스크린샷 또는 60% 미달/특이사항 공유:
+
 ## 스크린샷/로그 (선택)
 - 필요한 경우 첨부
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,6 +6,7 @@
 - `2. Git Convention` — 실제 작업 시 컨벤션 확인용
 - `3. 프로젝트 폴더 구조` — 아키텍처 기반 디렉터리 규칙
 - `4. Swagger 작성 가이드` — API 작업 시 Swagger 어노테이션 규칙
+- `5. 테스트 커버리지 (JaCoCo)` — 테스트/커버리지 기준 및 실행 방법
 
 ---
 
@@ -318,3 +319,40 @@ public record CreateUserRequest(
         String jobGroup
 ) { }
 ```
+
+---
+
+## 5. 테스트 커버리지 (JaCoCo)
+
+서비스 레이어 비즈니스 로직을 중심으로 단위 테스트를 작성하며, 커버리지는 JaCoCo로 측정합니다.
+
+### 5.1 합의된 기준
+
+- **라인 커버리지 60% 이상**
+- 브랜치 커버리지는 현 단계에서 강제하지 않습니다.
+- 기준은 `jacocoTestCoverageVerification`으로 자동 검증되며, 미달 시 로컬 `./gradlew check` 단계에서 빌드가 실패합니다.
+
+### 5.2 실행 방법
+
+| 명령 | 용도 |
+| --- | --- |
+| `./gradlew test` | 테스트 실행 + HTML 리포트 생성 (`finalizedBy`로 자동) |
+| `./gradlew check` | 위 + 커버리지 기준(60%) 검증까지 수행. PR 올리기 전 권장 |
+
+리포트 경로: `build/reports/jacoco/index.html`
+
+### 5.3 커버리지 측정 제외 패키지
+
+로직이 거의 없거나 자동 생성되는 클래스는 커버리지 지표에서 제외됩니다.
+
+- `**/*Application*` — Spring Boot 엔트리 클래스
+- `**/dto/**`, `**/response/**` — 요청/응답 DTO 및 래퍼
+- `**/config/**` — 설정 클래스
+- `**/exception/**` — 예외/에러코드 정의
+- `**/Q*.class` — QueryDSL 자동 생성 클래스
+
+새 패키지 추가 또는 제외 정책 변경이 필요하면 `build.gradle`의 `jacocoExcludes`를 수정하고 팀에 공유합니다.
+
+### 5.4 PR 연동
+
+PR 템플릿의 **`커버리지 (JaCoCo)`** 섹션에 라인 커버리지 수치를 기입합니다. 자세한 체크리스트는 `.github/pull_request_template.md` 참조.

--- a/build.gradle
+++ b/build.gradle
@@ -76,9 +76,29 @@ tasks.named('jacocoTestReport') {
 }
 
 tasks.named('jacocoTestCoverageVerification') {
+	dependsOn tasks.named('test')
 	classDirectories.setFrom(
 		files(classDirectories.files.collect {
 			fileTree(dir: it, exclude: jacocoExcludes)
 		})
 	)
+	violationRules {
+		rule {
+			element = 'BUNDLE'
+			limit {
+				counter = 'LINE'
+				value = 'COVEREDRATIO'
+				minimum = 0.70
+			}
+			limit {
+				counter = 'BRANCH'
+				value = 'COVEREDRATIO'
+				minimum = 0.60
+			}
+		}
+	}
+}
+
+tasks.named('check') {
+	dependsOn tasks.named('jacocoTestCoverageVerification')
 }

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,6 @@
 plugins {
 	id 'java'
+	id 'jacoco'
 	id 'org.springframework.boot' version '3.5.13'
 	id 'io.spring.dependency-management' version '1.1.7'
 }
@@ -20,7 +21,7 @@ repositories {
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-actuator'
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
+	implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
@@ -41,6 +42,11 @@ jar {
     enabled = false
 }
 
+jacoco {
+	toolVersion = '0.8.12'
+}
+
 tasks.named('test') {
 	useJUnitPlatform()
+	finalizedBy tasks.named('jacocoTestReport')
 }

--- a/build.gradle
+++ b/build.gradle
@@ -50,3 +50,13 @@ tasks.named('test') {
 	useJUnitPlatform()
 	finalizedBy tasks.named('jacocoTestReport')
 }
+
+tasks.named('jacocoTestReport') {
+	dependsOn tasks.named('test')
+	reports {
+		html.required = true
+		xml.required = false
+		csv.required = false
+		html.outputLocation = layout.buildDirectory.dir('reports/jacoco')
+	}
+}

--- a/build.gradle
+++ b/build.gradle
@@ -46,6 +46,15 @@ jacoco {
 	toolVersion = '0.8.12'
 }
 
+def jacocoExcludes = [
+	'**/*Application*',
+	'**/dto/**',
+	'**/response/**',
+	'**/config/**',
+	'**/exception/**',
+	'**/Q*.class',
+]
+
 tasks.named('test') {
 	useJUnitPlatform()
 	finalizedBy tasks.named('jacocoTestReport')
@@ -59,4 +68,17 @@ tasks.named('jacocoTestReport') {
 		csv.required = false
 		html.outputLocation = layout.buildDirectory.dir('reports/jacoco')
 	}
+	classDirectories.setFrom(
+		files(classDirectories.files.collect {
+			fileTree(dir: it, exclude: jacocoExcludes)
+		})
+	)
+}
+
+tasks.named('jacocoTestCoverageVerification') {
+	classDirectories.setFrom(
+		files(classDirectories.files.collect {
+			fileTree(dir: it, exclude: jacocoExcludes)
+		})
+	)
 }

--- a/build.gradle
+++ b/build.gradle
@@ -88,11 +88,6 @@ tasks.named('jacocoTestCoverageVerification') {
 			limit {
 				counter = 'LINE'
 				value = 'COVEREDRATIO'
-				minimum = 0.70
-			}
-			limit {
-				counter = 'BRANCH'
-				value = 'COVEREDRATIO'
 				minimum = 0.60
 			}
 		}


### PR DESCRIPTION
## 요약
- JaCoCo 기반 테스트 커버리지 측정 환경을 셋업하고, 팀 합의 기준(라인 커버리지 60%)을 빌드·PR 프로세스에 반영

## 변경 사항
- [ ] 기능
- [ ] 버그 수정
- [ ] 리팩토링
- [x] 문서
- [ ] 테스트
- [x] 기타

## 테스트
- [x] 로컬 테스트 완료
- 테스트 방법:
    - `./gradlew test` — 리포트 생성 확인 (`build/reports/jacoco/index.html`)
    - `./gradlew check` — 커버리지 기준(라인 60%) 검증 태스크 정상 실행 확인
    - 제외 패키지(config/exception/response/dto 등) 리포트에서 빠지는 것 확인

## 스크린샷/로그 (선택)
- 필요 시 `build/reports/jacoco/index.html` 로컬에서 확인

## 롤백/리스크
- 리스크 포인트:
    - 아직 서비스 레이어 테스트가 없으므로 현재는 공허 통과 상태. 실제 비즈니스 로직이 추가될 때 60% 미달로 로컬 `./gradlew check` 빌드가 실패할 수 있음 → 도메인 작업 시 단위 테스트 함께 작성 필요
    - 제외 패키지 정책(`jacocoExcludes`)이 새 디렉터리(auth/user/record 등 구현 시)에 자동 반영되지 않음 → 패키지 신설 시 정책 재검토
- 롤백 방법:
    - `build.gradle`의 `jacoco {}` 블록과 `jacocoTestReport` / `jacocoTestCoverageVerification` / `check.dependsOn` 설정 제거
    - `.github/pull_request_template.md`의 `### 커버리지 (JaCoCo)` 섹션 제거
    - `CONTRIBUTING.md`의 `## 5. 테스트 커버리지 (JaCoCo)` 섹션과 목차 항목 제거

## 관련 이슈
Closes #23 