### PR TITLE
 chore: .coderabbit.yaml Controller RequestMapping 패턴을 /api/<resource>로 수정

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -142,7 +142,7 @@ reviews:
         - 클래스: `@Tag(name, description)` 필수. 엔드포인트: `@Operation(summary, description)` 필수, 주요 응답은 `@ApiResponse`.
         - 인증 불필요 엔드포인트만 `@SecurityRequirement(name = "")`. 로그인 이후 엔드포인트에 빈 SecurityRequirement가 붙으면 지적.
         - 컨트롤러 리턴 타입은 일관되게 `ApiResponse<T>` 사용(또는 `ResponseEntity<ApiResponse<T>>`). 혼용되면 일관성 지적.
-        - `@RequestMapping` 루트는 `/api/v{n}/<resource>` 패턴. 케밥/스네이크 혼용 금지.
+        - `@RequestMapping` 루트는 `/api/<resource>` 패턴. 케밥/스네이크 혼용 금지.
         - `@Valid`·`@Validated` 누락된 Request DTO 파라미터 지적.
 
     - path: "src/main/java/com/groute/groute_server/{record,report}/adapter/in/web/**/*.java"


### PR DESCRIPTION
## 요약
- `.coderabbit.yaml` Controller path_instructions의 `@RequestMapping` 루트 패턴을 `/api/v{n}/<resource>`에서 `/api/<resource>`로 수정

## 변경 사항
- [ ] 기능
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 문서
- [ ] 테스트
- [x] 기타

## 테스트
- 해당 없음.

### 커버리지 (JaCoCo)
- 해당 없음.

## 스크린샷/로그 (선택)
- 없음.

## 롤백/리스크
- 리스크 포인트: 없음.
- 롤백 방법: 해당 라인을 `/api/v{n}/<resource>`로 되돌리기

## 관련 이슈
Closes #56 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Chores**
  * API 엔드포인트 URL 패턴 검증 규칙을 업데이트했습니다. 이제 `/api/<resource>` 형식을 지원하며, 기존의 버전 관련 검증 기준이 변경되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->