### PR TITLE
fix: Discord 웹훅 RestClient가 Spring ObjectMapper를 사용하도록 수정 (#30)

### DIFF
--- a/src/main/java/com/groute/groute_server/common/webhook/DiscordWebhookClient.java
+++ b/src/main/java/com/groute/groute_server/common/webhook/DiscordWebhookClient.java
@@ -1,8 +1,10 @@
 package com.groute.groute_server.common.webhook;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.MediaType;
 import org.springframework.http.client.SimpleClientHttpRequestFactory;
+import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
 import org.springframework.web.client.RestClient;
@@ -27,9 +29,9 @@ public class DiscordWebhookClient {
     private final DiscordWebhookProperties properties;
     private final RestClient restClient;
 
-    public DiscordWebhookClient(DiscordWebhookProperties properties) {
+    public DiscordWebhookClient(DiscordWebhookProperties properties, ObjectMapper objectMapper) {
         this.properties = properties;
-        this.restClient = buildRestClient();
+        this.restClient = buildRestClient(objectMapper);
     }
 
     @Async
@@ -57,12 +59,16 @@ public class DiscordWebhookClient {
                 && !properties.url().isBlank();
     }
 
-    private static RestClient buildRestClient() {
+    private static RestClient buildRestClient(ObjectMapper objectMapper) {
         SimpleClientHttpRequestFactory factory = new SimpleClientHttpRequestFactory();
         factory.setConnectTimeout(CONNECT_TIMEOUT_MS);
         factory.setReadTimeout(READ_TIMEOUT_MS);
         return RestClient.builder()
                 .requestFactory(factory)
+                .messageConverters(converters -> {
+                    converters.clear();
+                    converters.add(new MappingJackson2HttpMessageConverter(objectMapper));
+                })
                 .build();
     }
 }


### PR DESCRIPTION
## 요약
- Discord 웹훅 RestClient가 Spring 관리 `ObjectMapper`를 사용하도록 변경하여, `OffsetDateTime` 직렬화 실패로 인한 400 Bad Request 문제 해결

## 변경 사항
- [ ] 기능
- [x] 버그 수정
- [ ] 리팩토링
- [ ] 문서
- [ ] 테스트
- [ ] 기타

## 테스트
- [x] 로컬 테스트 완료
- 테스트 방법:
    - `./gradlew compileJava` / `./gradlew check` 통과 확인
    - stg 배포 후 서버 기동 시 Discord 채널에 `🎀 서버 기동 완료` 헬스체크 embed 수신 확인
    - 의도적으로 unhandled 500 유발 → 에러 embed가 400 없이 정상 수신되는지 확인

## 스크린샷/로그 (선택)
수정 전:
```
c.g.g.c.webhook.DiscordWebhookClient : Discord 웹훅 전송 실패: 400 Bad Request: "{"embeds": ["0"]}"
```

수정 후: Discord 채널에 embed 정상 수신 (stg 배포 후 확인 예정)

## 롤백/리스크
- 리스크 포인트:
    - X, 단순 개발 편의 기능
- 롤백 방법:
    - 해당 커밋 `git revert` 후 재배포

## 관련 이슈
Closes #30 