### PR TITLE
chore: master 머지 시 dev 자동 동기화 워크플로우 추가 (#46)

### DIFF
--- a/.github/workflows/sync-dev-with-master.yml
+++ b/.github/workflows/sync-dev-with-master.yml
@@ -1,0 +1,25 @@
+name: Sync dev with master
+
+on:
+  push:
+    branches: [master]
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Force-update dev ref to master tip
+        uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.git.updateRef({
+              owner: context.repo.owner,
+              repo:  context.repo.repo,
+              ref:   'heads/dev',
+              sha:   context.sha,
+              force: true,
+            });


### PR DESCRIPTION
## 요약
- master에 새 커밋이 들어올 때 `heads/dev` ref를 master tip으로 자동 force-update하여, rebase-merge로 발생하는 dev/master divergence(SHA 재작성으로 인한 ahead/behind)를 제거합니다.

## 변경 사항
- [ ] 기능
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 문서
- [ ] 테스트
- [x] 기타 (CI/CD 워크플로우 추가)

## 테스트
- [x] 로컬 테스트 완료
- 테스트 방법:
    - 워크플로우 YAML 문법 검증 (에디터/`actionlint`)
    - 실동작 검증은 dev 머지 후 dev → master PR 머지 시점에 Actions 탭에서 "Sync dev with master" 런 성공 확인 예정
    - 또는 master 머지 후 Actions → Run workflow(workflow_dispatch)로 수동 트리거 → `git fetch origin && git log origin/master..origin/dev` 빈 출력이면 성공

### 커버리지 (JaCoCo)
- 라인 커버리지: N/A (Java 소스 변경 없음, 워크플로우 YAML만 추가)
- [ ] `./gradlew test` 실행 후 `build/reports/jacoco/index.html`에서 수치 확인
- (선택) 리포트 스크린샷 또는 60% 미달/특이사항 공유: 해당 없음

## 스크린샷/로그 (선택)
- 해당 없음 (실동작 검증은 master 머지 이후 가능)

## 롤백/리스크
- 리스크 포인트:
    - master에 push가 일어나면 **dev가 force-update**되어 dev 기반 feature 브랜치는 `git rebase origin/dev` 재정렬 필요
    - 현재 dev/master branch protection 없음 → 기본 `GITHUB_TOKEN`으로 동작, 추후 protection 추가 시 PAT/App token 전환 필요
    - `on: push: branches: [master]` 트리거라, 어떤 경로로든 master가 변경되면 dev도 따라감 (의도된 동작)
- 롤백 방법:
    - `.github/workflows/sync-dev-with-master.yml` 파일 삭제 PR로 비활성화
    - 즉시 차단이 필요하면 Actions 탭 → "Sync dev with master" → Disable workflow

## 관련 이슈
Closes #46 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Chores**
  * 마스터 브랜치 업데이트 시 개발 브랜치를 자동으로 동기화하는 자동화 워크플로우가 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->