### PR TITLE
chore: 스테이징 도메인 수정 반영 master ↔ dev 재싱크

### DIFF
--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -157,7 +157,7 @@ spring:
 
 app:
   swagger:
-    server-url: https://stg.api.glit.today
+    server-url: https://stg-api.glit.today
     server-description: Staging
 
 discord:


### PR DESCRIPTION
## 요약
- dev 브랜치에 머지된 stg Swagger `server-url` 도메인 수정(#49 / PR #50)을 master 로 반영하는 재싱크 PR

## 변경 사항
- [ ] 기능
- [x] 버그 수정
- [ ] 리팩토링
- [ ] 문서
- [ ] 테스트
- [ ] 기타

## 테스트
- [x] 로컬 테스트 완료
- 테스트 방법:
    - `./gradlew test`
    - dev 브랜치에서 이미 검증된 단건 설정 변경(application.yaml 1줄)만 포함되어, 추가 테스트는 불필요

### 커버리지 (JaCoCo)
- 라인 커버리지: __%  (기준: 60% 이상)
- [ ] `./gradlew test` 실행 후 `build/reports/jacoco/index.html`에서 수치 확인
- (선택) 리포트 스크린샷 또는 60% 미달/특이사항 공유:
    - YAML 설정값 1줄 변경 → 커버리지 영향 없음

## 스크린샷/로그 (선택)
```diff
# src/main/resources/application.yaml (stg 프로파일)
 app:
   swagger:
-    server-url: https://stg.api.glit.today
+    server-url: https://stg-api.glit.today
     server-description: Staging
```

## 롤백/리스크
- 리스크 포인트:
    - master ↔ dev 단순 동기화 PR로, 실제 코드 변경은 PR #50 에서 이미 리뷰·머지 완료된 1줄뿐
    - stg 프로파일만 영향, prod(`api.glit.today`) 는 변경 없음
- 롤백 방법:
    - 해당 머지 커밋 revert 또는 `server-url` 한 줄을 구 도메인으로 되돌리고 재배포

## 관련 이슈
Closes #49 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 버그 수정

* 스테이징 환경의 Swagger API 서버 주소 형식이 수정되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->