### PR TITLE
chore: master 머지 시 dev 자동 동기화 워크플로우 추가 (#46)

### DIFF
--- a/.github/workflows/sync-dev-with-master.yml
+++ b/.github/workflows/sync-dev-with-master.yml
@@ -1,0 +1,25 @@
+name: Sync dev with master
+
+on:
+  push:
+    branches: [master]
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Force-update dev ref to master tip
+        uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.git.updateRef({
+              owner: context.repo.owner,
+              repo:  context.repo.repo,
+              ref:   'heads/dev',
+              sha:   context.sha,
+              force: true,
+            });


### PR DESCRIPTION
## 요약
- dev(#GRT-65 머지분)를 master로 승격. 본 PR이 master에 들어가는 순간 "Sync dev with master" 워크플로우가 활성화되어, 이후 master 변경 시마다 dev가 자동으로 master tip으로 정렬됩니다.

## 변경 사항
- [ ] 기능
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 문서
- [ ] 테스트
- [x] 기타 (CI/CD 워크플로우 활성화)

## 테스트
- [x] 로컬 테스트 완료
- 테스트 방법:
    - 본 PR 머지 직후 Actions 탭 → "Sync dev with master" 런 성공 여부 확인
    - `git fetch origin && git log origin/master..origin/dev` 빈 출력이면 성공
    - 수동 재검증: Actions → Run workflow(workflow_dispatch)

### 커버리지 (JaCoCo)
- 라인 커버리지: N/A (Java 소스 변경 없음, 워크플로우 YAML만 추가)
- [ ] `./gradlew test` 실행 후 `build/reports/jacoco/index.html`에서 수치 확인
- (선택) 리포트 스크린샷 또는 60% 미달/특이사항 공유: 해당 없음

## 스크린샷/로그 (선택)
- 머지 후 Actions 런 결과로 대체 예정

## 롤백/리스크
- 리스크 포인트:
    - 머지 직후부터 **master push → dev force-update**가 상시 동작. dev 기반 feature 브랜치 사용자는 `git rebase origin/dev` 루틴 필요 (팀 공지 완료 가정)
    - 현재 dev/master branch protection 없음 → 기본 `GITHUB_TOKEN`으로 동작. 추후 protection 추가 시 PAT/App token 전환 필요
- 롤백 방법:
    - `.github/workflows/sync-dev-with-master.yml` 삭제 PR
    - 즉시 차단: Actions 탭 → "Sync dev with master" → Disable workflow

## 관련 이슈
Closes #46

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Chores**
  * 코드 리포지토리의 개발 브랜치와 메인 브랜치 간 자동 동기화 워크플로우가 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->