### PR TITLE
chore: hibernate.jdbc.time_zone UTC 설정, spotless 설정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,6 +3,7 @@ plugins {
 	id 'jacoco'
 	id 'org.springframework.boot' version '3.5.13'
 	id 'io.spring.dependency-management' version '1.1.7'
+	id 'com.diffplug.spotless' version '6.25.0'
 }
 
 group = 'com.groute'
@@ -97,4 +98,19 @@ tasks.named('jacocoTestCoverageVerification') {
 
 tasks.named('check') {
 	dependsOn tasks.named('jacocoTestCoverageVerification')
+}
+
+spotless {
+	java {
+		// Google Java Format (AOSP 스타일: 4칸 들여쓰기)
+		googleJavaFormat().aosp()
+		// import 정렬 순서
+		importOrder('java', 'javax', 'jakarta', 'org', 'com')
+		// 사용하지 않는 import 제거
+		removeUnusedImports()
+		// 각 라인 끝 공백 제거
+		trimTrailingWhitespace()
+		// 파일 끝에 새로운 라인 추가
+		endWithNewline()
+	}
 }

--- a/src/main/java/com/groute/groute_server/GrouteServerApplication.java
+++ b/src/main/java/com/groute/groute_server/GrouteServerApplication.java
@@ -10,8 +10,7 @@ import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 @ConfigurationPropertiesScan
 public class GrouteServerApplication {
 
-	public static void main(String[] args) {
-		SpringApplication.run(GrouteServerApplication.class, args);
-	}
-
+    public static void main(String[] args) {
+        SpringApplication.run(GrouteServerApplication.class, args);
+    }
 }

--- a/src/main/java/com/groute/groute_server/auth/entity/AuthToken.java
+++ b/src/main/java/com/groute/groute_server/auth/entity/AuthToken.java
@@ -1,18 +1,20 @@
 package com.groute.groute_server.auth.entity;
 
+import java.time.OffsetDateTime;
+
+import jakarta.persistence.*;
+
 import com.groute.groute_server.common.entity.BaseTimeEntity;
 import com.groute.groute_server.user.entity.User;
-import jakarta.persistence.*;
+
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-
-import java.time.OffsetDateTime;
 
 /**
  * 리프레시 토큰 저장(액세스 토큰은 stateless).
  *
- * <p>재발급 요청 시 {@link #refreshTokenHash}로 유효성 검증(ONB001).
- * 디바이스 단위로 추적하며, 로그아웃(MYP004)/탈퇴(MYP005) 시 {@link #revokedAt}을 set한다.
+ * <p>재발급 요청 시 {@link #refreshTokenHash}로 유효성 검증(ONB001). 디바이스 단위로 추적하며, 로그아웃(MYP004)/탈퇴(MYP005) 시
+ * {@link #revokedAt}을 set한다.
  */
 @Getter
 @NoArgsConstructor

--- a/src/main/java/com/groute/groute_server/auth/entity/DeviceToken.java
+++ b/src/main/java/com/groute/groute_server/auth/entity/DeviceToken.java
@@ -1,9 +1,11 @@
 package com.groute.groute_server.auth.entity;
 
+import jakarta.persistence.*;
+
 import com.groute.groute_server.auth.enums.DevicePlatform;
 import com.groute.groute_server.common.entity.BaseTimeEntity;
 import com.groute.groute_server.user.entity.User;
-import jakarta.persistence.*;
+
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 

--- a/src/main/java/com/groute/groute_server/auth/entity/SocialAccount.java
+++ b/src/main/java/com/groute/groute_server/auth/entity/SocialAccount.java
@@ -1,17 +1,18 @@
 package com.groute.groute_server.auth.entity;
 
+import jakarta.persistence.*;
+
 import com.groute.groute_server.auth.enums.SocialProvider;
 import com.groute.groute_server.common.entity.BaseTimeEntity;
 import com.groute.groute_server.user.entity.User;
-import jakarta.persistence.*;
+
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 /**
  * 유저와 소셜 프로바이더 간 매핑.
  *
- * <p>한 유저가 여러 소셜 계정을 연결할 수 있다(ONB002).
- * 로그인 시 (provider, provider_uid) 조합으로 기존 유저를 찾는다.
+ * <p>한 유저가 여러 소셜 계정을 연결할 수 있다(ONB002). 로그인 시 (provider, provider_uid) 조합으로 기존 유저를 찾는다.
  */
 @Getter
 @NoArgsConstructor

--- a/src/main/java/com/groute/groute_server/auth/entity/TermVersion.java
+++ b/src/main/java/com/groute/groute_server/auth/entity/TermVersion.java
@@ -1,18 +1,19 @@
 package com.groute.groute_server.auth.entity;
 
+import java.time.OffsetDateTime;
+
+import jakarta.persistence.*;
+
 import com.groute.groute_server.auth.enums.TermType;
 import com.groute.groute_server.common.entity.BaseTimeEntity;
-import jakarta.persistence.*;
+
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-
-import java.time.OffsetDateTime;
 
 /**
  * 약관/개인정보처리방침 버전 관리.
  *
- * <p>약관 개정 시마다 새 row를 생성한다. 본문은 외부 호스팅(노션/CMS) URL 또는 S3에 두고 URL만 저장.
- * 클라이언트는 웹뷰로 본문을 노출한다(MYP006).
+ * <p>약관 개정 시마다 새 row를 생성한다. 본문은 외부 호스팅(노션/CMS) URL 또는 S3에 두고 URL만 저장. 클라이언트는 웹뷰로 본문을 노출한다(MYP006).
  */
 @Getter
 @NoArgsConstructor

--- a/src/main/java/com/groute/groute_server/auth/entity/UserTermAgreement.java
+++ b/src/main/java/com/groute/groute_server/auth/entity/UserTermAgreement.java
@@ -1,19 +1,20 @@
 package com.groute.groute_server.auth.entity;
 
+import java.time.OffsetDateTime;
+
+import jakarta.persistence.*;
+
 import com.groute.groute_server.common.entity.BaseTimeEntity;
 import com.groute.groute_server.user.entity.User;
-import jakarta.persistence.*;
+
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-
-import java.time.OffsetDateTime;
 
 /**
  * 유저별 약관 동의/철회 이력.
  *
- * <p>append-only 테이블 — 기존 row는 절대 UPDATE/DELETE하지 않는다(감사 추적 및 법적 증빙).
- * 마케팅 동의 ON/OFF를 토글해도 매번 새 row를 INSERT한다.
- * 이 규약은 DB 트리거가 아닌 애플리케이션 레벨에서 보장한다.
+ * <p>append-only 테이블 — 기존 row는 절대 UPDATE/DELETE하지 않는다(감사 추적 및 법적 증빙). 마케팅 동의 ON/OFF를 토글해도 매번 새 row를
+ * INSERT한다. 이 규약은 DB 트리거가 아닌 애플리케이션 레벨에서 보장한다.
  */
 @Getter
 @NoArgsConstructor

--- a/src/main/java/com/groute/groute_server/auth/enums/DevicePlatform.java
+++ b/src/main/java/com/groute/groute_server/auth/enums/DevicePlatform.java
@@ -1,9 +1,6 @@
 package com.groute.groute_server.auth.enums;
 
-/**
- * 디바이스 플랫폼.
- * FCM/APNs 푸시 토큰 등록 시 클라이언트 유형 구분 (MYP003).
- */
+/** 디바이스 플랫폼. FCM/APNs 푸시 토큰 등록 시 클라이언트 유형 구분 (MYP003). */
 public enum DevicePlatform {
     /** iOS 디바이스. APNs 토큰 사용. */
     IOS,

--- a/src/main/java/com/groute/groute_server/auth/enums/SocialProvider.java
+++ b/src/main/java/com/groute/groute_server/auth/enums/SocialProvider.java
@@ -1,9 +1,6 @@
 package com.groute.groute_server.auth.enums;
 
-/**
- * 소셜 로그인 프로바이더.
- * 사용자가 회원가입 시 연동한 소셜 계정 종류 (ONB002).
- */
+/** 소셜 로그인 프로바이더. 사용자가 회원가입 시 연동한 소셜 계정 종류 (ONB002). */
 public enum SocialProvider {
     /** 카카오 로그인. */
     KAKAO,

--- a/src/main/java/com/groute/groute_server/auth/enums/TermType.java
+++ b/src/main/java/com/groute/groute_server/auth/enums/TermType.java
@@ -1,9 +1,6 @@
 package com.groute.groute_server.auth.enums;
 
-/**
- * 약관 종류.
- * 회원가입 시 동의가 필요한 법적 약관 구분.
- */
+/** 약관 종류. 회원가입 시 동의가 필요한 법적 약관 구분. */
 public enum TermType {
     /** 개인정보 처리방침 (필수). */
     PRIVACY_POLICY,

--- a/src/main/java/com/groute/groute_server/common/config/AsyncConfig.java
+++ b/src/main/java/com/groute/groute_server/common/config/AsyncConfig.java
@@ -6,9 +6,8 @@ import org.springframework.scheduling.annotation.EnableAsync;
 /**
  * {@link org.springframework.scheduling.annotation.Async @Async} 활성화 설정.
  *
- * <p>Spring Boot가 자동 구성한 {@code applicationTaskExecutor}를 기본 풀로 사용한다.</p>
+ * <p>Spring Boot가 자동 구성한 {@code applicationTaskExecutor}를 기본 풀로 사용한다.
  */
 @Configuration
 @EnableAsync
-public class AsyncConfig {
-}
+public class AsyncConfig {}

--- a/src/main/java/com/groute/groute_server/common/config/JacksonConfig.java
+++ b/src/main/java/com/groute/groute_server/common/config/JacksonConfig.java
@@ -1,44 +1,48 @@
 package com.groute.groute_server.common.config;
 
-import com.fasterxml.jackson.databind.SerializationFeature;
-import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import java.util.TimeZone;
+
 import org.springframework.boot.autoconfigure.jackson.Jackson2ObjectMapperBuilderCustomizer;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
-import java.util.TimeZone;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 
 /**
  * 시간 타입의 JSON 직렬화/역직렬화 계약을 정의한다.
  *
  * <h2>정책</h2>
+ *
  * <ul>
- *   <li>{@link java.time.OffsetDateTime} 등 JSR-310 타입을 ISO-8601 문자열로 직렬화한다.</li>
- *   <li>직렬화 타임존은 UTC로 고정한다. 배포 환경(OS/JVM)의 기본 타임존에 의존하지 않는다.</li>
- *   <li>타임스탬프(숫자) 직렬화는 비활성화한다. 가독성과 클라이언트 파싱 안정성을 우선한다.</li>
+ *   <li>{@link java.time.OffsetDateTime} 등 JSR-310 타입을 ISO-8601 문자열로 직렬화한다.
+ *   <li>직렬화 타임존은 UTC로 고정한다. 배포 환경(OS/JVM)의 기본 타임존에 의존하지 않는다.
+ *   <li>타임스탬프(숫자) 직렬화는 비활성화한다. 가독성과 클라이언트 파싱 안정성을 우선한다.
  * </ul>
  *
  * <h2>적용 범위</h2>
+ *
  * <ul>
- *   <li>응답 DTO에 노출되는 <b>raw {@code OffsetDateTime}</b> 필드는 여기서 정의한 포맷으로 내려간다.</li>
- *   <li>사람이 읽는 화면용 문자열(예: "2026.04.18", "04.18 15:45")은 본 설정이 아니라
- *       {@link com.groute.groute_server.common.util.DateTimeFormatters}에서 처리한다.</li>
- *   <li>요청 바디에 {@code OffsetDateTime}이 포함되면 동일 규약으로 역직렬화된다.
- *       쿼리 파라미터의 날짜는 {@link java.time.LocalDate}로 받으며 본 설정과 무관하다.</li>
+ *   <li>응답 DTO에 노출되는 <b>raw {@code OffsetDateTime}</b> 필드는 여기서 정의한 포맷으로 내려간다.
+ *   <li>사람이 읽는 화면용 문자열(예: "2026.04.18", "04.18 15:45")은 본 설정이 아니라 {@link
+ *       com.groute.groute_server.common.util.DateTimeFormatters}에서 처리한다.
+ *   <li>요청 바디에 {@code OffsetDateTime}이 포함되면 동일 규약으로 역직렬화된다. 쿼리 파라미터의 날짜는 {@link
+ *       java.time.LocalDate}로 받으며 본 설정과 무관하다.
  * </ul>
  *
  * <h2>참고</h2>
- * 본 클래스만으로는 JVM 기본 타임존을 UTC로 바꾸지 않는다.
- * {@code application.yaml}의 {@code spring.jackson.time-zone: UTC}가 함께 적용되어야 일관성이 보장된다.
+ *
+ * 본 클래스만으로는 JVM 기본 타임존을 UTC로 바꾸지 않는다. {@code application.yaml}의 {@code spring.jackson.time-zone:
+ * UTC}가 함께 적용되어야 일관성이 보장된다.
  */
 @Configuration
 public class JacksonConfig {
 
     @Bean
     public Jackson2ObjectMapperBuilderCustomizer jacksonCustomizer() {
-        return builder -> builder
-                .modules(new JavaTimeModule())
-                .featuresToDisable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
-                .timeZone(TimeZone.getTimeZone("UTC"));
+        return builder ->
+                builder.modules(new JavaTimeModule())
+                        .featuresToDisable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
+                        .timeZone(TimeZone.getTimeZone("UTC"));
     }
 }

--- a/src/main/java/com/groute/groute_server/common/config/SecurityConfig.java
+++ b/src/main/java/com/groute/groute_server/common/config/SecurityConfig.java
@@ -12,17 +12,17 @@ public class SecurityConfig {
 
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
-        http
-                .csrf(csrf -> csrf.disable())
-                .authorizeHttpRequests(auth -> auth
-                        .requestMatchers(
-                                "/swagger-ui/**",
-                                "/swagger-ui.html",
-                                "/v3/api-docs/**",
-                                "/docs/error-code"
-                        ).permitAll()
-                        .anyRequest().authenticated()
-                );
+        http.csrf(csrf -> csrf.disable())
+                .authorizeHttpRequests(
+                        auth ->
+                                auth.requestMatchers(
+                                                "/swagger-ui/**",
+                                                "/swagger-ui.html",
+                                                "/v3/api-docs/**",
+                                                "/docs/error-code")
+                                        .permitAll()
+                                        .anyRequest()
+                                        .authenticated());
 
         return http.build();
     }

--- a/src/main/java/com/groute/groute_server/common/config/SwaggerConfig.java
+++ b/src/main/java/com/groute/groute_server/common/config/SwaggerConfig.java
@@ -1,5 +1,10 @@
 package com.groute.groute_server.common.config;
 
+import org.springdoc.core.models.GroupedOpenApi;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
 import io.swagger.v3.oas.annotations.enums.SecuritySchemeIn;
 import io.swagger.v3.oas.annotations.enums.SecuritySchemeType;
 import io.swagger.v3.oas.annotations.security.SecurityScheme;
@@ -7,10 +12,6 @@ import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Info;
 import io.swagger.v3.oas.models.security.SecurityRequirement;
 import io.swagger.v3.oas.models.servers.Server;
-import org.springdoc.core.models.GroupedOpenApi;
-import org.springframework.beans.factory.annotation.Value;
-import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Configuration;
 
 @Configuration
 @SecurityScheme(
@@ -18,8 +19,7 @@ import org.springframework.context.annotation.Configuration;
         type = SecuritySchemeType.HTTP,
         scheme = "bearer",
         bearerFormat = "JWT",
-        in = SecuritySchemeIn.HEADER
-)
+        in = SecuritySchemeIn.HEADER)
 public class SwaggerConfig {
 
     @Value("${app.swagger.server-url}")
@@ -31,10 +31,7 @@ public class SwaggerConfig {
     @Bean
     public OpenAPI openAPI() {
         return new OpenAPI()
-                .info(new Info()
-                        .title("GLIT API")
-                        .description("GLIT 백엔드 API 문서")
-                        .version("v1.0.0"))
+                .info(new Info().title("GLIT API").description("GLIT 백엔드 API 문서").version("v1.0.0"))
                 .addSecurityItem(new SecurityRequirement().addList("bearerAuth"))
                 .addServersItem(new Server().url(serverUrl).description(serverDescription));
     }

--- a/src/main/java/com/groute/groute_server/common/docs/ErrorCodeDocsController.java
+++ b/src/main/java/com/groute/groute_server/common/docs/ErrorCodeDocsController.java
@@ -1,17 +1,17 @@
 package com.groute.groute_server.common.docs;
 
-import com.groute.groute_server.common.exception.ErrorCode;
 import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
 
+import com.groute.groute_server.common.exception.ErrorCode;
+
 /**
  * ErrorCode 정적 조회 페이지 Controller.
  *
- * <p>{@code prod} 프로파일에서는 빈이 등록되지 않아 경로가 404 처리된다.
- * enum 값을 런타임에 그대로 조회하므로, 새로운 {@link ErrorCode} 추가 시
- * 별도 작업 없이 페이지에 자동 반영된다.</p>
+ * <p>{@code prod} 프로파일에서는 빈이 등록되지 않아 경로가 404 처리된다. enum 값을 런타임에 그대로 조회하므로, 새로운 {@link ErrorCode} 추가
+ * 시 별도 작업 없이 페이지에 자동 반영된다.
  */
 @Controller
 @Profile("!prod")

--- a/src/main/java/com/groute/groute_server/common/entity/BaseTimeEntity.java
+++ b/src/main/java/com/groute/groute_server/common/entity/BaseTimeEntity.java
@@ -1,20 +1,22 @@
 package com.groute.groute_server.common.entity;
 
+import java.time.OffsetDateTime;
+
 import jakarta.persistence.Column;
 import jakarta.persistence.EntityListeners;
 import jakarta.persistence.MappedSuperclass;
-import lombok.Getter;
+
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
-import java.time.OffsetDateTime;
+import lombok.Getter;
 
 /**
  * 생성/수정 시각을 자동으로 관리하는 엔티티 부모 클래스.
  *
- * <p>모든 도메인 엔티티는 본 클래스 또는 {@link SoftDeleteEntity}를 상속한다.
- * 동작하려면 애플리케이션 클래스에 {@code @EnableJpaAuditing}이 활성화되어 있어야 한다.
+ * <p>모든 도메인 엔티티는 본 클래스 또는 {@link SoftDeleteEntity}를 상속한다. 동작하려면 애플리케이션 클래스에
+ * {@code @EnableJpaAuditing}이 활성화되어 있어야 한다.
  *
  * <p>타임존 정책: DB는 {@code TIMESTAMPTZ}, Java 측은 UTC {@link OffsetDateTime}.
  */

--- a/src/main/java/com/groute/groute_server/common/entity/SoftDeleteEntity.java
+++ b/src/main/java/com/groute/groute_server/common/entity/SoftDeleteEntity.java
@@ -1,16 +1,17 @@
 package com.groute.groute_server.common.entity;
 
+import java.time.OffsetDateTime;
+
 import jakarta.persistence.Column;
 import jakarta.persistence.MappedSuperclass;
-import lombok.Getter;
 
-import java.time.OffsetDateTime;
+import lombok.Getter;
 
 /**
  * 논리 삭제(Soft Delete)를 지원하는 엔티티 부모 클래스.
  *
- * <p>{@link BaseTimeEntity}를 상속하며, {@link #isDeleted}=true인 레코드는 모든 조회에서 제외해야 한다.
- * 물리 삭제 대신 플래그 방식으로 이력을 보존한다.
+ * <p>{@link BaseTimeEntity}를 상속하며, {@link #isDeleted}=true인 레코드는 모든 조회에서 제외해야 한다. 물리 삭제 대신 플래그 방식으로
+ * 이력을 보존한다.
  */
 @Getter
 @MappedSuperclass

--- a/src/main/java/com/groute/groute_server/common/exception/BusinessException.java
+++ b/src/main/java/com/groute/groute_server/common/exception/BusinessException.java
@@ -5,8 +5,7 @@ import lombok.Getter;
 /**
  * 비즈니스 로직 예외의 베이스 클래스.
  *
- * <p>도메인 규칙 위반 시 {@link ErrorCode}와 함께 던지면
- * {@link GlobalExceptionHandler}가 일관된 에러 응답으로 변환한다.</p>
+ * <p>도메인 규칙 위반 시 {@link ErrorCode}와 함께 던지면 {@link GlobalExceptionHandler}가 일관된 에러 응답으로 변환한다.
  *
  * <pre>{@code
  * throw new BusinessException(ErrorCode.RESOURCE_NOT_FOUND);

--- a/src/main/java/com/groute/groute_server/common/exception/ErrorCode.java
+++ b/src/main/java/com/groute/groute_server/common/exception/ErrorCode.java
@@ -1,14 +1,15 @@
 package com.groute.groute_server.common.exception;
 
+import org.springframework.http.HttpStatus;
+
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.HttpStatus;
 
 /**
  * 애플리케이션 에러 코드 정의.
  *
- * <p>모든 에러 코드는 단일 enum에 정의하며, 도메인별 섹션 주석으로 구분한다.
- * 코드 값은 {@code {DOMAIN}_{NNN}} 형식을 따른다 (예: {@code COMMON_001}, {@code USER_001}).</p>
+ * <p>모든 에러 코드는 단일 enum에 정의하며, 도메인별 섹션 주석으로 구분한다. 코드 값은 {@code {DOMAIN}_{NNN}} 형식을 따른다 (예: {@code
+ * COMMON_001}, {@code USER_001}).
  *
  * <pre>
  * // 도메인 에러 코드 추가 예시

--- a/src/main/java/com/groute/groute_server/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/groute/groute_server/common/exception/GlobalExceptionHandler.java
@@ -1,25 +1,28 @@
 package com.groute.groute_server.common.exception;
 
-import com.groute.groute_server.common.response.ErrorResponse;
-import com.groute.groute_server.common.webhook.ErrorWebhookNotifier;
+import java.util.List;
+
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.ConstraintViolationException;
-import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
+
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
-import java.util.List;
+import com.groute.groute_server.common.response.ErrorResponse;
+import com.groute.groute_server.common.webhook.ErrorWebhookNotifier;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
 /**
  * 전역 예외 처리기.
  *
- * <p>모든 예외를 {@link ErrorResponse} 형식으로 변환하여 일관된 에러 응답을 보장한다.
- * {@link BusinessException} 등 핸들링된 예외는 Discord 웹훅 알림 대상이 아니며,
- * {@link #handleException} 로 떨어지는 unhandled 500만 {@link ErrorWebhookNotifier}로 알린다.</p>
+ * <p>모든 예외를 {@link ErrorResponse} 형식으로 변환하여 일관된 에러 응답을 보장한다. {@link BusinessException} 등 핸들링된 예외는
+ * Discord 웹훅 알림 대상이 아니며, {@link #handleException} 로 떨어지는 unhandled 500만 {@link
+ * ErrorWebhookNotifier}로 알린다.
  */
 @Slf4j
 @RestControllerAdvice
@@ -32,53 +35,61 @@ public class GlobalExceptionHandler {
     protected ResponseEntity<ErrorResponse> handleBusinessException(BusinessException e) {
         log.warn("BusinessException: {}", e.getMessage());
         ErrorCode errorCode = e.getErrorCode();
-        return ResponseEntity
-                .status(errorCode.getHttpStatus())
+        return ResponseEntity.status(errorCode.getHttpStatus())
                 .body(ErrorResponse.of(errorCode, e.getMessage()));
     }
 
     @ExceptionHandler(MethodArgumentNotValidException.class)
-    protected ResponseEntity<ErrorResponse> handleMethodArgumentNotValidException(MethodArgumentNotValidException e) {
+    protected ResponseEntity<ErrorResponse> handleMethodArgumentNotValidException(
+            MethodArgumentNotValidException e) {
         log.warn("MethodArgumentNotValidException: {}", e.getMessage());
-        List<ErrorResponse.FieldError> fieldErrors = e.getBindingResult().getFieldErrors().stream()
-                .map(error -> ErrorResponse.FieldError.of(
-                        error.getField(),
-                        error.getRejectedValue() == null ? "" : error.getRejectedValue().toString(),
-                        error.getDefaultMessage()))
-                .toList();
-        return ResponseEntity
-                .badRequest()
+        List<ErrorResponse.FieldError> fieldErrors =
+                e.getBindingResult().getFieldErrors().stream()
+                        .map(
+                                error ->
+                                        ErrorResponse.FieldError.of(
+                                                error.getField(),
+                                                error.getRejectedValue() == null
+                                                        ? ""
+                                                        : error.getRejectedValue().toString(),
+                                                error.getDefaultMessage()))
+                        .toList();
+        return ResponseEntity.badRequest()
                 .body(ErrorResponse.of(ErrorCode.INVALID_INPUT, fieldErrors));
     }
 
     @ExceptionHandler(ConstraintViolationException.class)
-    protected ResponseEntity<ErrorResponse> handleConstraintViolationException(ConstraintViolationException e) {
+    protected ResponseEntity<ErrorResponse> handleConstraintViolationException(
+            ConstraintViolationException e) {
         log.warn("ConstraintViolationException: {}", e.getMessage());
-        List<ErrorResponse.FieldError> fieldErrors = e.getConstraintViolations().stream()
-                .map(violation -> ErrorResponse.FieldError.of(
-                        violation.getPropertyPath().toString(),
-                        violation.getInvalidValue() == null ? "" : violation.getInvalidValue().toString(),
-                        violation.getMessage()))
-                .toList();
-        return ResponseEntity
-                .badRequest()
+        List<ErrorResponse.FieldError> fieldErrors =
+                e.getConstraintViolations().stream()
+                        .map(
+                                violation ->
+                                        ErrorResponse.FieldError.of(
+                                                violation.getPropertyPath().toString(),
+                                                violation.getInvalidValue() == null
+                                                        ? ""
+                                                        : violation.getInvalidValue().toString(),
+                                                violation.getMessage()))
+                        .toList();
+        return ResponseEntity.badRequest()
                 .body(ErrorResponse.of(ErrorCode.INVALID_INPUT, fieldErrors));
     }
 
     @ExceptionHandler(HttpMessageNotReadableException.class)
-    protected ResponseEntity<ErrorResponse> handleHttpMessageNotReadableException(HttpMessageNotReadableException e) {
+    protected ResponseEntity<ErrorResponse> handleHttpMessageNotReadableException(
+            HttpMessageNotReadableException e) {
         log.warn("HttpMessageNotReadableException: {}", e.getMessage());
-        return ResponseEntity
-                .badRequest()
-                .body(ErrorResponse.of(ErrorCode.INVALID_REQUEST_BODY));
+        return ResponseEntity.badRequest().body(ErrorResponse.of(ErrorCode.INVALID_REQUEST_BODY));
     }
 
     @ExceptionHandler(Exception.class)
-    protected ResponseEntity<ErrorResponse> handleException(Exception e, HttpServletRequest request) {
+    protected ResponseEntity<ErrorResponse> handleException(
+            Exception e, HttpServletRequest request) {
         log.error("Unhandled Exception: ", e);
         errorWebhookNotifier.notifyUnhandledError(e, request);
-        return ResponseEntity
-                .internalServerError()
+        return ResponseEntity.internalServerError()
                 .body(ErrorResponse.of(ErrorCode.INTERNAL_SERVER_ERROR));
     }
 }

--- a/src/main/java/com/groute/groute_server/common/response/ApiResponse.java
+++ b/src/main/java/com/groute/groute_server/common/response/ApiResponse.java
@@ -1,6 +1,7 @@
 package com.groute.groute_server.common.response;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
+
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -9,8 +10,7 @@ import lombok.Getter;
 /**
  * 공통 API 응답 래퍼.
  *
- * <p>모든 API 엔드포인트는 이 클래스를 통해 일관된 형식으로 응답을 반환한다.
- * null 필드는 JSON 직렬화 시 생략된다.</p>
+ * <p>모든 API 엔드포인트는 이 클래스를 통해 일관된 형식으로 응답을 반환한다. null 필드는 JSON 직렬화 시 생략된다.
  *
  * <pre>{@code
  * // 데이터 + 메시지

--- a/src/main/java/com/groute/groute_server/common/response/ErrorResponse.java
+++ b/src/main/java/com/groute/groute_server/common/response/ErrorResponse.java
@@ -1,19 +1,19 @@
 package com.groute.groute_server.common.response;
 
+import java.util.List;
+
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.groute.groute_server.common.exception.ErrorCode;
+
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
-import java.util.List;
-
 /**
  * 공통 에러 응답 DTO.
  *
- * <p>{@code success}는 항상 {@code false}이며, Validation 에러 시
- * {@code errors} 필드에 필드별 상세 정보가 포함된다.</p>
+ * <p>{@code success}는 항상 {@code false}이며, Validation 에러 시 {@code errors} 필드에 필드별 상세 정보가 포함된다.
  *
  * @see ErrorCode
  * @see FieldError

--- a/src/main/java/com/groute/groute_server/common/util/DateTimeFormatters.java
+++ b/src/main/java/com/groute/groute_server/common/util/DateTimeFormatters.java
@@ -6,36 +6,33 @@ import java.time.ZoneId;
  * 사람이 읽는 시간 문자열 포맷을 한 곳에서 관리하는 유틸리티.
  *
  * <h2>포지셔닝</h2>
+ *
  * <ul>
- *   <li>엔티티/DB에 저장되는 시간은 {@link java.time.OffsetDateTime} UTC를 기준으로 한다.</li>
- *   <li>응답 DTO에 <b>raw {@code OffsetDateTime}</b> 필드를 노출하는 경우,
- *       직렬화는 {@link com.groute.groute_server.common.config.JacksonConfig}가 ISO-8601 UTC로 처리한다.
- *       (예: 클라이언트가 직접 상대시간("2시간 전")을 계산하는 케이스)</li>
- *   <li>응답 DTO에 <b>사람이 읽는 문자열</b>(예: "2026.04.18", "04.18 15:45")을 내려야 하는 경우,
- *       서비스/어셈블러 레이어에서 본 클래스의 포맷터/헬퍼를 사용해 {@code String}으로 채운다.</li>
+ *   <li>엔티티/DB에 저장되는 시간은 {@link java.time.OffsetDateTime} UTC를 기준으로 한다.
+ *   <li>응답 DTO에 <b>raw {@code OffsetDateTime}</b> 필드를 노출하는 경우, 직렬화는 {@link
+ *       com.groute.groute_server.common.config.JacksonConfig}가 ISO-8601 UTC로 처리한다. (예: 클라이언트가 직접
+ *       상대시간("2시간 전")을 계산하는 케이스)
+ *   <li>응답 DTO에 <b>사람이 읽는 문자열</b>(예: "2026.04.18", "04.18 15:45")을 내려야 하는 경우, 서비스/어셈블러 레이어에서 본 클래스의
+ *       포맷터/헬퍼를 사용해 {@code String}으로 채운다.
  * </ul>
  *
  * <h2>사용 위치</h2>
- * 서비스 레이어 또는 DTO 어셈블러에서만 호출한다.
- * 엔티티와 컨트롤러는 시간 포맷팅에 관여하지 않는다.
+ *
+ * 서비스 레이어 또는 DTO 어셈블러에서만 호출한다. 엔티티와 컨트롤러는 시간 포맷팅에 관여하지 않는다.
  *
  * <h2>타임존 변환 책임</h2>
- * UTC로 저장된 시간을 KST 표현으로 변환하는 로직은 본 클래스 내부에서 처리한다.
- * 호출부는 UTC/KST 변환을 신경 쓰지 않고 "어떤 포맷으로 보여줄지"만 결정한다.
+ *
+ * UTC로 저장된 시간을 KST 표현으로 변환하는 로직은 본 클래스 내부에서 처리한다. 호출부는 UTC/KST 변환을 신경 쓰지 않고 "어떤 포맷으로 보여줄지"만 결정한다.
  *
  * <h2>현재 상태</h2>
- * 응답 DTO 작업 전이므로 실제 포맷터 상수/메서드는 비어 있다.
- * 클라이언트 요구 패턴이 확정되는 대로 이곳에 상수와 헬퍼 메서드를 추가한다.
- * (예: {@code KST_DATE_DOT}, {@code KST_DATE_TIME_DOT}, {@code toKstDate(OffsetDateTime)} 등)
+ *
+ * 응답 DTO 작업 전이므로 실제 포맷터 상수/메서드는 비어 있다. 클라이언트 요구 패턴이 확정되는 대로 이곳에 상수와 헬퍼 메서드를 추가한다. (예: {@code
+ * KST_DATE_DOT}, {@code KST_DATE_TIME_DOT}, {@code toKstDate(OffsetDateTime)} 등)
  */
 public final class DateTimeFormatters {
 
-    /**
-     * 한국 서비스 기준 표시용 타임존.
-     * UTC로 저장된 시간을 KST로 환산할 때 모든 포맷터/헬퍼가 공통으로 사용한다.
-     */
+    /** 한국 서비스 기준 표시용 타임존. UTC로 저장된 시간을 KST로 환산할 때 모든 포맷터/헬퍼가 공통으로 사용한다. */
     public static final ZoneId ZONE_KST = ZoneId.of("Asia/Seoul");
 
-    private DateTimeFormatters() {
-    }
+    private DateTimeFormatters() {}
 }

--- a/src/main/java/com/groute/groute_server/common/webhook/DiscordEmbed.java
+++ b/src/main/java/com/groute/groute_server/common/webhook/DiscordEmbed.java
@@ -1,17 +1,17 @@
 package com.groute.groute_server.common.webhook;
 
-import com.fasterxml.jackson.annotation.JsonInclude;
-
 import java.time.OffsetDateTime;
 import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
 
 /**
  * Discord 웹훅 embed 페이로드.
  *
- * <p>Discord 공식 스키마의 필드명을 그대로 직렬화하도록 필드명을 맞춘다.
- * {@code null} 필드는 직렬화에서 제외된다.</p>
+ * <p>Discord 공식 스키마의 필드명을 그대로 직렬화하도록 필드명을 맞춘다. {@code null} 필드는 직렬화에서 제외된다.
  *
- * @see <a href="https://discord.com/developers/docs/resources/message#embed-object">Discord Embed Object</a>
+ * @see <a href="https://discord.com/developers/docs/resources/message#embed-object">Discord Embed
+ *     Object</a>
  */
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public record DiscordEmbed(
@@ -19,10 +19,8 @@ public record DiscordEmbed(
         String description,
         Integer color,
         OffsetDateTime timestamp,
-        List<Field> fields
-) {
+        List<Field> fields) {
 
     @JsonInclude(JsonInclude.Include.NON_NULL)
-    public record Field(String name, String value, Boolean inline) {
-    }
+    public record Field(String name, String value, Boolean inline) {}
 }

--- a/src/main/java/com/groute/groute_server/common/webhook/DiscordWebhookClient.java
+++ b/src/main/java/com/groute/groute_server/common/webhook/DiscordWebhookClient.java
@@ -1,7 +1,7 @@
 package com.groute.groute_server.common.webhook;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import lombok.extern.slf4j.Slf4j;
+import java.util.concurrent.CompletableFuture;
+
 import org.springframework.http.MediaType;
 import org.springframework.http.client.SimpleClientHttpRequestFactory;
 import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
@@ -10,14 +10,15 @@ import org.springframework.stereotype.Component;
 import org.springframework.web.client.RestClient;
 import org.springframework.web.client.RestClientException;
 
-import java.util.concurrent.CompletableFuture;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import lombok.extern.slf4j.Slf4j;
 
 /**
  * Discord 웹훅 전송 클라이언트.
  *
- * <p>{@code discord.webhook.enabled}가 {@code false}이거나 URL이 비어 있으면 전송을 건너뛴다.
- * 네트워크 오류는 로그로만 남기고 호출자에게 전파하지 않아, 에러 알림 실패가 애플리케이션 응답을
- * 막지 않도록 한다. 전송은 {@link Async}로 처리되어 요청 처리 스레드를 블로킹하지 않는다.</p>
+ * <p>{@code discord.webhook.enabled}가 {@code false}이거나 URL이 비어 있으면 전송을 건너뛴다. 네트워크 오류는 로그로만 남기고
+ * 호출자에게 전파하지 않아, 에러 알림 실패가 애플리케이션 응답을 막지 않도록 한다. 전송은 {@link Async}로 처리되어 요청 처리 스레드를 블로킹하지 않는다.
  */
 @Slf4j
 @Component
@@ -40,7 +41,8 @@ public class DiscordWebhookClient {
             return CompletableFuture.completedFuture(null);
         }
         try {
-            restClient.post()
+            restClient
+                    .post()
                     .uri(properties.url())
                     .contentType(MediaType.APPLICATION_JSON)
                     .body(DiscordWebhookPayload.of(embed))
@@ -54,9 +56,7 @@ public class DiscordWebhookClient {
     }
 
     private boolean isActive() {
-        return properties.enabled()
-                && properties.url() != null
-                && !properties.url().isBlank();
+        return properties.enabled() && properties.url() != null && !properties.url().isBlank();
     }
 
     private static RestClient buildRestClient(ObjectMapper objectMapper) {
@@ -65,10 +65,11 @@ public class DiscordWebhookClient {
         factory.setReadTimeout(READ_TIMEOUT_MS);
         return RestClient.builder()
                 .requestFactory(factory)
-                .messageConverters(converters -> {
-                    converters.clear();
-                    converters.add(new MappingJackson2HttpMessageConverter(objectMapper));
-                })
+                .messageConverters(
+                        converters -> {
+                            converters.clear();
+                            converters.add(new MappingJackson2HttpMessageConverter(objectMapper));
+                        })
                 .build();
     }
 }

--- a/src/main/java/com/groute/groute_server/common/webhook/DiscordWebhookPayload.java
+++ b/src/main/java/com/groute/groute_server/common/webhook/DiscordWebhookPayload.java
@@ -1,18 +1,12 @@
 package com.groute.groute_server.common.webhook;
 
-import com.fasterxml.jackson.annotation.JsonInclude;
-
 import java.util.List;
 
-/**
- * Discord 웹훅 요청 바디. 최상위 페이로드로 하나 이상의 {@link DiscordEmbed}를 감싼다.
- */
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+/** Discord 웹훅 요청 바디. 최상위 페이로드로 하나 이상의 {@link DiscordEmbed}를 감싼다. */
 @JsonInclude(JsonInclude.Include.NON_NULL)
-public record DiscordWebhookPayload(
-        String username,
-        String content,
-        List<DiscordEmbed> embeds
-) {
+public record DiscordWebhookPayload(String username, String content, List<DiscordEmbed> embeds) {
 
     public static DiscordWebhookPayload of(DiscordEmbed embed) {
         return new DiscordWebhookPayload(null, null, List.of(embed));

--- a/src/main/java/com/groute/groute_server/common/webhook/DiscordWebhookProperties.java
+++ b/src/main/java/com/groute/groute_server/common/webhook/DiscordWebhookProperties.java
@@ -5,13 +5,9 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 /**
  * Discord 웹훅 전송 설정.
  *
- * <p>{@code enabled}가 {@code false}이거나 {@code url}이 비어 있으면 전송을 건너뛴다.
- * 환경별 URL은 SSM Parameter Store의 {@code /groute/{env}/DISCORD_WEBHOOK_URL}에서
- * 주입되며, 배포 파이프라인이 컨테이너 환경변수 {@code DISCORD_WEBHOOK_URL}로 변환한다.</p>
+ * <p>{@code enabled}가 {@code false}이거나 {@code url}이 비어 있으면 전송을 건너뛴다. 환경별 URL은 SSM Parameter Store의
+ * {@code /groute/{env}/DISCORD_WEBHOOK_URL}에서 주입되며, 배포 파이프라인이 컨테이너 환경변수 {@code
+ * DISCORD_WEBHOOK_URL}로 변환한다.
  */
 @ConfigurationProperties(prefix = "discord.webhook")
-public record DiscordWebhookProperties(
-        boolean enabled,
-        String url
-) {
-}
+public record DiscordWebhookProperties(boolean enabled, String url) {}

--- a/src/main/java/com/groute/groute_server/common/webhook/ErrorWebhookNotifier.java
+++ b/src/main/java/com/groute/groute_server/common/webhook/ErrorWebhookNotifier.java
@@ -1,20 +1,21 @@
 package com.groute.groute_server.common.webhook;
 
-import jakarta.servlet.http.HttpServletRequest;
-import lombok.RequiredArgsConstructor;
-import org.springframework.core.env.Environment;
-import org.springframework.stereotype.Component;
-
 import java.time.OffsetDateTime;
 import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import jakarta.servlet.http.HttpServletRequest;
+
+import org.springframework.core.env.Environment;
+import org.springframework.stereotype.Component;
+
+import lombok.RequiredArgsConstructor;
+
 /**
  * Unhandled 서버 에러를 Discord 웹훅으로 알린다.
  *
- * <p>PII 유출 방지를 위해 요청 바디/헤더/쿼리스트링은 포함하지 않고,
- * HTTP method, path, 프로파일, 예외 타입·메시지, 스택 트레이스 헤드만 전송한다.</p>
+ * <p>PII 유출 방지를 위해 요청 바디/헤더/쿼리스트링은 포함하지 않고, HTTP method, path, 프로파일, 예외 타입·메시지, 스택 트레이스 헤드만 전송한다.
  */
 @Component
 @RequiredArgsConstructor
@@ -29,18 +30,18 @@ public class ErrorWebhookNotifier {
     private final Environment environment;
 
     public void notifyUnhandledError(Exception e, HttpServletRequest request) {
-        DiscordEmbed embed = new DiscordEmbed(
-                "🚨 서버가 처리하지 못하는 에러가 발생했어요!",
-                buildDescription(e),
-                COLOR_RED,
-                OffsetDateTime.now(),
-                List.of(
-                        new DiscordEmbed.Field("Profile", resolveProfile(), true),
-                        new DiscordEmbed.Field("Method", request.getMethod(), true),
-                        new DiscordEmbed.Field("Path", request.getRequestURI(), false),
-                        new DiscordEmbed.Field("Exception", e.getClass().getName(), false)
-                )
-        );
+        DiscordEmbed embed =
+                new DiscordEmbed(
+                        "🚨 서버가 처리하지 못하는 에러가 발생했어요!",
+                        buildDescription(e),
+                        COLOR_RED,
+                        OffsetDateTime.now(),
+                        List.of(
+                                new DiscordEmbed.Field("Profile", resolveProfile(), true),
+                                new DiscordEmbed.Field("Method", request.getMethod(), true),
+                                new DiscordEmbed.Field("Path", request.getRequestURI(), false),
+                                new DiscordEmbed.Field(
+                                        "Exception", e.getClass().getName(), false)));
         webhookClient.send(embed);
     }
 
@@ -53,16 +54,15 @@ public class ErrorWebhookNotifier {
         if (msg == null || msg.isBlank()) {
             return "(no message)";
         }
-        return msg.length() > MAX_MESSAGE_LEN
-                ? msg.substring(0, MAX_MESSAGE_LEN) + "..."
-                : msg;
+        return msg.length() > MAX_MESSAGE_LEN ? msg.substring(0, MAX_MESSAGE_LEN) + "..." : msg;
     }
 
     private String formatStackHead(Throwable e) {
-        String joined = Arrays.stream(e.getStackTrace())
-                .limit(MAX_STACK_LINES)
-                .map(StackTraceElement::toString)
-                .collect(Collectors.joining("\n"));
+        String joined =
+                Arrays.stream(e.getStackTrace())
+                        .limit(MAX_STACK_LINES)
+                        .map(StackTraceElement::toString)
+                        .collect(Collectors.joining("\n"));
         return joined.length() > MAX_STACK_CHARS
                 ? joined.substring(0, MAX_STACK_CHARS) + "\n... (truncated)"
                 : joined;

--- a/src/main/java/com/groute/groute_server/common/webhook/StartupWebhookNotifier.java
+++ b/src/main/java/com/groute/groute_server/common/webhook/StartupWebhookNotifier.java
@@ -1,19 +1,19 @@
 package com.groute.groute_server.common.webhook;
 
-import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
+import java.time.OffsetDateTime;
+
 import org.springframework.boot.context.event.ApplicationReadyEvent;
 import org.springframework.context.event.EventListener;
 import org.springframework.core.env.Environment;
 import org.springframework.stereotype.Component;
 
-import java.time.OffsetDateTime;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
 /**
  * 서버 기동 완료 시 Discord 웹훅 헬스체크 메시지를 전송한다.
  *
- * <p>{@link ApplicationReadyEvent}를 수신하여 활성 프로파일과 함께 기동 알림을 보낸다.
- * 웹훅 비활성 상태면 조용히 건너뛴다.</p>
+ * <p>{@link ApplicationReadyEvent}를 수신하여 활성 프로파일과 함께 기동 알림을 보낸다. 웹훅 비활성 상태면 조용히 건너뛴다.
  */
 @Slf4j
 @Component
@@ -34,17 +34,17 @@ public class StartupWebhookNotifier {
         }
 
         String profile = resolveActiveProfile();
-        DiscordEmbed embed = new DiscordEmbed(
-                "\uD83C\uDF80 서버 기동 완료",
-                "`" + profile + "` 프로파일 서버가 정상 기동되었습니다.",
-                COLOR_PINK,
-                OffsetDateTime.now(),
-                null
-        );
+        DiscordEmbed embed =
+                new DiscordEmbed(
+                        "\uD83C\uDF80 서버 기동 완료",
+                        "`" + profile + "` 프로파일 서버가 정상 기동되었습니다.",
+                        COLOR_PINK,
+                        OffsetDateTime.now(),
+                        null);
 
-        webhookClient.send(embed).thenRun(() ->
-                log.info("Discord 헬스체크 메시지 전송 성공 (profile={})", profile)
-        );
+        webhookClient
+                .send(embed)
+                .thenRun(() -> log.info("Discord 헬스체크 메시지 전송 성공 (profile={})", profile));
     }
 
     private String resolveActiveProfile() {

--- a/src/main/java/com/groute/groute_server/record/domain/AiTaggingJob.java
+++ b/src/main/java/com/groute/groute_server/record/domain/AiTaggingJob.java
@@ -1,21 +1,24 @@
 package com.groute.groute_server.record.domain;
 
-import com.groute.groute_server.common.entity.BaseTimeEntity;
-import com.groute.groute_server.record.domain.enums.JobStatus;
+import java.time.OffsetDateTime;
+import java.util.Map;
+
 import jakarta.persistence.*;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+
 import org.hibernate.annotations.JdbcTypeCode;
 import org.hibernate.type.SqlTypes;
 
-import java.time.OffsetDateTime;
-import java.util.Map;
+import com.groute.groute_server.common.entity.BaseTimeEntity;
+import com.groute.groute_server.record.domain.enums.JobStatus;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 /**
  * AI 태깅 비동기 잡 큐(REC006).
  *
- * <p>워커가 {@code SELECT FOR UPDATE SKIP LOCKED}로 QUEUED 잡을 폴링해 처리한다.
- * 최대 1회 재시도 허용(1차 실패 → 재시도 → 2차 실패 시 FAILED 확정).
+ * <p>워커가 {@code SELECT FOR UPDATE SKIP LOCKED}로 QUEUED 잡을 폴링해 처리한다. 최대 1회 재시도 허용(1차 실패 → 재시도 → 2차
+ * 실패 시 FAILED 확정).
  */
 @Getter
 @NoArgsConstructor
@@ -44,10 +47,7 @@ public class AiTaggingJob extends BaseTimeEntity {
     @Column(name = "request_payload", columnDefinition = "jsonb")
     private Map<String, Object> requestPayload;
 
-    /**
-     * AI 응답 원문.
-     * {primary_category, detail_tags[]} JSON. 디버깅 및 모델 교체 대비용 원본 보관.
-     */
+    /** AI 응답 원문. {primary_category, detail_tags[]} JSON. 디버깅 및 모델 교체 대비용 원본 보관. */
     @JdbcTypeCode(SqlTypes.JSON)
     @Column(name = "response_payload", columnDefinition = "jsonb")
     private Map<String, Object> responsePayload;

--- a/src/main/java/com/groute/groute_server/record/domain/DailyCompetencyStat.java
+++ b/src/main/java/com/groute/groute_server/record/domain/DailyCompetencyStat.java
@@ -1,24 +1,26 @@
 package com.groute.groute_server.record.domain;
 
-import com.groute.groute_server.common.entity.BaseTimeEntity;
-import com.groute.groute_server.record.domain.enums.CompetencyCategory;
-import com.groute.groute_server.user.entity.User;
-import jakarta.persistence.*;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import org.hibernate.annotations.JdbcTypeCode;
-import org.hibernate.type.SqlTypes;
-
 import java.time.LocalDate;
 import java.util.HashMap;
 import java.util.Map;
 
+import jakarta.persistence.*;
+
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
+
+import com.groute.groute_server.common.entity.BaseTimeEntity;
+import com.groute.groute_server.record.domain.enums.CompetencyCategory;
+import com.groute.groute_server.user.entity.User;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
 /**
  * 일자별 역량 집계 테이블.
  *
- * <p>홈 잔디(HOM002)·레이더 차트(HOM003)의 성능 최적화용.
- * STAR 완료 시 upsert되며, (user_id, stat_date) UNIQUE 기준으로 ON CONFLICT 갱신.
- * 최근 3개월 구간만 조회 대상(HOM002).
+ * <p>홈 잔디(HOM002)·레이더 차트(HOM003)의 성능 최적화용. STAR 완료 시 upsert되며, (user_id, stat_date) UNIQUE 기준으로 ON
+ * CONFLICT 갱신. 최근 3개월 구간만 조회 대상(HOM002).
  */
 @Getter
 @NoArgsConstructor
@@ -46,18 +48,12 @@ public class DailyCompetencyStat extends BaseTimeEntity {
     @Column(name = "star_count", nullable = false)
     private Short starCount = 0;
 
-    /**
-     * 해당 날짜 대표 역량. 잔디 색상 결정.
-     * STAR 0건이면 NULL.
-     */
+    /** 해당 날짜 대표 역량. 잔디 색상 결정. STAR 0건이면 NULL. */
     @Enumerated(EnumType.STRING)
     @Column(name = "primary_category")
     private CompetencyCategory primaryCategory;
 
-    /**
-     * 레이더 차트용 카테고리별 카운트(HOM003).
-     * 예: {@code {"DISCOVERY_ANALYSIS":2,"PLANNING_EXECUTION":1,...}}
-     */
+    /** 레이더 차트용 카테고리별 카운트(HOM003). 예: {@code {"DISCOVERY_ANALYSIS":2,"PLANNING_EXECUTION":1,...}} */
     @JdbcTypeCode(SqlTypes.JSON)
     @Column(name = "category_counts", nullable = false, columnDefinition = "jsonb")
     private Map<String, Object> categoryCounts = new HashMap<>();

--- a/src/main/java/com/groute/groute_server/record/domain/Project.java
+++ b/src/main/java/com/groute/groute_server/record/domain/Project.java
@@ -1,16 +1,18 @@
 package com.groute.groute_server.record.domain;
 
+import jakarta.persistence.*;
+
 import com.groute.groute_server.common.entity.SoftDeleteEntity;
 import com.groute.groute_server.user.entity.User;
-import jakarta.persistence.*;
+
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 /**
  * 프로젝트 태그(사용자별 태그 원본).
  *
- * <p>스크럼 제목 구성 시 드롭다운으로 노출되며, 사용자별로 고유한 태그명을 가진다(REC002).
- * {@link #titleCount}=0일 때만 태그 삭제가 허용된다(심화기록 포함 카운팅 기준).
+ * <p>스크럼 제목 구성 시 드롭다운으로 노출되며, 사용자별로 고유한 태그명을 가진다(REC002). {@link #titleCount}=0일 때만 태그 삭제가
+ * 허용된다(심화기록 포함 카운팅 기준).
  */
 @Getter
 @NoArgsConstructor
@@ -30,10 +32,7 @@ public class Project extends SoftDeleteEntity {
     @Column(name = "name", nullable = false, length = 15)
     private String name;
 
-    /**
-     * 비정규화 카운터: 이 프로젝트에 연결된 scrum_titles 수.
-     * 0이면 태그 삭제 가능(REC002 태그 삭제 조건).
-     */
+    /** 비정규화 카운터: 이 프로젝트에 연결된 scrum_titles 수. 0이면 태그 삭제 가능(REC002 태그 삭제 조건). */
     @Column(name = "title_count", nullable = false)
     private Short titleCount = 0;
 }

--- a/src/main/java/com/groute/groute_server/record/domain/Scrum.java
+++ b/src/main/java/com/groute/groute_server/record/domain/Scrum.java
@@ -1,19 +1,21 @@
 package com.groute.groute_server.record.domain;
 
+import java.time.LocalDate;
+
+import jakarta.persistence.*;
+
 import com.groute.groute_server.common.entity.SoftDeleteEntity;
 import com.groute.groute_server.record.domain.enums.CompetencyCategory;
 import com.groute.groute_server.user.entity.User;
-import jakarta.persistence.*;
+
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-
-import java.time.LocalDate;
 
 /**
  * 데일리 스크럼 본문.
  *
- * <p>스크럼 제목(N:1)에 매달리는 데일리 기록. 날짜당 유저별 전체 스크럼 최대 5개 제약(REC002).
- * {@link #hasStar}=true이면 심화 STAR 기록이 존재하며, 스크럼 수정이 잠긴다(CAL002).
+ * <p>스크럼 제목(N:1)에 매달리는 데일리 기록. 날짜당 유저별 전체 스크럼 최대 5개 제약(REC002). {@link #hasStar}=true이면 심화 STAR 기록이
+ * 존재하며, 스크럼 수정이 잠긴다(CAL002).
  */
 @Getter
 @NoArgsConstructor
@@ -39,24 +41,17 @@ public class Scrum extends SoftDeleteEntity {
     private String content;
 
     /**
-     * 사용자가 선택한 날짜.
-     * 당일 기준 최근 14일 이내만 선택 가능하며 미래 불가(REC002).
-     * 범위 검증은 CURRENT_DATE 의존이라 DB CHECK 대신 애플리케이션 레벨에서 수행.
+     * 사용자가 선택한 날짜. 당일 기준 최근 14일 이내만 선택 가능하며 미래 불가(REC002). 범위 검증은 CURRENT_DATE 의존이라 DB CHECK 대신
+     * 애플리케이션 레벨에서 수행.
      */
     @Column(name = "scrum_date", nullable = false)
     private LocalDate scrumDate;
 
-    /**
-     * 심화 STAR 기록 연결 여부.
-     * true 시 스크럼 수정 잠금. 스크럼 삭제 시 심화기록도 함께 삭제(CAL002).
-     */
+    /** 심화 STAR 기록 연결 여부. true 시 스크럼 수정 잠금. 스크럼 삭제 시 심화기록도 함께 삭제(CAL002). */
     @Column(name = "has_star", nullable = false)
     private boolean hasStar = false;
 
-    /**
-     * 사용자가 선택한 5대 역량(REC004).
-     * STAR 심화 기록 시작 전 선택. NULL 허용(미선택 상태).
-     */
+    /** 사용자가 선택한 5대 역량(REC004). STAR 심화 기록 시작 전 선택. NULL 허용(미선택 상태). */
     @Enumerated(EnumType.STRING)
     @Column(name = "selected_competency")
     private CompetencyCategory selectedCompetency;

--- a/src/main/java/com/groute/groute_server/record/domain/ScrumTitle.java
+++ b/src/main/java/com/groute/groute_server/record/domain/ScrumTitle.java
@@ -1,16 +1,17 @@
 package com.groute.groute_server.record.domain;
 
+import jakarta.persistence.*;
+
 import com.groute.groute_server.common.entity.SoftDeleteEntity;
 import com.groute.groute_server.user.entity.User;
-import jakarta.persistence.*;
+
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 /**
  * 스크럼 제목.
  *
- * <p>프로젝트 태그(FK) + 자유작성 텍스트(최대 20자)로 구성된다(REC002).
- * 날짜와 무관하게 재사용 가능하며, 제목 선택 드롭다운 UI에 노출된다.
+ * <p>프로젝트 태그(FK) + 자유작성 텍스트(최대 20자)로 구성된다(REC002). 날짜와 무관하게 재사용 가능하며, 제목 선택 드롭다운 UI에 노출된다.
  */
 @Getter
 @NoArgsConstructor
@@ -35,10 +36,7 @@ public class ScrumTitle extends SoftDeleteEntity {
     @Column(name = "free_text", nullable = false, length = 20)
     private String freeText;
 
-    /**
-     * 비정규화 카운터: 이 제목에 연결된 scrums 수.
-     * UI의 "N회 사용" 뱃지 렌더링(REC002, is_deleted=false 기준).
-     */
+    /** 비정규화 카운터: 이 제목에 연결된 scrums 수. UI의 "N회 사용" 뱃지 렌더링(REC002, is_deleted=false 기준). */
     @Column(name = "scrum_count", nullable = false)
     private Short scrumCount = 0;
 }

--- a/src/main/java/com/groute/groute_server/record/domain/StarImage.java
+++ b/src/main/java/com/groute/groute_server/record/domain/StarImage.java
@@ -1,7 +1,9 @@
 package com.groute.groute_server.record.domain;
 
-import com.groute.groute_server.common.entity.BaseTimeEntity;
 import jakarta.persistence.*;
+
+import com.groute.groute_server.common.entity.BaseTimeEntity;
+
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 

--- a/src/main/java/com/groute/groute_server/record/domain/StarRecord.java
+++ b/src/main/java/com/groute/groute_server/record/domain/StarRecord.java
@@ -1,19 +1,21 @@
 package com.groute.groute_server.record.domain;
 
+import java.time.OffsetDateTime;
+
+import jakarta.persistence.*;
+
 import com.groute.groute_server.common.entity.SoftDeleteEntity;
 import com.groute.groute_server.record.domain.enums.StarStep;
 import com.groute.groute_server.user.entity.User;
-import jakarta.persistence.*;
+
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-
-import java.time.OffsetDateTime;
 
 /**
  * 심화 STAR 기록.
  *
- * <p>스크럼과 1:1(REC008). 단계별로 작성이 진행되며, 3단계 완료 후 AI 태깅 호출로 완료된다.
- * {@link #currentStep} + 각 단계 필드(S/T, A, R)로 임시저장을 대체한다(REC010).
+ * <p>스크럼과 1:1(REC008). 단계별로 작성이 진행되며, 3단계 완료 후 AI 태깅 호출로 완료된다. {@link #currentStep} + 각 단계 필드(S/T,
+ * A, R)로 임시저장을 대체한다(REC010).
  */
 @Getter
 @NoArgsConstructor
@@ -46,10 +48,7 @@ public class StarRecord extends SoftDeleteEntity {
     @Column(name = "result", columnDefinition = "TEXT")
     private String result;
 
-    /**
-     * 현재 작성 단계(REC005).
-     * 재진입 시 이 단계부터 복원되어 임시저장 역할을 한다(REC010).
-     */
+    /** 현재 작성 단계(REC005). 재진입 시 이 단계부터 복원되어 임시저장 역할을 한다(REC010). */
     @Enumerated(EnumType.STRING)
     @Column(name = "current_step", nullable = false)
     private StarStep currentStep = StarStep.ST;
@@ -58,10 +57,7 @@ public class StarRecord extends SoftDeleteEntity {
     @Column(name = "is_completed", nullable = false)
     private boolean isCompleted = false;
 
-    /**
-     * 완료 시각.
-     * 리포트 임계치(10회 단위) 카운트 기준(RPT001).
-     */
+    /** 완료 시각. 리포트 임계치(10회 단위) 카운트 기준(RPT001). */
     @Column(name = "completed_at")
     private OffsetDateTime completedAt;
 }

--- a/src/main/java/com/groute/groute_server/record/domain/StarTag.java
+++ b/src/main/java/com/groute/groute_server/record/domain/StarTag.java
@@ -1,8 +1,10 @@
 package com.groute.groute_server.record.domain;
 
+import jakarta.persistence.*;
+
 import com.groute.groute_server.common.entity.BaseTimeEntity;
 import com.groute.groute_server.record.domain.enums.CompetencyCategory;
-import jakarta.persistence.*;
+
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -25,18 +27,12 @@ public class StarTag extends BaseTimeEntity {
     @JoinColumn(name = "star_record_id", nullable = false)
     private StarRecord starRecord;
 
-    /**
-     * 대표 역량 1개.
-     * 홈 잔디 색상 결정(HOM002). REC007 완료 화면에 노출.
-     */
+    /** 대표 역량 1개. 홈 잔디 색상 결정(HOM002). REC007 완료 화면에 노출. */
     @Enumerated(EnumType.STRING)
     @Column(name = "primary_category", nullable = false)
     private CompetencyCategory primaryCategory;
 
-    /**
-     * 세부 태그. AI가 자유롭게 생성(예: "이해관계자 조율").
-     * REC007 완료 화면에 최대 3개 노출.
-     */
+    /** 세부 태그. AI가 자유롭게 생성(예: "이해관계자 조율"). REC007 완료 화면에 최대 3개 노출. */
     @Column(name = "detail_tag", nullable = false, length = 50)
     private String detailTag;
 }

--- a/src/main/java/com/groute/groute_server/record/domain/enums/CompetencyCategory.java
+++ b/src/main/java/com/groute/groute_server/record/domain/enums/CompetencyCategory.java
@@ -1,10 +1,6 @@
 package com.groute.groute_server.record.domain.enums;
 
-/**
- * 5대 역량 카테고리.
- * 사용자가 STAR 작성 시 선택하거나(REC004) AI 태깅이 자동 분류하며,
- * 홈 잔디/레이더 차트의 색상과 집계 기준이 된다.
- */
+/** 5대 역량 카테고리. 사용자가 STAR 작성 시 선택하거나(REC004) AI 태깅이 자동 분류하며, 홈 잔디/레이더 차트의 색상과 집계 기준이 된다. */
 public enum CompetencyCategory {
     /** 발견/분석. */
     DISCOVERY_ANALYSIS,

--- a/src/main/java/com/groute/groute_server/record/domain/enums/JobStatus.java
+++ b/src/main/java/com/groute/groute_server/record/domain/enums/JobStatus.java
@@ -1,9 +1,6 @@
 package com.groute.groute_server.record.domain.enums;
 
-/**
- * AI 태깅 비동기 잡 상태.
- * 워커가 SELECT FOR UPDATE SKIP LOCKED로 QUEUED 잡을 폴링한다.
- */
+/** AI 태깅 비동기 잡 상태. 워커가 SELECT FOR UPDATE SKIP LOCKED로 QUEUED 잡을 폴링한다. */
 public enum JobStatus {
     /** 대기 중. 워커가 폴링하는 대상. */
     QUEUED,

--- a/src/main/java/com/groute/groute_server/record/domain/enums/StarStep.java
+++ b/src/main/java/com/groute/groute_server/record/domain/enums/StarStep.java
@@ -1,9 +1,6 @@
 package com.groute.groute_server.record.domain.enums;
 
-/**
- * STAR 심화 기록 작성 단계.
- * 재진입 시 이 단계부터 복원되어 임시저장 역할을 한다(REC005, REC010).
- */
+/** STAR 심화 기록 작성 단계. 재진입 시 이 단계부터 복원되어 임시저장 역할을 한다(REC005, REC010). */
 public enum StarStep {
     /** Situation·Task 작성 중. */
     ST,

--- a/src/main/java/com/groute/groute_server/report/domain/Report.java
+++ b/src/main/java/com/groute/groute_server/report/domain/Report.java
@@ -1,22 +1,24 @@
 package com.groute.groute_server.report.domain;
 
+import java.util.Map;
+
+import jakarta.persistence.*;
+
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
+
 import com.groute.groute_server.common.entity.BaseTimeEntity;
 import com.groute.groute_server.report.domain.enums.ReportStatus;
 import com.groute.groute_server.report.domain.enums.ReportType;
 import com.groute.groute_server.user.entity.User;
-import jakarta.persistence.*;
+
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.hibernate.annotations.JdbcTypeCode;
-import org.hibernate.type.SqlTypes;
-
-import java.util.Map;
 
 /**
  * 리포트(RPT001).
  *
- * <p>미니(첫 10회 1회성) + 커리어(이후 10회 단위) 두 종류를 지원.
- * MVP에서는 결제 플로우 없이 무료 생성만 제공한다.
+ * <p>미니(첫 10회 1회성) + 커리어(이후 10회 단위) 두 종류를 지원. MVP에서는 결제 플로우 없이 무료 생성만 제공한다.
  */
 @Getter
 @NoArgsConstructor
@@ -50,10 +52,7 @@ public class Report extends BaseTimeEntity {
     @Column(name = "title", length = 200)
     private String title;
 
-    /**
-     * 리포트 본문 JSON.
-     * 통합 서사 요약 / 핵심 강점 / 전략적 어필 포인트 / 예상 면접 질문 / branding_title 등(RPT003).
-     */
+    /** 리포트 본문 JSON. 통합 서사 요약 / 핵심 강점 / 전략적 어필 포인트 / 예상 면접 질문 / branding_title 등(RPT003). */
     @JdbcTypeCode(SqlTypes.JSON)
     @Column(name = "content_json", columnDefinition = "jsonb")
     private Map<String, Object> contentJson;

--- a/src/main/java/com/groute/groute_server/report/domain/enums/ReportStatus.java
+++ b/src/main/java/com/groute/groute_server/report/domain/enums/ReportStatus.java
@@ -1,8 +1,6 @@
 package com.groute.groute_server.report.domain.enums;
 
-/**
- * 리포트 생성 상태.
- */
+/** 리포트 생성 상태. */
 public enum ReportStatus {
     /** AI 호출 중. */
     GENERATING,

--- a/src/main/java/com/groute/groute_server/report/domain/enums/ReportType.java
+++ b/src/main/java/com/groute/groute_server/report/domain/enums/ReportType.java
@@ -1,9 +1,6 @@
 package com.groute.groute_server.report.domain.enums;
 
-/**
- * 리포트 타입.
- * MVP에서는 결제 없이 무료 생성만 제공.
- */
+/** 리포트 타입. MVP에서는 결제 없이 무료 생성만 제공. */
 public enum ReportType {
     /** 미니 리포트. 첫 심화기록 10회 누적 시 1회성 발행 (무료). */
     MINI,

--- a/src/main/java/com/groute/groute_server/user/entity/CoachmarkHistory.java
+++ b/src/main/java/com/groute/groute_server/user/entity/CoachmarkHistory.java
@@ -1,17 +1,19 @@
 package com.groute.groute_server.user.entity;
 
-import com.groute.groute_server.common.entity.BaseTimeEntity;
+import java.time.OffsetDateTime;
+
 import jakarta.persistence.*;
+
+import com.groute.groute_server.common.entity.BaseTimeEntity;
+
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-
-import java.time.OffsetDateTime;
 
 /**
  * 코치마크 노출 이력.
  *
- * <p>유저당 코치마크 종류별 1회만 노출. 최초 노출 시 row를 생성하고 이후 재노출하지 않는다.
- * 첫 스크럼/첫 심화기록 완료 후 캘린더 탭 코치마크가 대표 예시(REC002/REC007).
+ * <p>유저당 코치마크 종류별 1회만 노출. 최초 노출 시 row를 생성하고 이후 재노출하지 않는다. 첫 스크럼/첫 심화기록 완료 후 캘린더 탭 코치마크가 대표
+ * 예시(REC002/REC007).
  */
 @Getter
 @NoArgsConstructor

--- a/src/main/java/com/groute/groute_server/user/entity/NotificationSetting.java
+++ b/src/main/java/com/groute/groute_server/user/entity/NotificationSetting.java
@@ -1,19 +1,20 @@
 package com.groute.groute_server.user.entity;
 
+import java.time.LocalTime;
+
+import jakarta.persistence.*;
+
 import com.groute.groute_server.common.entity.BaseTimeEntity;
 import com.groute.groute_server.user.enums.DayOfWeek;
-import jakarta.persistence.*;
+
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-
-import java.time.LocalTime;
 
 /**
  * 유저 알림 설정(MYP003).
  *
- * <p>요일 + 시간 조합으로 여러 슬롯을 등록할 수 있다.
- * 시간대는 07:00~자정(00:00) 범위 내 30분 단위로 제한(DB CHECK로 강제).
- * 스케줄러는 (day_of_week, notify_time) 기준으로 발송 대상 유저를 역조회한다.
+ * <p>요일 + 시간 조합으로 여러 슬롯을 등록할 수 있다. 시간대는 07:00~자정(00:00) 범위 내 30분 단위로 제한(DB CHECK로 강제). 스케줄러는
+ * (day_of_week, notify_time) 기준으로 발송 대상 유저를 역조회한다.
  */
 @Getter
 @NoArgsConstructor
@@ -34,10 +35,7 @@ public class NotificationSetting extends BaseTimeEntity {
     @Column(name = "day_of_week", nullable = false)
     private DayOfWeek dayOfWeek;
 
-    /**
-     * 알림 시각.
-     * 07:00~자정(00:00) 사이 30분 단위만 허용(MYP003). 범위·그리드 제약은 DB CHECK가 강제.
-     */
+    /** 알림 시각. 07:00~자정(00:00) 사이 30분 단위만 허용(MYP003). 범위·그리드 제약은 DB CHECK가 강제. */
     @Column(name = "notify_time", nullable = false)
     private LocalTime notifyTime;
 

--- a/src/main/java/com/groute/groute_server/user/entity/User.java
+++ b/src/main/java/com/groute/groute_server/user/entity/User.java
@@ -1,20 +1,21 @@
 package com.groute.groute_server.user.entity;
 
+import java.time.OffsetDateTime;
+
+import jakarta.persistence.*;
+
 import com.groute.groute_server.common.entity.SoftDeleteEntity;
 import com.groute.groute_server.user.enums.JobRole;
 import com.groute.groute_server.user.enums.UserStatus;
-import jakarta.persistence.*;
+
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-
-import java.time.OffsetDateTime;
 
 /**
  * 서비스 사용자.
  *
- * <p>소셜 로그인으로 가입하며 닉네임/직군/현재 상태를 보유한다.
- * 회원 탈퇴 시 {@link #hardDeleteAt}을 설정해두고, 배치 잡이 해당 시각 이후 모든 연관 데이터를 물리 삭제한다(MYP005).
- * 논리 삭제 플래그(is_deleted/deleted_at)는 부모 {@link SoftDeleteEntity}에서 상속.
+ * <p>소셜 로그인으로 가입하며 닉네임/직군/현재 상태를 보유한다. 회원 탈퇴 시 {@link #hardDeleteAt}을 설정해두고, 배치 잡이 해당 시각 이후 모든 연관
+ * 데이터를 물리 삭제한다(MYP005). 논리 삭제 플래그(is_deleted/deleted_at)는 부모 {@link SoftDeleteEntity}에서 상속.
  */
 @Getter
 @NoArgsConstructor
@@ -43,8 +44,7 @@ public class User extends SoftDeleteEntity {
     /**
      * 리포트에서 생성된 커리어 브랜딩 문장.
      *
-     * <p>리포트 미생성 시 NULL → 기본 카피("하루를 기록하고, 나는 어떤 사람인지 확인해보세요") 노출(HOM001).
-     * 리포트 발행 시 자동 교체된다.
+     * <p>리포트 미생성 시 NULL → 기본 카피("하루를 기록하고, 나는 어떤 사람인지 확인해보세요") 노출(HOM001). 리포트 발행 시 자동 교체된다.
      */
     @Column(name = "branding_title", length = 100)
     private String brandingTitle;
@@ -56,8 +56,7 @@ public class User extends SoftDeleteEntity {
     /**
      * 물리 삭제 예약 시각.
      *
-     * <p>회원 탈퇴 요청 시 set. 배치 잡이 이 시각 이후 모든 연관 데이터를 물리 삭제(MYP005).
-     * 복구 불가. 개인정보보호법 대응 목적.
+     * <p>회원 탈퇴 요청 시 set. 배치 잡이 이 시각 이후 모든 연관 데이터를 물리 삭제(MYP005). 복구 불가. 개인정보보호법 대응 목적.
      */
     @Column(name = "hard_delete_at")
     private OffsetDateTime hardDeleteAt;

--- a/src/main/java/com/groute/groute_server/user/enums/DayOfWeek.java
+++ b/src/main/java/com/groute/groute_server/user/enums/DayOfWeek.java
@@ -1,9 +1,6 @@
 package com.groute.groute_server.user.enums;
 
-/**
- * 요일.
- * 알림 설정(MYP003) 등에서 요일 체크박스 다중 선택에 사용.
- */
+/** 요일. 알림 설정(MYP003) 등에서 요일 체크박스 다중 선택에 사용. */
 public enum DayOfWeek {
     /** 월요일. */
     MON,

--- a/src/main/java/com/groute/groute_server/user/enums/JobRole.java
+++ b/src/main/java/com/groute/groute_server/user/enums/JobRole.java
@@ -1,10 +1,6 @@
 package com.groute.groute_server.user.enums;
 
-/**
- * 사용자 직군.
- * 온보딩 시 1회 선택하며(ONB004), 마이페이지에서 변경 가능(MYP002).
- * AI 태깅 시 컨텍스트로 활용된다.
- */
+/** 사용자 직군. 온보딩 시 1회 선택하며(ONB004), 마이페이지에서 변경 가능(MYP002). AI 태깅 시 컨텍스트로 활용된다. */
 public enum JobRole {
     /** 기획자. */
     PLANNER,

--- a/src/main/java/com/groute/groute_server/user/enums/UserStatus.java
+++ b/src/main/java/com/groute/groute_server/user/enums/UserStatus.java
@@ -1,9 +1,6 @@
 package com.groute.groute_server.user.enums;
 
-/**
- * 사용자 현재 상태.
- * 온보딩 시 선택(ONB005), 마이페이지에서 자유롭게 변경 가능(MYP002).
- */
+/** 사용자 현재 상태. 온보딩 시 선택(ONB005), 마이페이지에서 자유롭게 변경 가능(MYP002). */
 public enum UserStatus {
     /** 재학 중. */
     STUDENT,

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -22,6 +22,7 @@ spring:
     properties:
       hibernate:
         dialect: org.hibernate.dialect.PostgreSQLDialect
+        jdbc.time_zone: UTC
     open-in-view: false
 
   flyway:

--- a/src/test/java/com/groute/groute_server/GrouteServerApplicationTests.java
+++ b/src/test/java/com/groute/groute_server/GrouteServerApplicationTests.java
@@ -6,8 +6,6 @@ import org.springframework.boot.test.context.SpringBootTest;
 @SpringBootTest
 class GrouteServerApplicationTests {
 
-	@Test
-	void contextLoads() {
-	}
-
+    @Test
+    void contextLoads() {}
 }


### PR DESCRIPTION
## 요약
hibernate.jdbc.time_zone UTC 설정

spotless 설정
- ./gradlew build 또는 ./gradlew 
  compileJava → Spotless 적용 안 됨
- ./gradlew spotlessApply → 수동으로
  포맷팅 적용
- ./gradlew spotlessCheck → 포맷팅
  검증만 (수정 안 함)

- googleJavaFormat().aosp(): Google Java
   Format 적용 (4칸 들여쓰기)
- importOrder('java', 'javax',
  'jakarta', 'org', 'com'): import 문 정렬
   순서 지정
- removeUnusedImports(): 미사용 import
  제거
- trimTrailingWhitespace(): 각 줄 끝
  공백 제거
- endWithNewline(): 파일 끝 개행 추가


## 변경 사항
- [ ] 기능
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 문서
- [ ] 테스트
- [x] 기타

## 테스트
- [x] 로컬 테스트 완료
- 테스트 방법:

- hibernate.jdbc.time_zone UTC 설정
-> 로컬 PostgreSQL 연결 및 애플리케이션 정상 실행 확인

- spotless 설정
-> ./gradlew spotlessApply로 적용 확인 완료

## 스크린샷/로그 (선택)
- 필요한 경우 첨부

## 롤백/리스크
- 리스크 포인트:
- 롤백 방법:
UTC 설정: `application.yaml`에서 `jdbc.time_zone: UTC` 줄 제거
Spotless: `build.gradle`에서 spotless 플러그인 및 설정 블록 제거


## 관련 이슈
Closes #33 