### PR TITLE
fix: swagger 서버 url 이전 도메인에서 최신 도메인으로 변경 (#49)

### DIFF
--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -157,7 +157,7 @@ spring:
 
 app:
   swagger:
-    server-url: https://stg.api.glit.today
+    server-url: https://stg-api.glit.today
     server-description: Staging
 
 discord:


### PR DESCRIPTION
## 요약
- stg 프로파일의 Swagger `server-url` 이 구 도메인(`stg.api.glit.today`)을 가리키던 문제를 신규 도메인(`stg-api.glit.today`)으로 교체

## 변경 사항
- [ ] 기능
- [x] 버그 수정
- [ ] 리팩토링
- [ ] 문서
- [ ] 테스트
- [ ] 기타

## 테스트
- 로컬 테스트 미진행
- 테스트 방법:
    - 배포 후 `https://stg-api.glit.today/swagger-ui.html` 에서 "Try it out" → Execute 시 신규 도메인으로 요청이 나가는지 네트워크 탭으로 확인

### 커버리지 (JaCoCo)
- 라인 커버리지: __%  (기준: 60% 이상)
- [ ] `./gradlew test` 실행 후 `build/reports/jacoco/index.html`에서 수치 확인
- (선택) 리포트 스크린샷 또는 60% 미달/특이사항 공유:
    - 설정값(YAML) 1줄 변경이라 커버리지 영향 없음

## 스크린샷/로그 (선택)
```diff
# src/main/resources/application.yaml (stg 프로파일)
 app:
   swagger:
-    server-url: https://stg.api.glit.today
+    server-url: https://stg-api.glit.today
     server-description: Staging
```

## 롤백/리스크
- 리스크 포인트:
    - 운영(prod) 프로파일은 변경하지 않았으며 `api.glit.today` 그대로 유지
    - Swagger `server-url` 외 다른 곳에서 구 도메인을 하드코딩한 부분 없음 (전체 grep으로 확인 완료)
- 롤백 방법:
    - 해당 커밋 revert 또는 `server-url` 한 줄을 이전 도메인으로 되돌리면 끝 (재시작만 필요)

## 관련 이슈
Closes #49 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Chores**
  * 스테이징 환경의 Swagger API 서버 URL 구성이 업데이트되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->