### PR TITLE
chore: Redis 컨테이너 추가 및 docker-compose 기반 배포로 전환 (#29)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,4 +73,4 @@ jobs:
 
       - name: docker-compose.yml을 S3에 업로드
         if: github.event_name == 'push'
-        run: aws s3 cp docker-compose.yml s3://glit-images/deploy/docker-compose.yml
+        run: aws s3 cp docker-compose.yml s3://glit-images/deploy/${{ github.sha }}/docker-compose.yml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,3 +70,7 @@ jobs:
           docker build -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG .
           docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
           echo "Pushed → $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG"
+
+      - name: docker-compose.yml을 S3에 업로드
+        if: github.event_name == 'push'
+        run: aws s3 cp docker-compose.yml s3://glit-images/deploy/docker-compose.yml

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -55,12 +55,15 @@ jobs:
             Parameters: {
               commands: [
                 "set -e",
+                "docker compose version >/dev/null 2>&1 || apt-get install -y docker-compose-plugin",
                 ("aws ecr get-login-password --region ap-northeast-2 | docker login --username AWS --password-stdin " + $reg),
+                "mkdir -p /home/ubuntu/groute",
+                ("aws ssm get-parameters-by-path --region ap-northeast-2 --path " + $ssmpath + " --recursive --with-decryption --query 'Parameters[*].[Name,Value]' --output text | awk -F'\\t' '{n=$1; sub(/.*\\//, \"\", n); print n\"=\"$2}' > /tmp/groute.env"),
+                "export REDIS_PASSWORD=$(grep '^REDIS_PASSWORD=' /tmp/groute.env | cut -d= -f2-)",
+                ("printf 'services:\\n  app:\\n    image: %s\\n    ports:\\n      - \"8080:8080\"\\n    env_file:\\n      - /tmp/groute.env\\n    environment:\\n      SPRING_PROFILES_ACTIVE: %s\\n      REDIS_HOST: redis\\n    depends_on:\\n      redis:\\n        condition: service_healthy\\n    restart: unless-stopped\\n  redis:\\n    image: redis:7.2-alpine\\n    command: >-\\n      redis-server --requirepass ${REDIS_PASSWORD} --maxmemory 128mb --maxmemory-policy volatile-lru\\n    healthcheck:\\n      test: [\"CMD\", \"redis-cli\", \"-a\", \"${REDIS_PASSWORD}\", \"ping\"]\\n      interval: 10s\\n      timeout: 5s\\n      retries: 3\\n    restart: unless-stopped\\n' " + $image + " " + $env_val + " > /home/ubuntu/groute/docker-compose.yml"),
                 "docker stop groute-server 2>/dev/null || true",
                 "docker rm   groute-server 2>/dev/null || true",
-                ("docker pull " + $image),
-                ("aws ssm get-parameters-by-path --region ap-northeast-2 --path " + $ssmpath + " --recursive --with-decryption --query 'Parameters[*].[Name,Value]' --output text | awk -F'\\t' '{n=$1; sub(/.*\\//, \"\", n); print n\"=\"$2}' > /tmp/groute.env"),
-                ("docker run -d --name groute-server --restart unless-stopped --env-file /tmp/groute.env -e SPRING_PROFILES_ACTIVE=" + $env_val + " -p 8080:8080 " + $image),
+                "cd /home/ubuntu/groute && docker compose up -d --pull always",
                 "rm -f /tmp/groute.env"
               ]
             },

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -57,13 +57,15 @@ jobs:
                 "set -e",
                 "docker compose version >/dev/null 2>&1 || (apt-get update && apt-get install -y docker-compose-plugin)",
                 ("aws ecr get-login-password --region ap-northeast-2 | docker login --username AWS --password-stdin " + $reg),
-                "mkdir -p /home/ubuntu/groute",
+                "mkdir -p /home/ssm-user/glit",
                 ("aws ssm get-parameters-by-path --region ap-northeast-2 --path " + $ssmpath + " --recursive --with-decryption --query 'Parameters[*].[Name,Value]' --output text | awk -F'\\t' '{n=$1; sub(/.*\\//, \"\", n); print n\"=\"$2}' > /tmp/groute.env"),
+                ("export APP_IMAGE=" + $image),
+                ("export SPRING_PROFILES_ACTIVE=" + $env_val),
                 "export REDIS_PASSWORD=$(grep '^REDIS_PASSWORD=' /tmp/groute.env | cut -d= -f2-)",
-                ("printf 'services:\\n  app:\\n    image: %s\\n    ports:\\n      - \"8080:8080\"\\n    env_file:\\n      - /tmp/groute.env\\n    environment:\\n      SPRING_PROFILES_ACTIVE: %s\\n      REDIS_HOST: redis\\n    depends_on:\\n      redis:\\n        condition: service_healthy\\n    restart: unless-stopped\\n  redis:\\n    image: redis:7.2-alpine\\n    command: >-\\n      redis-server --requirepass ${REDIS_PASSWORD} --maxmemory 128mb --maxmemory-policy volatile-lru\\n    healthcheck:\\n      test: [\"CMD\", \"redis-cli\", \"-a\", \"${REDIS_PASSWORD}\", \"ping\"]\\n      interval: 10s\\n      timeout: 5s\\n      retries: 3\\n    restart: unless-stopped\\n' " + $image + " " + $env_val + " > /home/ubuntu/groute/docker-compose.yml"),
+                "aws s3 cp s3://glit-images/deploy/docker-compose.yml /home/ssm-user/glit/docker-compose.yml",
                 "docker stop groute-server 2>/dev/null || true",
                 "docker rm   groute-server 2>/dev/null || true",
-                "cd /home/ubuntu/groute && docker compose up -d --pull always",
+                "cd /home/ssm-user/glit && docker compose up -d --pull always",
                 "rm -f /tmp/groute.env"
               ]
             },

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -68,7 +68,7 @@ jobs:
                 ("aws s3 cp s3://glit-images/deploy/" + $sha + "/docker-compose.yml /home/ssm-user/glit/docker-compose.yml"),
                 "docker stop groute-server 2>/dev/null || true",
                 "docker rm   groute-server 2>/dev/null || true",
-                "cd /home/ssm-user/glit && docker compose up -d --pull always"
+                "cd /home/ssm-user/glit && docker compose up -d --pull always --wait"
               ]
             },
             TimeoutSeconds: 300

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -58,7 +58,7 @@ jobs:
                 "set -e",
                 "cleanup() { rm -f /tmp/groute.env; }",
                 "trap cleanup EXIT",
-                "docker compose version >/dev/null 2>&1 || (apt-get update && apt-get install -y docker-compose-plugin)",
+                "docker compose version >/dev/null 2>&1 || (apt-get update && apt-get install -y --no-install-recommends docker-compose-plugin)",
                 ("aws ecr get-login-password --region ap-northeast-2 | docker login --username AWS --password-stdin " + $reg),
                 "mkdir -p /home/ssm-user/glit",
                 ("aws ssm get-parameters-by-path --region ap-northeast-2 --path " + $ssmpath + " --recursive --with-decryption --query 'Parameters[*].[Name,Value]' --output text | awk -F'\\t' '{n=$1; sub(/.*\\//, \"\", n); print n\"=\"$2}' > /tmp/groute.env"),

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -65,6 +65,7 @@ jobs:
                 ("export APP_IMAGE=" + $image),
                 ("export SPRING_PROFILES_ACTIVE=" + $env_val),
                 "export REDIS_PASSWORD=$(grep '^REDIS_PASSWORD=' /tmp/groute.env | cut -d= -f2-)",
+                "[ -n \"$REDIS_PASSWORD\" ] || { echo 'REDIS_PASSWORD가 SSM에 없습니다'; exit 1; }",
                 ("aws s3 cp s3://glit-images/deploy/" + $sha + "/docker-compose.yml /home/ssm-user/glit/docker-compose.yml"),
                 "docker stop groute-server 2>/dev/null || true",
                 "docker rm   groute-server 2>/dev/null || true",

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -56,6 +56,8 @@ jobs:
             Parameters: {
               commands: [
                 "set -e",
+                "cleanup() { rm -f /tmp/groute.env; }",
+                "trap cleanup EXIT",
                 "docker compose version >/dev/null 2>&1 || (apt-get update && apt-get install -y docker-compose-plugin)",
                 ("aws ecr get-login-password --region ap-northeast-2 | docker login --username AWS --password-stdin " + $reg),
                 "mkdir -p /home/ssm-user/glit",
@@ -66,8 +68,7 @@ jobs:
                 ("aws s3 cp s3://glit-images/deploy/" + $sha + "/docker-compose.yml /home/ssm-user/glit/docker-compose.yml"),
                 "docker stop groute-server 2>/dev/null || true",
                 "docker rm   groute-server 2>/dev/null || true",
-                "cd /home/ssm-user/glit && docker compose up -d --pull always",
-                "rm -f /tmp/groute.env"
+                "cd /home/ssm-user/glit && docker compose up -d --pull always"
               ]
             },
             TimeoutSeconds: 300

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -31,6 +31,7 @@ jobs:
             echo "SSM_PATH=/groute/prod"                  >> $GITHUB_ENV
           fi
           echo "IMAGE_TAG=sha-${{ github.event.workflow_run.head_sha }}" >> $GITHUB_ENV
+          echo "HEAD_SHA=${{ github.event.workflow_run.head_sha }}"    >> $GITHUB_ENV
 
       - name: Configure AWS credentials (OIDC)
         uses: aws-actions/configure-aws-credentials@v4
@@ -62,7 +63,7 @@ jobs:
                 ("export APP_IMAGE=" + $image),
                 ("export SPRING_PROFILES_ACTIVE=" + $env_val),
                 "export REDIS_PASSWORD=$(grep '^REDIS_PASSWORD=' /tmp/groute.env | cut -d= -f2-)",
-                "aws s3 cp s3://glit-images/deploy/docker-compose.yml /home/ssm-user/glit/docker-compose.yml",
+                ("aws s3 cp s3://glit-images/deploy/" + $sha + "/docker-compose.yml /home/ssm-user/glit/docker-compose.yml"),
                 "docker stop groute-server 2>/dev/null || true",
                 "docker rm   groute-server 2>/dev/null || true",
                 "cd /home/ssm-user/glit && docker compose up -d --pull always",
@@ -78,6 +79,7 @@ jobs:
             --arg reg     "$ECR_REGISTRY" \
             --arg image   "$FULL_IMAGE" \
             --arg ssmpath "$SSM_PATH" \
+            --arg sha     "$HEAD_SHA" \
             -f /tmp/jq-deploy.jq > /tmp/ssm-input.json
 
           COMMAND_ID=$(aws ssm send-command \

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -55,7 +55,7 @@ jobs:
             Parameters: {
               commands: [
                 "set -e",
-                "docker compose version >/dev/null 2>&1 || apt-get install -y docker-compose-plugin",
+                "docker compose version >/dev/null 2>&1 || (apt-get update && apt-get install -y docker-compose-plugin)",
                 ("aws ecr get-login-password --region ap-northeast-2 | docker login --username AWS --password-stdin " + $reg),
                 "mkdir -p /home/ubuntu/groute",
                 ("aws ssm get-parameters-by-path --region ap-northeast-2 --path " + $ssmpath + " --recursive --with-decryption --query 'Parameters[*].[Name,Value]' --output text | awk -F'\\t' '{n=$1; sub(/.*\\//, \"\", n); print n\"=\"$2}' > /tmp/groute.env"),

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM eclipse-temurin:21-jdk-jammy
-RUN apt-get update && apt-get install -y curl && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y --no-install-recommends curl && rm -rf /var/lib/apt/lists/*
 WORKDIR /app
 COPY build/libs/*.jar app.jar
 EXPOSE 8080

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
 FROM eclipse-temurin:21-jdk-jammy
+RUN apt-get update && apt-get install -y curl && rm -rf /var/lib/apt/lists/*
 WORKDIR /app
 COPY build/libs/*.jar app.jar
 EXPOSE 8080

--- a/build.gradle
+++ b/build.gradle
@@ -25,6 +25,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
+	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
 	implementation 'org.flywaydb:flyway-core'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,30 @@
+# 참고용 파일입니다. 실제 배포 시에는 deploy.yml의 SSM 명령어에서 동적으로 생성됩니다.
+# APP_IMAGE, SPRING_PROFILES_ACTIVE, REDIS_PASSWORD는 배포 시 주입됩니다.
+services:
+  app:
+    image: ${APP_IMAGE}
+    ports:
+      - "8080:8080"
+    env_file:
+      - /tmp/groute.env
+    environment:
+      SPRING_PROFILES_ACTIVE: ${SPRING_PROFILES_ACTIVE}
+      REDIS_HOST: redis
+    depends_on:
+      redis:
+        condition: service_healthy
+    restart: unless-stopped
+
+  redis:
+    image: redis:7.2-alpine
+    command: >-
+      redis-server
+      --requirepass ${REDIS_PASSWORD}
+      --maxmemory 256mb
+      --maxmemory-policy allkeys-lru
+    healthcheck:
+      test: ["CMD", "redis-cli", "-a", "${REDIS_PASSWORD}", "ping"]
+      interval: 10s
+      timeout: 5s
+      retries: 3
+    restart: unless-stopped

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-# 참고용 파일입니다. 실제 배포 시에는 deploy.yml의 SSM 명령어에서 동적으로 생성됩니다.
-# APP_IMAGE, SPRING_PROFILES_ACTIVE, REDIS_PASSWORD는 배포 시 주입됩니다.
 services:
   app:
     image: ${APP_IMAGE}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,8 +20,10 @@ services:
       --requirepass ${REDIS_PASSWORD}
       --maxmemory 128mb
       --maxmemory-policy volatile-lru
+    environment:
+      REDIS_PASSWORD: ${REDIS_PASSWORD}
     healthcheck:
-      test: ["CMD", "redis-cli", "-a", "${REDIS_PASSWORD}", "ping"]
+      test: ["CMD", "sh", "-c", "REDISCLI_AUTH=$$REDIS_PASSWORD redis-cli ping"]
       interval: 10s
       timeout: 5s
       retries: 3

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,8 +20,8 @@ services:
     command: >-
       redis-server
       --requirepass ${REDIS_PASSWORD}
-      --maxmemory 256mb
-      --maxmemory-policy allkeys-lru
+      --maxmemory 128mb
+      --maxmemory-policy volatile-lru
     healthcheck:
       test: ["CMD", "redis-cli", "-a", "${REDIS_PASSWORD}", "ping"]
       interval: 10s

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,6 +11,12 @@ services:
     depends_on:
       redis:
         condition: service_healthy
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8080/actuator/health"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 30s
     restart: unless-stopped
 
   redis:

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -73,6 +73,12 @@ spring:
             user-info-uri: https://openapi.naver.com/v1/nid/me
             user-name-attribute: response
 
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health
+
 server:
   port: 8080
 

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -6,6 +6,12 @@ spring:
   jackson:
     time-zone: UTC
 
+  data:
+    redis:
+      host: ${REDIS_HOST:localhost}
+      port: 6379
+      password: ${REDIS_PASSWORD:}
+
   datasource:
     url: ${SPRING_DATASOURCE_URL:jdbc:postgresql://localhost:5432/groute_local}
     username: ${SPRING_DATASOURCE_USERNAME:postgres}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -9,7 +9,7 @@ spring:
   data:
     redis:
       host: ${REDIS_HOST:localhost}
-      port: 6379
+      port: ${REDIS_PORT:6379}
       password: ${REDIS_PASSWORD:}
 
   datasource:


### PR DESCRIPTION
## 요약
- docker run 단일 컨테이너 배포에서 docker compose 기반 배포로 전환하고, Redis 컨테이너를 함께 실행

## 변경 사항
- [ ] 기능
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 문서
- [ ] 테스트
- [x] 기타

**ci.yml**
- ECR 이미지 푸시 후 docker-compose.yml을 S3(`glit-images/deploy/`)에 업로드하는 스텝 추가

**deploy.yml**
- 기존: `docker pull` + `docker run` 단일 앱 컨테이너 실행
- 변경: EC2가 S3에서 docker-compose.yml을 다운로드 후 `docker compose up`으로 앱 + Redis 함께 실행
- docker compose plugin 미설치 시 자동 설치 처리 추가
- compose 변수 치환을 위한 `APP_IMAGE`, `SPRING_PROFILES_ACTIVE`, `REDIS_PASSWORD` export 추가

**docker-compose.yml**
- 앱 서비스 + Redis 7.2 서비스 구성
- Redis: `--maxmemory 128mb`, `--maxmemory-policy volatile-lru`, healthcheck 설정
- 앱이 Redis healthcheck 통과 후 시작되도록 `depends_on` 설정

## 테스트
- [ ] 로컬 테스트 완료
- 테스트 방법:
    - dev 머지 후 GitHub Actions Deploy 워크플로우 결과 및 EC2 `docker compose ps` 확인

## 롤백/리스크
- 리스크 포인트: 첫 배포 시 기존 `groute-server` 컨테이너(docker run 방식)를 stop/rm 후 docker compose로 교체됨
- 롤백 방법: 이전 커밋으로 revert 후 재배포

## 관련 이슈
Closes #29 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Redis 캐시 통합으로 데이터 접근 성능 및 응답 속도 향상
  * Docker Compose 기반 멀티서비스 배포 구성 추가 및 서비스 헬스체크 도입

* **Chores**
  * CI/CD 워크플로우 개선: 배포 절차 강화 및 배포 아티팩트 자동 업로드
  * 배포 환경 보완: 필수 유틸리티 설치 등으로 런타임 신뢰성 향상
<!-- end of auto-generated comment: release notes by coderabbit.ai -->