### PR TITLE
chore: 디스코드 에러 웹훅 설정 (#26)

### DIFF
--- a/src/main/java/com/groute/groute_server/GrouteServerApplication.java
+++ b/src/main/java/com/groute/groute_server/GrouteServerApplication.java
@@ -2,10 +2,12 @@ package com.groute.groute_server;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @EnableJpaAuditing
 @SpringBootApplication
+@ConfigurationPropertiesScan
 public class GrouteServerApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/com/groute/groute_server/common/config/AsyncConfig.java
+++ b/src/main/java/com/groute/groute_server/common/config/AsyncConfig.java
@@ -1,0 +1,14 @@
+package com.groute.groute_server.common.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableAsync;
+
+/**
+ * {@link org.springframework.scheduling.annotation.Async @Async} 활성화 설정.
+ *
+ * <p>Spring Boot가 자동 구성한 {@code applicationTaskExecutor}를 기본 풀로 사용한다.</p>
+ */
+@Configuration
+@EnableAsync
+public class AsyncConfig {
+}

--- a/src/main/java/com/groute/groute_server/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/groute/groute_server/common/exception/GlobalExceptionHandler.java
@@ -1,7 +1,10 @@
 package com.groute.groute_server.common.exception;
 
 import com.groute.groute_server.common.response.ErrorResponse;
+import com.groute.groute_server.common.webhook.ErrorWebhookNotifier;
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.ConstraintViolationException;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
@@ -14,11 +17,16 @@ import java.util.List;
 /**
  * 전역 예외 처리기.
  *
- * <p>모든 예외를 {@link ErrorResponse} 형식으로 변환하여 일관된 에러 응답을 보장한다.</p>
+ * <p>모든 예외를 {@link ErrorResponse} 형식으로 변환하여 일관된 에러 응답을 보장한다.
+ * {@link BusinessException} 등 핸들링된 예외는 Discord 웹훅 알림 대상이 아니며,
+ * {@link #handleException} 로 떨어지는 unhandled 500만 {@link ErrorWebhookNotifier}로 알린다.</p>
  */
 @Slf4j
 @RestControllerAdvice
+@RequiredArgsConstructor
 public class GlobalExceptionHandler {
+
+    private final ErrorWebhookNotifier errorWebhookNotifier;
 
     @ExceptionHandler(BusinessException.class)
     protected ResponseEntity<ErrorResponse> handleBusinessException(BusinessException e) {
@@ -66,8 +74,9 @@ public class GlobalExceptionHandler {
     }
 
     @ExceptionHandler(Exception.class)
-    protected ResponseEntity<ErrorResponse> handleException(Exception e) {
+    protected ResponseEntity<ErrorResponse> handleException(Exception e, HttpServletRequest request) {
         log.error("Unhandled Exception: ", e);
+        errorWebhookNotifier.notifyUnhandledError(e, request);
         return ResponseEntity
                 .internalServerError()
                 .body(ErrorResponse.of(ErrorCode.INTERNAL_SERVER_ERROR));

--- a/src/main/java/com/groute/groute_server/common/webhook/DiscordEmbed.java
+++ b/src/main/java/com/groute/groute_server/common/webhook/DiscordEmbed.java
@@ -1,0 +1,28 @@
+package com.groute.groute_server.common.webhook;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+import java.time.OffsetDateTime;
+import java.util.List;
+
+/**
+ * Discord 웹훅 embed 페이로드.
+ *
+ * <p>Discord 공식 스키마의 필드명을 그대로 직렬화하도록 필드명을 맞춘다.
+ * {@code null} 필드는 직렬화에서 제외된다.</p>
+ *
+ * @see <a href="https://discord.com/developers/docs/resources/message#embed-object">Discord Embed Object</a>
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public record DiscordEmbed(
+        String title,
+        String description,
+        Integer color,
+        OffsetDateTime timestamp,
+        List<Field> fields
+) {
+
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public record Field(String name, String value, Boolean inline) {
+    }
+}

--- a/src/main/java/com/groute/groute_server/common/webhook/DiscordWebhookClient.java
+++ b/src/main/java/com/groute/groute_server/common/webhook/DiscordWebhookClient.java
@@ -8,6 +8,8 @@ import org.springframework.stereotype.Component;
 import org.springframework.web.client.RestClient;
 import org.springframework.web.client.RestClientException;
 
+import java.util.concurrent.CompletableFuture;
+
 /**
  * Discord 웹훅 전송 클라이언트.
  *
@@ -31,9 +33,9 @@ public class DiscordWebhookClient {
     }
 
     @Async
-    public void send(DiscordEmbed embed) {
+    public CompletableFuture<Void> send(DiscordEmbed embed) {
         if (!isActive()) {
-            return;
+            return CompletableFuture.completedFuture(null);
         }
         try {
             restClient.post()
@@ -42,8 +44,10 @@ public class DiscordWebhookClient {
                     .body(DiscordWebhookPayload.of(embed))
                     .retrieve()
                     .toBodilessEntity();
+            return CompletableFuture.completedFuture(null);
         } catch (RestClientException e) {
             log.warn("Discord 웹훅 전송 실패: {}", e.getMessage());
+            return CompletableFuture.failedFuture(e);
         }
     }
 

--- a/src/main/java/com/groute/groute_server/common/webhook/DiscordWebhookClient.java
+++ b/src/main/java/com/groute/groute_server/common/webhook/DiscordWebhookClient.java
@@ -1,0 +1,64 @@
+package com.groute.groute_server.common.webhook;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.MediaType;
+import org.springframework.http.client.SimpleClientHttpRequestFactory;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestClient;
+import org.springframework.web.client.RestClientException;
+
+/**
+ * Discord 웹훅 전송 클라이언트.
+ *
+ * <p>{@code discord.webhook.enabled}가 {@code false}이거나 URL이 비어 있으면 전송을 건너뛴다.
+ * 네트워크 오류는 로그로만 남기고 호출자에게 전파하지 않아, 에러 알림 실패가 애플리케이션 응답을
+ * 막지 않도록 한다. 전송은 {@link Async}로 처리되어 요청 처리 스레드를 블로킹하지 않는다.</p>
+ */
+@Slf4j
+@Component
+public class DiscordWebhookClient {
+
+    private static final int CONNECT_TIMEOUT_MS = 3_000;
+    private static final int READ_TIMEOUT_MS = 5_000;
+
+    private final DiscordWebhookProperties properties;
+    private final RestClient restClient;
+
+    public DiscordWebhookClient(DiscordWebhookProperties properties) {
+        this.properties = properties;
+        this.restClient = buildRestClient();
+    }
+
+    @Async
+    public void send(DiscordEmbed embed) {
+        if (!isActive()) {
+            return;
+        }
+        try {
+            restClient.post()
+                    .uri(properties.url())
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .body(DiscordWebhookPayload.of(embed))
+                    .retrieve()
+                    .toBodilessEntity();
+        } catch (RestClientException e) {
+            log.warn("Discord 웹훅 전송 실패: {}", e.getMessage());
+        }
+    }
+
+    private boolean isActive() {
+        return properties.enabled()
+                && properties.url() != null
+                && !properties.url().isBlank();
+    }
+
+    private static RestClient buildRestClient() {
+        SimpleClientHttpRequestFactory factory = new SimpleClientHttpRequestFactory();
+        factory.setConnectTimeout(CONNECT_TIMEOUT_MS);
+        factory.setReadTimeout(READ_TIMEOUT_MS);
+        return RestClient.builder()
+                .requestFactory(factory)
+                .build();
+    }
+}

--- a/src/main/java/com/groute/groute_server/common/webhook/DiscordWebhookPayload.java
+++ b/src/main/java/com/groute/groute_server/common/webhook/DiscordWebhookPayload.java
@@ -1,0 +1,20 @@
+package com.groute.groute_server.common.webhook;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+import java.util.List;
+
+/**
+ * Discord 웹훅 요청 바디. 최상위 페이로드로 하나 이상의 {@link DiscordEmbed}를 감싼다.
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public record DiscordWebhookPayload(
+        String username,
+        String content,
+        List<DiscordEmbed> embeds
+) {
+
+    public static DiscordWebhookPayload of(DiscordEmbed embed) {
+        return new DiscordWebhookPayload(null, null, List.of(embed));
+    }
+}

--- a/src/main/java/com/groute/groute_server/common/webhook/DiscordWebhookProperties.java
+++ b/src/main/java/com/groute/groute_server/common/webhook/DiscordWebhookProperties.java
@@ -1,0 +1,17 @@
+package com.groute.groute_server.common.webhook;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+/**
+ * Discord 웹훅 전송 설정.
+ *
+ * <p>{@code enabled}가 {@code false}이거나 {@code url}이 비어 있으면 전송을 건너뛴다.
+ * 환경별 URL은 SSM Parameter Store의 {@code /groute/{env}/DISCORD_WEBHOOK_URL}에서
+ * 주입되며, 배포 파이프라인이 컨테이너 환경변수 {@code DISCORD_WEBHOOK_URL}로 변환한다.</p>
+ */
+@ConfigurationProperties(prefix = "discord.webhook")
+public record DiscordWebhookProperties(
+        boolean enabled,
+        String url
+) {
+}

--- a/src/main/java/com/groute/groute_server/common/webhook/ErrorWebhookNotifier.java
+++ b/src/main/java/com/groute/groute_server/common/webhook/ErrorWebhookNotifier.java
@@ -1,0 +1,75 @@
+package com.groute.groute_server.common.webhook;
+
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.core.env.Environment;
+import org.springframework.stereotype.Component;
+
+import java.time.OffsetDateTime;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * Unhandled 서버 에러를 Discord 웹훅으로 알린다.
+ *
+ * <p>PII 유출 방지를 위해 요청 바디/헤더/쿼리스트링은 포함하지 않고,
+ * HTTP method, path, 프로파일, 예외 타입·메시지, 스택 트레이스 헤드만 전송한다.</p>
+ */
+@Component
+@RequiredArgsConstructor
+public class ErrorWebhookNotifier {
+
+    private static final int COLOR_RED = 0xE74C3C;
+    private static final int MAX_STACK_LINES = 20;
+    private static final int MAX_MESSAGE_LEN = 500;
+    private static final int MAX_STACK_CHARS = 3500;
+
+    private final DiscordWebhookClient webhookClient;
+    private final Environment environment;
+
+    public void notifyUnhandledError(Exception e, HttpServletRequest request) {
+        DiscordEmbed embed = new DiscordEmbed(
+                "🚨 서버가 처리하지 못하는 에러가 발생했어요!",
+                buildDescription(e),
+                COLOR_RED,
+                OffsetDateTime.now(),
+                List.of(
+                        new DiscordEmbed.Field("Profile", resolveProfile(), true),
+                        new DiscordEmbed.Field("Method", request.getMethod(), true),
+                        new DiscordEmbed.Field("Path", request.getRequestURI(), false),
+                        new DiscordEmbed.Field("Exception", e.getClass().getName(), false)
+                )
+        );
+        webhookClient.send(embed);
+    }
+
+    private String buildDescription(Throwable e) {
+        return "**Message:** " + safeMessage(e) + "\n```\n" + formatStackHead(e) + "\n```";
+    }
+
+    private String safeMessage(Throwable e) {
+        String msg = e.getMessage();
+        if (msg == null || msg.isBlank()) {
+            return "(no message)";
+        }
+        return msg.length() > MAX_MESSAGE_LEN
+                ? msg.substring(0, MAX_MESSAGE_LEN) + "..."
+                : msg;
+    }
+
+    private String formatStackHead(Throwable e) {
+        String joined = Arrays.stream(e.getStackTrace())
+                .limit(MAX_STACK_LINES)
+                .map(StackTraceElement::toString)
+                .collect(Collectors.joining("\n"));
+        return joined.length() > MAX_STACK_CHARS
+                ? joined.substring(0, MAX_STACK_CHARS) + "\n... (truncated)"
+                : joined;
+    }
+
+    private String resolveProfile() {
+        String[] active = environment.getActiveProfiles();
+        return active.length == 0 ? "default" : String.join(",", active);
+    }
+}

--- a/src/main/java/com/groute/groute_server/common/webhook/StartupWebhookNotifier.java
+++ b/src/main/java/com/groute/groute_server/common/webhook/StartupWebhookNotifier.java
@@ -1,0 +1,54 @@
+package com.groute.groute_server.common.webhook;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.context.event.ApplicationReadyEvent;
+import org.springframework.context.event.EventListener;
+import org.springframework.core.env.Environment;
+import org.springframework.stereotype.Component;
+
+import java.time.OffsetDateTime;
+
+/**
+ * 서버 기동 완료 시 Discord 웹훅 헬스체크 메시지를 전송한다.
+ *
+ * <p>{@link ApplicationReadyEvent}를 수신하여 활성 프로파일과 함께 기동 알림을 보낸다.
+ * 웹훅 비활성 상태면 조용히 건너뛴다.</p>
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class StartupWebhookNotifier {
+
+    private static final int COLOR_PINK = 0xFF69B4;
+
+    private final DiscordWebhookClient webhookClient;
+    private final DiscordWebhookProperties properties;
+    private final Environment environment;
+
+    @EventListener(ApplicationReadyEvent.class)
+    public void sendStartupHeartbeat() {
+        if (!properties.enabled()) {
+            log.debug("Discord 웹훅 비활성 상태, 기동 헬스체크 생략");
+            return;
+        }
+
+        String profile = resolveActiveProfile();
+        DiscordEmbed embed = new DiscordEmbed(
+                "\uD83C\uDF80 서버 기동 완료",
+                "`" + profile + "` 프로파일 서버가 정상 기동되었습니다.",
+                COLOR_PINK,
+                OffsetDateTime.now(),
+                null
+        );
+
+        webhookClient.send(embed).thenRun(() ->
+                log.info("Discord 헬스체크 메시지 전송 성공 (profile={})", profile)
+        );
+    }
+
+    private String resolveActiveProfile() {
+        String[] active = environment.getActiveProfiles();
+        return active.length == 0 ? "default" : String.join(",", active);
+    }
+}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -91,6 +91,11 @@ app:
     server-url: http://localhost:8080
     server-description: Local
 
+discord:
+  webhook:
+    enabled: false
+    url: ${DISCORD_WEBHOOK_URL:}
+
 ---
 # ===== 로컬 개발 환경 =====
 spring:
@@ -128,6 +133,11 @@ app:
     server-url: https://stg.api.glit.today
     server-description: Staging
 
+discord:
+  webhook:
+    enabled: true
+    url: ${DISCORD_WEBHOOK_URL}
+
 logging:
   level:
     com.groute: INFO
@@ -156,6 +166,11 @@ app:
   swagger:
     server-url: https://api.glit.today
     server-description: Production
+
+discord:
+  webhook:
+    enabled: true
+    url: ${DISCORD_WEBHOOK_URL}
 
 logging:
   level:


### PR DESCRIPTION
## 요약
- unhandled 500 에러 발생 시 환경별 Discord 채널(stg-warn / prod-warn)로 알림이 자동 전송되도록 공통 웹훅 유틸과 GlobalExceptionHandler 연동 로직을 추가했습니다.

## 변경 사항
- [x] 기능
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 문서
- [ ] 테스트
- [x] 기타

상세:
- `DiscordWebhookProperties` (@ConfigurationProperties) 도입 및 `application.yaml` 환경별(stg/prod 활성, local 비활성) 설정 분리
- `DiscordWebhookClient` 공통 유틸 구현 (RestClient 기반, @Async, 실패 격리, timeouts 3s/5s)
- `@EnableAsync` 설정 (`AsyncConfig`) - 에러 알림 네트워크 호출이 요청 응답 스레드를 블로킹하지 않도록 분리했습니다!
- `StartupWebhookNotifier` — `ApplicationReadyEvent` 수신 시 기동 헬스체크 메시지 전송 + 성공 INFO 로그
- `ErrorWebhookNotifier` — unhandled 500 발생 시 profile / method / path / exception / stack head(첫 20줄) embed 전송
  - PII(개인 식별 정보) 유출 방지: 쿼리스트링·헤더·바디 미포함, URI path만 포함
- `GlobalExceptionHandler#handleException`에서 알림 훅 연동 (BusinessException 등 핸들링된 예외는 제외)

## 테스트
- 로컬 테스트가 불가능해, 머지 이후 확인해야 합니다.
- 테스트 방법:
    - `./gradlew compileJava` 컴파일 통과 확인 ✅ 
    - 임시 Webhook URL 환경변수 주입 + `discord.webhook.enabled=true` 로 로컬 구동 → `🎀 서버 기동 완료` 메시지 수신 확인
    - 테스트용 컨트롤러에서 `throw new RuntimeException(...)` 발생 → `🚨 서버가 처리하지 못하는 에러가 발생했어요!` 알림 수신 및 embed 필드(Profile/Method/Path/Exception/Message/StackHead) 확인
    - `BusinessException` 발생 시 웹훅이 **나가지 않는** 것 확인

## 스크린샷/로그 (선택)
X

## 롤백/리스크
- 리스크 포인트:
    - stg/prod `DISCORD_WEBHOOK_URL` 환경변수 누락 시 기동 실패
      - 추가는 해두었으나, 문제가 생긴다면 이쪽으로 예상됩니다!
- 롤백 방법:
    - 해당 PR revert

## 관련 이슈
Closes #26