### PR TITLE
fix: application.yaml의 spring.data 중복 키 제거로 부팅 실패 해소 (#43)

### DIFF
--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -22,12 +22,6 @@ spring:
       minimum-idle: 5
       connection-timeout: 30000
 
-  data:
-    redis:
-      host: ${SPRING_DATA_REDIS_HOST:localhost}
-      port: ${SPRING_DATA_REDIS_PORT:6379}
-      password: ${SPRING_DATA_REDIS_PASSWORD:}
-
   jpa:
     hibernate:
       ddl-auto: none


### PR DESCRIPTION
## 요약
- `application.yaml` 의 `spring.data` 중복 키를 제거해 dev 부팅 실패(재시작 루프)를 해소

## 변경 사항
- [ ] 기능
- [x] 버그 수정
- [ ] 리팩토링
- [ ] 문서
- [ ] 테스트
- [ ] 기타

## 테스트
- [x] 로컬 테스트 완료
- 테스트 방법:
    - `python3 -c "import yaml; list(yaml.safe_load_all(open('src/main/resources/application.yaml')))"` → 중복 키 에러 없이 파싱 성공
    - `./gradlew bootRun --args='--spring.profiles.active=local'` → 정상 부팅 확인
    - `./gradlew spotlessCheck` 통과

## 스크린샷/로그 (선택)
수정 전 (dev 배포 시):
```
ERROR org.springframework.boot.SpringApplication -- Application run failed
while constructing a mapping
 in 'reader', line 3, column 3:
      application:
      ^
found duplicate key data
 in 'reader', line 25, column 3:
      data:
      ^
```
→ 수정 후 해당 에러 미발생, 애플리케이션 정상 부팅

## 롤백/리스크
- 리스크 포인트:
    - 제거한 블록은 `SPRING_DATA_REDIS_*` 환경변수를 참조하던 중복 설정이며, Spring Boot relaxed binding 이 `SPRING_DATA_REDIS_HOST` → `spring.data.redis.host` 로 자동 매핑하므로 동일 환경변수가 설정된 배포 환경에서도 기능 손실 없음
    - 남은 블록은 `REDIS_*` 환경변수를 사용하는 기존 설정이라 로컬 기본값(`localhost:6379`) 동작도 동일
- 롤백 방법:
    - 이 PR 의 머지 커밋을 `git revert <merge-sha>` 로 되돌린 뒤 dev 재배포
    - 단, 롤백 시 부팅 실패 상태로 다시 돌아가므로 **원인 커밋(`033f889`) 이전 상태로 추가 조치 필요**

## 관련 이슈
Closes #43 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Chores**
  * 애플리케이션 구성 파일에서 Redis 관련 설정 항목 제거 (호스트, 포트, 암호 설정)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->