### PR TITLE
chore: Redis 도입 및 docker compose 기반 배포 전환

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -55,12 +55,15 @@ jobs:
             Parameters: {
               commands: [
                 "set -e",
+                "docker compose version >/dev/null 2>&1 || apt-get install -y docker-compose-plugin",
                 ("aws ecr get-login-password --region ap-northeast-2 | docker login --username AWS --password-stdin " + $reg),
+                "mkdir -p /home/ubuntu/groute",
+                ("aws ssm get-parameters-by-path --region ap-northeast-2 --path " + $ssmpath + " --recursive --with-decryption --query 'Parameters[*].[Name,Value]' --output text | awk -F'\\t' '{n=$1; sub(/.*\\//, \"\", n); print n\"=\"$2}' > /tmp/groute.env"),
+                "export REDIS_PASSWORD=$(grep '^REDIS_PASSWORD=' /tmp/groute.env | cut -d= -f2-)",
+                ("printf 'services:\\n  app:\\n    image: %s\\n    ports:\\n      - \"8080:8080\"\\n    env_file:\\n      - /tmp/groute.env\\n    environment:\\n      SPRING_PROFILES_ACTIVE: %s\\n      REDIS_HOST: redis\\n    depends_on:\\n      redis:\\n        condition: service_healthy\\n    restart: unless-stopped\\n  redis:\\n    image: redis:7.2-alpine\\n    command: >-\\n      redis-server --requirepass ${REDIS_PASSWORD} --maxmemory 128mb --maxmemory-policy volatile-lru\\n    healthcheck:\\n      test: [\"CMD\", \"redis-cli\", \"-a\", \"${REDIS_PASSWORD}\", \"ping\"]\\n      interval: 10s\\n      timeout: 5s\\n      retries: 3\\n    restart: unless-stopped\\n' " + $image + " " + $env_val + " > /home/ubuntu/groute/docker-compose.yml"),
                 "docker stop groute-server 2>/dev/null || true",
                 "docker rm   groute-server 2>/dev/null || true",
-                ("docker pull " + $image),
-                ("aws ssm get-parameters-by-path --region ap-northeast-2 --path " + $ssmpath + " --recursive --with-decryption --query 'Parameters[*].[Name,Value]' --output text | awk -F'\\t' '{n=$1; sub(/.*\\//, \"\", n); print n\"=\"$2}' > /tmp/groute.env"),
-                ("docker run -d --name groute-server --restart unless-stopped --env-file /tmp/groute.env -e SPRING_PROFILES_ACTIVE=" + $env_val + " -p 8080:8080 " + $image),
+                "cd /home/ubuntu/groute && docker compose up -d --pull always",
                 "rm -f /tmp/groute.env"
               ]
             },

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -55,7 +55,7 @@ jobs:
             Parameters: {
               commands: [
                 "set -e",
-                "docker compose version >/dev/null 2>&1 || apt-get install -y docker-compose-plugin",
+                "docker compose version >/dev/null 2>&1 || (apt-get update && apt-get install -y docker-compose-plugin)",
                 ("aws ecr get-login-password --region ap-northeast-2 | docker login --username AWS --password-stdin " + $reg),
                 "mkdir -p /home/ubuntu/groute",
                 ("aws ssm get-parameters-by-path --region ap-northeast-2 --path " + $ssmpath + " --recursive --with-decryption --query 'Parameters[*].[Name,Value]' --output text | awk -F'\\t' '{n=$1; sub(/.*\\//, \"\", n); print n\"=\"$2}' > /tmp/groute.env"),

--- a/build.gradle
+++ b/build.gradle
@@ -24,6 +24,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
+	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
 	implementation 'org.flywaydb:flyway-core'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,30 @@
+# 참고용 파일입니다. 실제 배포 시에는 deploy.yml의 SSM 명령어에서 동적으로 생성됩니다.
+# APP_IMAGE, SPRING_PROFILES_ACTIVE, REDIS_PASSWORD는 배포 시 주입됩니다.
+services:
+  app:
+    image: ${APP_IMAGE}
+    ports:
+      - "8080:8080"
+    env_file:
+      - /tmp/groute.env
+    environment:
+      SPRING_PROFILES_ACTIVE: ${SPRING_PROFILES_ACTIVE}
+      REDIS_HOST: redis
+    depends_on:
+      redis:
+        condition: service_healthy
+    restart: unless-stopped
+
+  redis:
+    image: redis:7.2-alpine
+    command: >-
+      redis-server
+      --requirepass ${REDIS_PASSWORD}
+      --maxmemory 256mb
+      --maxmemory-policy allkeys-lru
+    healthcheck:
+      test: ["CMD", "redis-cli", "-a", "${REDIS_PASSWORD}", "ping"]
+      interval: 10s
+      timeout: 5s
+      retries: 3
+    restart: unless-stopped

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,8 +20,8 @@ services:
     command: >-
       redis-server
       --requirepass ${REDIS_PASSWORD}
-      --maxmemory 256mb
-      --maxmemory-policy allkeys-lru
+      --maxmemory 128mb
+      --maxmemory-policy volatile-lru
     healthcheck:
       test: ["CMD", "redis-cli", "-a", "${REDIS_PASSWORD}", "ping"]
       interval: 10s

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -6,6 +6,12 @@ spring:
   jackson:
     time-zone: UTC
 
+  data:
+    redis:
+      host: ${REDIS_HOST:localhost}
+      port: 6379
+      password: ${REDIS_PASSWORD:}
+
   datasource:
     url: ${SPRING_DATASOURCE_URL:jdbc:postgresql://localhost:5432/groute_local}
     username: ${SPRING_DATASOURCE_USERNAME:postgres}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -9,7 +9,7 @@ spring:
   data:
     redis:
       host: ${REDIS_HOST:localhost}
-      port: 6379
+      port: ${REDIS_PORT:6379}
       password: ${REDIS_PASSWORD:}
 
   datasource:


### PR DESCRIPTION
## 요약
- Redis 도입을 위한 Spring 설정 추가 및 docker compose 기반 배포 방식으로 전환

## 변경 사항
- [ ] 기능
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 문서
- [ ] 테스트
- [x] 기타

**[build.gradle]**
 -  spring-boot-starter-data-redis 의존성 추가
 
**[application.yaml]**
- Redis 연결 설정 추가 (REDIS_HOST, REDIS_PORT, REDIS_PASSWORD 환경변수로 주입) 

**[docker-compose.yml (신규)]**
- Spring 앱 + Redis 컨테이너 구성 참고용 파일
- 실제 배포 시에는 deploy.yml SSM 명령어에서 동적으로 생성됨

**[deploy.yml]**
- 기존: docker pull + docker run 단일 컨테이너 실행 방식
- 변경: docker compose up -d --pull always 방식으로 전환 (Spring + Redis 두 컨테이너를 같은 브리지 네트워크에서 실행)
- SSM 명령어 내에서 docker-compose.yml을 동적으로 생성 후 실행
- docker-compose-plugin 미설치 시 자동 설치 추가 (apt-get update && apt-get install -y docker-compose-plugin)
- SSM 파라미터(REDIS_PASSWORD)를 env 파일에서 추출해 docker compose 실행 시 주입

## 참고
- S3 버킷 생성은 가능하나 EC2 IAM 역할에 S3 읽기 권한 추가가 불가하여 일단 현재 방식(SSM 명령어 내 동적 생성)으로 구현했습니다.
- 추후 S3 설정 시,  docker-compose.yml을 S3에 업로드하고 EC2에서 내려받는 방식으로 전환하면 좋을 것 같습니다.

## 테스트
- [ ] 로컬 테스트 완료
- 테스트 방법:
    - dev 브랜치 머지 후 배포 워크플로우 실행 결과 확인
    - 실패한다면, 빠르게 해결해놓겠습니다,,

## 롤백/리스크
- 리스크 포인트: deploy.yml 변경으로 배포 실패 시 기존 docker run 방식으로 되돌려야 함
- 롤백 방법: deploy.yml을 이전 커밋으로 revert 후 재배포

## 관련 이슈
Closes #29 