### PR TITLE
test: auth 도메인 서비스 계층 단위 테스트 추가 (#53)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -66,8 +66,6 @@ def jacocoExcludes = [
 	'**/webhook/**',
 	'**/resolver/**',
 	'**/jwt/**',
-	// TODO(#53): auth 도메인 단위 테스트 추가 후 제외 해제
-	'**/auth/**',
 ]
 
 tasks.named('test') {

--- a/src/test/java/com/groute/groute_server/auth/service/AuthServiceTest.java
+++ b/src/test/java/com/groute/groute_server/auth/service/AuthServiceTest.java
@@ -1,0 +1,133 @@
+package com.groute.groute_server.auth.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.groute.groute_server.auth.dto.TokenResponse;
+import com.groute.groute_server.auth.repository.RefreshTokenRepository;
+import com.groute.groute_server.common.exception.BusinessException;
+import com.groute.groute_server.common.exception.ErrorCode;
+import com.groute.groute_server.common.jwt.JwtTokenProvider;
+import com.groute.groute_server.common.jwt.JwtValidationResult;
+import com.groute.groute_server.common.jwt.TokenType;
+
+@ExtendWith(MockitoExtension.class)
+class AuthServiceTest {
+
+    @Mock JwtTokenProvider jwtTokenProvider;
+    @Mock RefreshTokenRepository refreshTokenRepository;
+
+    @InjectMocks AuthService authService;
+
+    @Nested
+    @DisplayName("재발급")
+    class Reissue {
+
+        @Test
+        @DisplayName("토큰이 null일 때 REFRESH_TOKEN_REQUIRED를 던진다")
+        void should_throwRefreshTokenRequired_when_tokenIsNull() {
+            // when & then
+            assertThatThrownBy(() -> authService.reissue(null))
+                    .isInstanceOf(BusinessException.class)
+                    .extracting("errorCode")
+                    .isEqualTo(ErrorCode.REFRESH_TOKEN_REQUIRED);
+        }
+
+        @Test
+        @DisplayName("토큰이 공백 문자열일 때 REFRESH_TOKEN_REQUIRED를 던진다")
+        void should_throwRefreshTokenRequired_when_tokenIsBlank() {
+            // when & then
+            assertThatThrownBy(() -> authService.reissue("   "))
+                    .isInstanceOf(BusinessException.class)
+                    .extracting("errorCode")
+                    .isEqualTo(ErrorCode.REFRESH_TOKEN_REQUIRED);
+        }
+
+        @Test
+        @DisplayName("validate 결과가 VALID가 아닐 때 INVALID_REFRESH_TOKEN을 던진다")
+        void should_throwInvalidRefreshToken_when_validateFails() {
+            // given
+            String expired = "expired-token";
+            given(jwtTokenProvider.validate(expired)).willReturn(JwtValidationResult.EXPIRED);
+
+            // when & then
+            assertThatThrownBy(() -> authService.reissue(expired))
+                    .isInstanceOf(BusinessException.class)
+                    .extracting("errorCode")
+                    .isEqualTo(ErrorCode.INVALID_REFRESH_TOKEN);
+        }
+
+        @Test
+        @DisplayName("토큰 타입이 REFRESH가 아닐 때 INVALID_REFRESH_TOKEN을 던진다")
+        void should_throwInvalidRefreshToken_when_tokenTypeIsNotRefresh() {
+            // given
+            String access = "access-token";
+            given(jwtTokenProvider.validate(access)).willReturn(JwtValidationResult.VALID);
+            given(jwtTokenProvider.getTokenType(access)).willReturn(TokenType.ACCESS);
+
+            // when & then
+            assertThatThrownBy(() -> authService.reissue(access))
+                    .isInstanceOf(BusinessException.class)
+                    .extracting("errorCode")
+                    .isEqualTo(ErrorCode.INVALID_REFRESH_TOKEN);
+        }
+
+        @Test
+        @DisplayName("rotate에 성공했을 때 새 토큰 쌍을 반환하고 저장값을 삭제하지 않는다")
+        void should_returnNewTokens_when_rotateSucceeds() {
+            // given
+            String oldRefresh = "old-refresh";
+            String newAccess = "new-access";
+            String newRefresh = "new-refresh";
+            Long userId = 42L;
+            given(jwtTokenProvider.validate(oldRefresh)).willReturn(JwtValidationResult.VALID);
+            given(jwtTokenProvider.getTokenType(oldRefresh)).willReturn(TokenType.REFRESH);
+            given(jwtTokenProvider.getUserId(oldRefresh)).willReturn(userId);
+            given(jwtTokenProvider.createAccessToken(userId)).willReturn(newAccess);
+            given(jwtTokenProvider.createRefreshToken(userId)).willReturn(newRefresh);
+            given(refreshTokenRepository.rotate(userId, oldRefresh, newRefresh)).willReturn(true);
+
+            // when
+            TokenResponse response = authService.reissue(oldRefresh);
+
+            // then
+            assertThat(response.accessToken()).isEqualTo(newAccess);
+            assertThat(response.refreshToken()).isEqualTo(newRefresh);
+            verify(refreshTokenRepository, never()).deleteByUserId(anyLong());
+        }
+
+        @Test
+        @DisplayName("rotate에 실패했을 때 저장값을 삭제하고 INVALID_REFRESH_TOKEN을 던진다")
+        void should_deleteStoredAndThrowInvalidRefreshToken_when_rotateFails() {
+            // given
+            String oldRefresh = "old-refresh";
+            String newRefresh = "new-refresh";
+            Long userId = 42L;
+            given(jwtTokenProvider.validate(oldRefresh)).willReturn(JwtValidationResult.VALID);
+            given(jwtTokenProvider.getTokenType(oldRefresh)).willReturn(TokenType.REFRESH);
+            given(jwtTokenProvider.getUserId(oldRefresh)).willReturn(userId);
+            given(jwtTokenProvider.createAccessToken(userId)).willReturn("new-access");
+            given(jwtTokenProvider.createRefreshToken(userId)).willReturn(newRefresh);
+            given(refreshTokenRepository.rotate(userId, oldRefresh, newRefresh)).willReturn(false);
+
+            // when & then
+            assertThatThrownBy(() -> authService.reissue(oldRefresh))
+                    .isInstanceOf(BusinessException.class)
+                    .extracting("errorCode")
+                    .isEqualTo(ErrorCode.INVALID_REFRESH_TOKEN);
+            verify(refreshTokenRepository).deleteByUserId(userId);
+        }
+    }
+}

--- a/src/test/java/com/groute/groute_server/auth/service/SocialLoginServiceTest.java
+++ b/src/test/java/com/groute/groute_server/auth/service/SocialLoginServiceTest.java
@@ -1,0 +1,111 @@
+package com.groute.groute_server.auth.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+import java.util.Map;
+import java.util.Optional;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InOrder;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import com.groute.groute_server.auth.entity.SocialAccount;
+import com.groute.groute_server.auth.enums.SocialProvider;
+import com.groute.groute_server.auth.repository.SocialAccountRepository;
+import com.groute.groute_server.auth.service.oauth.OAuthAttributes;
+import com.groute.groute_server.user.entity.User;
+import com.groute.groute_server.user.repository.UserRepository;
+
+@ExtendWith(MockitoExtension.class)
+class SocialLoginServiceTest {
+
+    @Mock UserRepository userRepository;
+    @Mock SocialAccountRepository socialAccountRepository;
+
+    @InjectMocks SocialLoginService socialLoginService;
+
+    @Nested
+    @DisplayName("upsertUser")
+    class UpsertUser {
+
+        @Test
+        @DisplayName("기존 소셜 계정이 없을 때 User를 먼저 저장하고 SocialAccount를 이어서 저장한 뒤 User를 반환한다")
+        void should_createUserAndSocialAccount_when_socialAccountNotFound() {
+            // given
+            OAuthAttributes attributes =
+                    OAuthAttributes.from(
+                            "kakao",
+                            Map.of("id", 9999L, "kakao_account", Map.of("email", "new@kakao.com")));
+            given(
+                            socialAccountRepository.findByProviderAndProviderUid(
+                                    SocialProvider.KAKAO, "9999"))
+                    .willReturn(Optional.empty());
+            given(userRepository.save(any(User.class)))
+                    .willAnswer(
+                            invocation -> {
+                                User saved = invocation.getArgument(0);
+                                ReflectionTestUtils.setField(saved, "id", 42L);
+                                return saved;
+                            });
+
+            // when
+            User result = socialLoginService.upsertUser(attributes);
+
+            // then
+            assertThat(result.getId()).isEqualTo(42L);
+            assertThat(result.getLastLoginAt()).isNotNull();
+
+            InOrder inOrder = inOrder(userRepository, socialAccountRepository);
+            inOrder.verify(userRepository).save(any(User.class));
+
+            ArgumentCaptor<SocialAccount> captor = ArgumentCaptor.forClass(SocialAccount.class);
+            inOrder.verify(socialAccountRepository).save(captor.capture());
+            SocialAccount saved = captor.getValue();
+            assertThat(saved.getProvider()).isEqualTo(SocialProvider.KAKAO);
+            assertThat(saved.getProviderUid()).isEqualTo("9999");
+            assertThat(saved.getEmail()).isEqualTo("new@kakao.com");
+            assertThat(saved.getUser()).isSameAs(result);
+        }
+
+        @Test
+        @DisplayName("기존 소셜 계정이 있을 때 email을 갱신하고 recordLogin만 호출하며 새로 저장하지 않는다")
+        void should_updateEmailAndRecordLoginOnly_when_socialAccountExists() {
+            // given
+            User existingUser = User.createForSocialLogin();
+            ReflectionTestUtils.setField(existingUser, "id", 42L);
+            SocialAccount existingAccount =
+                    SocialAccount.create(
+                            existingUser, SocialProvider.KAKAO, "9999", "old@kakao.com");
+            given(
+                            socialAccountRepository.findByProviderAndProviderUid(
+                                    SocialProvider.KAKAO, "9999"))
+                    .willReturn(Optional.of(existingAccount));
+            OAuthAttributes attributes =
+                    OAuthAttributes.from(
+                            "kakao",
+                            Map.of("id", 9999L, "kakao_account", Map.of("email", "new@kakao.com")));
+
+            // when
+            User result = socialLoginService.upsertUser(attributes);
+
+            // then
+            assertThat(result).isSameAs(existingUser);
+            assertThat(result.getLastLoginAt()).isNotNull();
+            assertThat(existingAccount.getEmail()).isEqualTo("new@kakao.com");
+            verify(userRepository, never()).save(any(User.class));
+            verify(socialAccountRepository, never()).save(any(SocialAccount.class));
+        }
+    }
+}

--- a/src/test/java/com/groute/groute_server/auth/service/TokenDeliveryServiceTest.java
+++ b/src/test/java/com/groute/groute_server/auth/service/TokenDeliveryServiceTest.java
@@ -1,0 +1,75 @@
+package com.groute.groute_server.auth.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpHeaders;
+import org.springframework.mock.web.MockHttpServletResponse;
+
+import com.groute.groute_server.auth.config.AuthProperties;
+import com.groute.groute_server.auth.dto.TokenResponse;
+import com.groute.groute_server.common.jwt.JwtProperties;
+
+class TokenDeliveryServiceTest {
+
+    private static final long REFRESH_TTL_MILLIS = 3_600_000L;
+    private static final String ACCESS_TOKEN = "access-token";
+    private static final String REFRESH_TOKEN = "refresh-token";
+
+    private TokenDeliveryService serviceWithCookieEnabled(boolean enabled) {
+        JwtProperties jwtProperties = new JwtProperties("secret", 900_000L, REFRESH_TTL_MILLIS);
+        AuthProperties authProperties =
+                new AuthProperties(new AuthProperties.RefreshToken(enabled));
+        return new TokenDeliveryService(jwtProperties, authProperties);
+    }
+
+    @Nested
+    @DisplayName("deliver")
+    class Deliver {
+
+        @Test
+        @DisplayName("쿠키 모드일 때 Set-Cookie에 refresh를 담고 응답 본문의 refresh는 null로 둔다")
+        void should_setRefreshCookieAndOmitBody_when_cookieEnabled() {
+            // given
+            TokenDeliveryService service = serviceWithCookieEnabled(true);
+            MockHttpServletResponse response = new MockHttpServletResponse();
+
+            // when
+            TokenResponse result = service.deliver(response, ACCESS_TOKEN, REFRESH_TOKEN);
+
+            // then
+            assertThat(result.accessToken()).isEqualTo(ACCESS_TOKEN);
+            assertThat(result.refreshToken()).isNull();
+
+            List<String> cookies = response.getHeaders(HttpHeaders.SET_COOKIE);
+            assertThat(cookies).hasSize(1);
+            assertThat(cookies.get(0))
+                    .contains("refreshToken=" + REFRESH_TOKEN)
+                    .contains("Max-Age=" + (REFRESH_TTL_MILLIS / 1000))
+                    .contains("Path=/")
+                    .contains("HttpOnly")
+                    .contains("Secure")
+                    .contains("SameSite=Strict");
+        }
+
+        @Test
+        @DisplayName("쿠키 모드가 꺼져 있을 때 access·refresh 모두 본문으로 반환하고 Set-Cookie를 설정하지 않는다")
+        void should_returnBothTokensInBody_when_cookieDisabled() {
+            // given
+            TokenDeliveryService service = serviceWithCookieEnabled(false);
+            MockHttpServletResponse response = new MockHttpServletResponse();
+
+            // when
+            TokenResponse result = service.deliver(response, ACCESS_TOKEN, REFRESH_TOKEN);
+
+            // then
+            assertThat(result.accessToken()).isEqualTo(ACCESS_TOKEN);
+            assertThat(result.refreshToken()).isEqualTo(REFRESH_TOKEN);
+            assertThat(response.getHeaders(HttpHeaders.SET_COOKIE)).isEmpty();
+        }
+    }
+}

--- a/src/test/java/com/groute/groute_server/auth/service/oauth/CustomOAuth2UserServiceTest.java
+++ b/src/test/java/com/groute/groute_server/auth/service/oauth/CustomOAuth2UserServiceTest.java
@@ -1,0 +1,113 @@
+package com.groute.groute_server.auth.service.oauth;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+import java.util.Map;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.oauth2.client.registration.ClientRegistration;
+import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import com.groute.groute_server.auth.enums.SocialProvider;
+import com.groute.groute_server.auth.service.SocialLoginService;
+import com.groute.groute_server.common.exception.BusinessException;
+import com.groute.groute_server.common.exception.ErrorCode;
+import com.groute.groute_server.user.entity.User;
+
+@ExtendWith(MockitoExtension.class)
+class CustomOAuth2UserServiceTest {
+
+    @Mock SocialLoginService socialLoginService;
+    @Mock DefaultOAuth2UserService delegate;
+
+    @InjectMocks CustomOAuth2UserService service;
+
+    @BeforeEach
+    void replaceDelegate() {
+        // delegate는 필드 초기화로 new 되므로, 테스트에서는 HTTP I/O를 피하기 위해 mock을 주입한다.
+        ReflectionTestUtils.setField(service, "delegate", delegate);
+    }
+
+    @Nested
+    @DisplayName("loadUser")
+    class LoadUser {
+
+        @Test
+        @DisplayName("정상 응답일 때 OAuthAttributes를 upsert에 위임하고 PrincipalUser를 반환한다")
+        void should_delegateUpsertAndReturnPrincipal_when_responseIsValid() {
+            // given
+            Map<String, Object> rawAttributes =
+                    Map.of("id", 9999L, "kakao_account", Map.of("email", "new@kakao.com"));
+            OAuth2User delegated = mock(OAuth2User.class);
+            given(delegated.getAttributes()).willReturn(rawAttributes);
+            OAuth2UserRequest request = userRequestFor("kakao");
+            given(delegate.loadUser(request)).willReturn(delegated);
+
+            User user = User.createForSocialLogin();
+            ReflectionTestUtils.setField(user, "id", 42L);
+            given(socialLoginService.upsertUser(any(OAuthAttributes.class))).willReturn(user);
+
+            // when
+            OAuth2User result = service.loadUser(request);
+
+            // then
+            assertThat(result).isInstanceOf(PrincipalUser.class);
+            PrincipalUser principal = (PrincipalUser) result;
+            assertThat(principal.getUserId()).isEqualTo(42L);
+            assertThat(principal.getProvider()).isEqualTo(SocialProvider.KAKAO);
+            assertThat(principal.getAttributes()).isEqualTo(rawAttributes);
+
+            ArgumentCaptor<OAuthAttributes> captor = ArgumentCaptor.forClass(OAuthAttributes.class);
+            verify(socialLoginService).upsertUser(captor.capture());
+            OAuthAttributes captured = captor.getValue();
+            assertThat(captured.provider()).isEqualTo(SocialProvider.KAKAO);
+            assertThat(captured.providerUid()).isEqualTo("9999");
+            assertThat(captured.email()).isEqualTo("new@kakao.com");
+        }
+
+        @Test
+        @DisplayName("정규화 중 BusinessException이 발생했을 때 OAuth2AuthenticationException으로 래핑한다")
+        void should_wrapAsOAuth2AuthenticationException_when_normalizationFails() {
+            // given
+            OAuth2User delegated = mock(OAuth2User.class);
+            given(delegated.getAttributes()).willReturn(Map.of());
+            OAuth2UserRequest request = userRequestFor("apple");
+            given(delegate.loadUser(request)).willReturn(delegated);
+
+            // when & then
+            assertThatThrownBy(() -> service.loadUser(request))
+                    .isInstanceOfSatisfying(
+                            OAuth2AuthenticationException.class,
+                            ex -> {
+                                assertThat(ex.getError().getErrorCode())
+                                        .isEqualTo(ErrorCode.UNSUPPORTED_OAUTH_PROVIDER.getCode());
+                                assertThat(ex.getCause()).isInstanceOf(BusinessException.class);
+                            });
+        }
+    }
+
+    private OAuth2UserRequest userRequestFor(String registrationId) {
+        OAuth2UserRequest request = mock(OAuth2UserRequest.class);
+        ClientRegistration registration = mock(ClientRegistration.class);
+        given(request.getClientRegistration()).willReturn(registration);
+        given(registration.getRegistrationId()).willReturn(registrationId);
+        return request;
+    }
+}

--- a/src/test/java/com/groute/groute_server/auth/service/oauth/OAuth2LoginFailureHandlerTest.java
+++ b/src/test/java/com/groute/groute_server/auth/service/oauth/OAuth2LoginFailureHandlerTest.java
@@ -1,0 +1,78 @@
+package com.groute.groute_server.auth.service.oauth;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.security.authentication.BadCredentialsException;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.OAuth2Error;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.groute.groute_server.common.exception.BusinessException;
+import com.groute.groute_server.common.exception.ErrorCode;
+
+class OAuth2LoginFailureHandlerTest {
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+    private final OAuth2LoginFailureHandler handler = new OAuth2LoginFailureHandler(objectMapper);
+
+    @Nested
+    @DisplayName("onAuthenticationFailure")
+    class OnFailure {
+
+        @Test
+        @DisplayName("원인 체인에 BusinessException이 있을 때 해당 ErrorCode로 응답하고 상세 메시지는 마스킹한다")
+        void should_respondWithMaskedErrorResponse_when_businessExceptionInCauseChain()
+                throws Exception {
+            // given
+            BusinessException businessException =
+                    new BusinessException(
+                            ErrorCode.INVALID_OAUTH_RESPONSE,
+                            "providerUid가 비어 있습니다: provider=KAKAO");
+            OAuth2AuthenticationException exception =
+                    new OAuth2AuthenticationException(
+                            new OAuth2Error(ErrorCode.INVALID_OAUTH_RESPONSE.getCode()),
+                            "providerUid=1234 정규화 실패",
+                            businessException);
+            MockHttpServletRequest request = new MockHttpServletRequest();
+            MockHttpServletResponse response = new MockHttpServletResponse();
+
+            // when
+            handler.onAuthenticationFailure(request, response, exception);
+
+            // then
+            assertThat(response.getStatus())
+                    .isEqualTo(ErrorCode.INVALID_OAUTH_RESPONSE.getHttpStatus().value());
+            assertThat(response.getContentType()).startsWith(MediaType.APPLICATION_JSON_VALUE);
+            assertThat(response.getContentAsString())
+                    .contains("\"code\":\"" + ErrorCode.INVALID_OAUTH_RESPONSE.getCode() + "\"")
+                    .contains(
+                            "\"message\":\"" + ErrorCode.INVALID_OAUTH_RESPONSE.getMessage() + "\"")
+                    .doesNotContain("providerUid");
+        }
+
+        @Test
+        @DisplayName("원인 체인에 BusinessException이 없을 때 UNAUTHORIZED 기본 응답을 반환한다")
+        void should_respondWithUnauthorized_when_noBusinessExceptionCause() throws Exception {
+            // given
+            BadCredentialsException exception = new BadCredentialsException("자격 증명 실패");
+            MockHttpServletRequest request = new MockHttpServletRequest();
+            MockHttpServletResponse response = new MockHttpServletResponse();
+
+            // when
+            handler.onAuthenticationFailure(request, response, exception);
+
+            // then
+            assertThat(response.getStatus())
+                    .isEqualTo(ErrorCode.UNAUTHORIZED.getHttpStatus().value());
+            assertThat(response.getContentAsString())
+                    .contains("\"code\":\"" + ErrorCode.UNAUTHORIZED.getCode() + "\"")
+                    .contains("\"message\":\"" + ErrorCode.UNAUTHORIZED.getMessage() + "\"");
+        }
+    }
+}

--- a/src/test/java/com/groute/groute_server/auth/service/oauth/OAuth2LoginSuccessHandlerTest.java
+++ b/src/test/java/com/groute/groute_server/auth/service/oauth/OAuth2LoginSuccessHandlerTest.java
@@ -1,0 +1,90 @@
+package com.groute.groute_server.auth.service.oauth;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+import java.util.Map;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.security.core.Authentication;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.groute.groute_server.auth.dto.TokenResponse;
+import com.groute.groute_server.auth.enums.SocialProvider;
+import com.groute.groute_server.auth.repository.RefreshTokenRepository;
+import com.groute.groute_server.auth.service.TokenDeliveryService;
+import com.groute.groute_server.common.jwt.JwtTokenProvider;
+
+@ExtendWith(MockitoExtension.class)
+class OAuth2LoginSuccessHandlerTest {
+
+    @Mock JwtTokenProvider jwtTokenProvider;
+    @Mock RefreshTokenRepository refreshTokenRepository;
+    @Mock TokenDeliveryService tokenDeliveryService;
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    private OAuth2LoginSuccessHandler handler;
+
+    @BeforeEach
+    void setUp() {
+        handler =
+                new OAuth2LoginSuccessHandler(
+                        jwtTokenProvider,
+                        refreshTokenRepository,
+                        tokenDeliveryService,
+                        objectMapper);
+    }
+
+    @Nested
+    @DisplayName("onAuthenticationSuccess")
+    class OnSuccess {
+
+        @Test
+        @DisplayName("인증 성공일 때 토큰 쌍을 발급·저장하고 deliver 결과를 JSON 본문으로 기록한다")
+        void should_issueTokensAndWriteJson_when_authenticated() throws Exception {
+            // given
+            Long userId = 42L;
+            PrincipalUser principal = new PrincipalUser(userId, SocialProvider.KAKAO, Map.of());
+            Authentication authentication = mock(Authentication.class);
+            given(authentication.getPrincipal()).willReturn(principal);
+
+            String access = "access-token";
+            String refresh = "refresh-token";
+            given(jwtTokenProvider.createAccessToken(userId)).willReturn(access);
+            given(jwtTokenProvider.createRefreshToken(userId)).willReturn(refresh);
+
+            MockHttpServletRequest request = new MockHttpServletRequest();
+            MockHttpServletResponse response = new MockHttpServletResponse();
+            given(tokenDeliveryService.deliver(response, access, refresh))
+                    .willReturn(new TokenResponse(access, null));
+
+            // when
+            handler.onAuthenticationSuccess(request, response, authentication);
+
+            // then
+            verify(refreshTokenRepository).save(userId, refresh);
+            verify(tokenDeliveryService).deliver(response, access, refresh);
+
+            assertThat(response.getStatus()).isEqualTo(HttpStatus.OK.value());
+            assertThat(response.getContentType()).startsWith(MediaType.APPLICATION_JSON_VALUE);
+            assertThat(response.getCharacterEncoding()).isEqualToIgnoringCase("UTF-8");
+            assertThat(response.getContentAsString())
+                    .contains("\"success\":true")
+                    .contains("\"accessToken\":\"" + access + "\"")
+                    .doesNotContain("\"refreshToken\"");
+        }
+    }
+}

--- a/src/test/java/com/groute/groute_server/auth/service/oauth/OAuthAttributesTest.java
+++ b/src/test/java/com/groute/groute_server/auth/service/oauth/OAuthAttributesTest.java
@@ -20,13 +20,16 @@ class OAuthAttributesTest {
     class Kakao {
 
         @Test
-        @DisplayName("정상 응답을 (KAKAO, providerUid, email)로 정규화한다")
-        void parsesNormalResponse() {
+        @DisplayName("정상 응답일 때 (KAKAO, providerUid, email)로 정규화한다")
+        void should_normalize_when_kakaoResponseIsValid() {
+            // given
             Map<String, Object> attributes =
                     Map.of("id", 1234567890L, "kakao_account", Map.of("email", "user@kakao.com"));
 
+            // when
             OAuthAttributes result = OAuthAttributes.from("kakao", attributes);
 
+            // then
             assertThat(result.provider()).isEqualTo(SocialProvider.KAKAO);
             assertThat(result.providerUid()).isEqualTo("1234567890");
             assertThat(result.email()).isEqualTo("user@kakao.com");
@@ -34,23 +37,28 @@ class OAuthAttributesTest {
         }
 
         @Test
-        @DisplayName("kakao_account가 없어도 email을 null로 정상 파싱한다")
-        void parsesWhenKakaoAccountMissing() {
+        @DisplayName("kakao_account가 없을 때 email을 null로 정규화한다")
+        void should_normalizeWithNullEmail_when_kakaoAccountMissing() {
+            // given
             Map<String, Object> attributes = Map.of("id", 42L);
 
+            // when
             OAuthAttributes result = OAuthAttributes.from("kakao", attributes);
 
+            // then
             assertThat(result.provider()).isEqualTo(SocialProvider.KAKAO);
             assertThat(result.providerUid()).isEqualTo("42");
             assertThat(result.email()).isNull();
         }
 
         @Test
-        @DisplayName("id가 누락되면 INVALID_OAUTH_RESPONSE")
-        void throwsWhenIdMissing() {
+        @DisplayName("id가 누락됐을 때 INVALID_OAUTH_RESPONSE를 던진다")
+        void should_throwInvalidOAuthResponse_when_kakaoIdMissing() {
+            // given
             Map<String, Object> attributes =
                     Map.of("kakao_account", Map.of("email", "user@kakao.com"));
 
+            // when & then
             assertThatThrownBy(() -> OAuthAttributes.from("kakao", attributes))
                     .isInstanceOf(BusinessException.class)
                     .extracting("errorCode")
@@ -63,15 +71,16 @@ class OAuthAttributesTest {
     class Google {
 
         @Test
-        @DisplayName("정상 응답을 (GOOGLE, providerUid, email)로 정규화한다")
-        void parsesNormalResponse() {
+        @DisplayName("정상 응답일 때 (GOOGLE, providerUid, email)로 정규화한다")
+        void should_normalize_when_googleResponseIsValid() {
+            // given
             Map<String, Object> attributes =
-                    Map.of(
-                            "sub", "google-sub-001",
-                            "email", "user@gmail.com");
+                    Map.of("sub", "google-sub-001", "email", "user@gmail.com");
 
+            // when
             OAuthAttributes result = OAuthAttributes.from("google", attributes);
 
+            // then
             assertThat(result.provider()).isEqualTo(SocialProvider.GOOGLE);
             assertThat(result.providerUid()).isEqualTo("google-sub-001");
             assertThat(result.email()).isEqualTo("user@gmail.com");
@@ -79,10 +88,12 @@ class OAuthAttributesTest {
         }
 
         @Test
-        @DisplayName("sub가 누락되면 INVALID_OAUTH_RESPONSE")
-        void throwsWhenSubMissing() {
+        @DisplayName("sub가 누락됐을 때 INVALID_OAUTH_RESPONSE를 던진다")
+        void should_throwInvalidOAuthResponse_when_googleSubMissing() {
+            // given
             Map<String, Object> attributes = Map.of("email", "user@gmail.com");
 
+            // when & then
             assertThatThrownBy(() -> OAuthAttributes.from("google", attributes))
                     .isInstanceOf(BusinessException.class)
                     .extracting("errorCode")
@@ -95,17 +106,16 @@ class OAuthAttributesTest {
     class Naver {
 
         @Test
-        @DisplayName("response 하위 값을 (NAVER, providerUid, email)로 정규화한다")
-        void parsesNormalResponse() {
+        @DisplayName("정상 응답일 때 response 하위 값을 (NAVER, providerUid, email)로 정규화한다")
+        void should_normalize_when_naverResponseIsValid() {
+            // given
             Map<String, Object> attributes =
-                    Map.of(
-                            "response",
-                            Map.of(
-                                    "id", "naver-id-001",
-                                    "email", "user@naver.com"));
+                    Map.of("response", Map.of("id", "naver-id-001", "email", "user@naver.com"));
 
+            // when
             OAuthAttributes result = OAuthAttributes.from("naver", attributes);
 
+            // then
             assertThat(result.provider()).isEqualTo(SocialProvider.NAVER);
             assertThat(result.providerUid()).isEqualTo("naver-id-001");
             assertThat(result.email()).isEqualTo("user@naver.com");
@@ -113,10 +123,12 @@ class OAuthAttributesTest {
         }
 
         @Test
-        @DisplayName("response 루트가 없으면 INVALID_OAUTH_RESPONSE")
-        void throwsWhenResponseMissing() {
+        @DisplayName("response 루트가 없을 때 INVALID_OAUTH_RESPONSE를 던진다")
+        void should_throwInvalidOAuthResponse_when_naverResponseMissing() {
+            // given
             Map<String, Object> attributes = Map.of("id", "naver-id-001");
 
+            // when & then
             assertThatThrownBy(() -> OAuthAttributes.from("naver", attributes))
                     .isInstanceOf(BusinessException.class)
                     .extracting("errorCode")
@@ -124,10 +136,12 @@ class OAuthAttributesTest {
         }
 
         @Test
-        @DisplayName("response.id가 누락되면 INVALID_OAUTH_RESPONSE")
-        void throwsWhenIdMissing() {
+        @DisplayName("response.id가 누락됐을 때 INVALID_OAUTH_RESPONSE를 던진다")
+        void should_throwInvalidOAuthResponse_when_naverIdMissing() {
+            // given
             Map<String, Object> attributes = Map.of("response", Map.of("email", "user@naver.com"));
 
+            // when & then
             assertThatThrownBy(() -> OAuthAttributes.from("naver", attributes))
                     .isInstanceOf(BusinessException.class)
                     .extracting("errorCode")
@@ -140,21 +154,23 @@ class OAuthAttributesTest {
     class Registration {
 
         @Test
-        @DisplayName("대소문자가 섞여 있어도 provider를 매칭한다")
-        void matchesCaseInsensitively() {
+        @DisplayName("registrationId 대소문자가 섞여 있을 때 동일 provider로 매칭한다")
+        void should_matchProvider_when_registrationIdCaseMixed() {
+            // given
             Map<String, Object> attributes =
-                    Map.of(
-                            "sub", "google-sub-001",
-                            "email", "user@gmail.com");
+                    Map.of("sub", "google-sub-001", "email", "user@gmail.com");
 
+            // when
             OAuthAttributes result = OAuthAttributes.from("GOOGLE", attributes);
 
+            // then
             assertThat(result.provider()).isEqualTo(SocialProvider.GOOGLE);
         }
 
         @Test
-        @DisplayName("미지원 registrationId면 UNSUPPORTED_OAUTH_PROVIDER")
-        void throwsOnUnsupportedProvider() {
+        @DisplayName("미지원 registrationId일 때 UNSUPPORTED_OAUTH_PROVIDER를 던진다")
+        void should_throwUnsupportedProvider_when_registrationIdNotSupported() {
+            // when & then
             assertThatThrownBy(() -> OAuthAttributes.from("apple", Map.of()))
                     .isInstanceOf(BusinessException.class)
                     .extracting("errorCode")

--- a/src/test/java/com/groute/groute_server/auth/service/oauth/OAuthAttributesTest.java
+++ b/src/test/java/com/groute/groute_server/auth/service/oauth/OAuthAttributesTest.java
@@ -1,0 +1,164 @@
+package com.groute.groute_server.auth.service.oauth;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.Map;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import com.groute.groute_server.auth.enums.SocialProvider;
+import com.groute.groute_server.common.exception.BusinessException;
+import com.groute.groute_server.common.exception.ErrorCode;
+
+class OAuthAttributesTest {
+
+    @Nested
+    @DisplayName("카카오")
+    class Kakao {
+
+        @Test
+        @DisplayName("정상 응답을 (KAKAO, providerUid, email)로 정규화한다")
+        void parsesNormalResponse() {
+            Map<String, Object> attributes =
+                    Map.of("id", 1234567890L, "kakao_account", Map.of("email", "user@kakao.com"));
+
+            OAuthAttributes result = OAuthAttributes.from("kakao", attributes);
+
+            assertThat(result.provider()).isEqualTo(SocialProvider.KAKAO);
+            assertThat(result.providerUid()).isEqualTo("1234567890");
+            assertThat(result.email()).isEqualTo("user@kakao.com");
+            assertThat(result.attributes()).isEqualTo(attributes);
+        }
+
+        @Test
+        @DisplayName("kakao_account가 없어도 email을 null로 정상 파싱한다")
+        void parsesWhenKakaoAccountMissing() {
+            Map<String, Object> attributes = Map.of("id", 42L);
+
+            OAuthAttributes result = OAuthAttributes.from("kakao", attributes);
+
+            assertThat(result.provider()).isEqualTo(SocialProvider.KAKAO);
+            assertThat(result.providerUid()).isEqualTo("42");
+            assertThat(result.email()).isNull();
+        }
+
+        @Test
+        @DisplayName("id가 누락되면 INVALID_OAUTH_RESPONSE")
+        void throwsWhenIdMissing() {
+            Map<String, Object> attributes =
+                    Map.of("kakao_account", Map.of("email", "user@kakao.com"));
+
+            assertThatThrownBy(() -> OAuthAttributes.from("kakao", attributes))
+                    .isInstanceOf(BusinessException.class)
+                    .extracting("errorCode")
+                    .isEqualTo(ErrorCode.INVALID_OAUTH_RESPONSE);
+        }
+    }
+
+    @Nested
+    @DisplayName("구글")
+    class Google {
+
+        @Test
+        @DisplayName("정상 응답을 (GOOGLE, providerUid, email)로 정규화한다")
+        void parsesNormalResponse() {
+            Map<String, Object> attributes =
+                    Map.of(
+                            "sub", "google-sub-001",
+                            "email", "user@gmail.com");
+
+            OAuthAttributes result = OAuthAttributes.from("google", attributes);
+
+            assertThat(result.provider()).isEqualTo(SocialProvider.GOOGLE);
+            assertThat(result.providerUid()).isEqualTo("google-sub-001");
+            assertThat(result.email()).isEqualTo("user@gmail.com");
+            assertThat(result.attributes()).isEqualTo(attributes);
+        }
+
+        @Test
+        @DisplayName("sub가 누락되면 INVALID_OAUTH_RESPONSE")
+        void throwsWhenSubMissing() {
+            Map<String, Object> attributes = Map.of("email", "user@gmail.com");
+
+            assertThatThrownBy(() -> OAuthAttributes.from("google", attributes))
+                    .isInstanceOf(BusinessException.class)
+                    .extracting("errorCode")
+                    .isEqualTo(ErrorCode.INVALID_OAUTH_RESPONSE);
+        }
+    }
+
+    @Nested
+    @DisplayName("네이버")
+    class Naver {
+
+        @Test
+        @DisplayName("response 하위 값을 (NAVER, providerUid, email)로 정규화한다")
+        void parsesNormalResponse() {
+            Map<String, Object> attributes =
+                    Map.of(
+                            "response",
+                            Map.of(
+                                    "id", "naver-id-001",
+                                    "email", "user@naver.com"));
+
+            OAuthAttributes result = OAuthAttributes.from("naver", attributes);
+
+            assertThat(result.provider()).isEqualTo(SocialProvider.NAVER);
+            assertThat(result.providerUid()).isEqualTo("naver-id-001");
+            assertThat(result.email()).isEqualTo("user@naver.com");
+            assertThat(result.attributes()).isEqualTo(attributes);
+        }
+
+        @Test
+        @DisplayName("response 루트가 없으면 INVALID_OAUTH_RESPONSE")
+        void throwsWhenResponseMissing() {
+            Map<String, Object> attributes = Map.of("id", "naver-id-001");
+
+            assertThatThrownBy(() -> OAuthAttributes.from("naver", attributes))
+                    .isInstanceOf(BusinessException.class)
+                    .extracting("errorCode")
+                    .isEqualTo(ErrorCode.INVALID_OAUTH_RESPONSE);
+        }
+
+        @Test
+        @DisplayName("response.id가 누락되면 INVALID_OAUTH_RESPONSE")
+        void throwsWhenIdMissing() {
+            Map<String, Object> attributes = Map.of("response", Map.of("email", "user@naver.com"));
+
+            assertThatThrownBy(() -> OAuthAttributes.from("naver", attributes))
+                    .isInstanceOf(BusinessException.class)
+                    .extracting("errorCode")
+                    .isEqualTo(ErrorCode.INVALID_OAUTH_RESPONSE);
+        }
+    }
+
+    @Nested
+    @DisplayName("registrationId 분기")
+    class Registration {
+
+        @Test
+        @DisplayName("대소문자가 섞여 있어도 provider를 매칭한다")
+        void matchesCaseInsensitively() {
+            Map<String, Object> attributes =
+                    Map.of(
+                            "sub", "google-sub-001",
+                            "email", "user@gmail.com");
+
+            OAuthAttributes result = OAuthAttributes.from("GOOGLE", attributes);
+
+            assertThat(result.provider()).isEqualTo(SocialProvider.GOOGLE);
+        }
+
+        @Test
+        @DisplayName("미지원 registrationId면 UNSUPPORTED_OAUTH_PROVIDER")
+        void throwsOnUnsupportedProvider() {
+            assertThatThrownBy(() -> OAuthAttributes.from("apple", Map.of()))
+                    .isInstanceOf(BusinessException.class)
+                    .extracting("errorCode")
+                    .isEqualTo(ErrorCode.UNSUPPORTED_OAUTH_PROVIDER);
+        }
+    }
+}


### PR DESCRIPTION
## 요약
- auth 도메인 `service/` 계층에 단위 테스트를 추가해 JaCoCo 커버리지 확보
- DoD 기준: AuthService·SocialLoginService·TokenDeliveryService·CustomOAuth2UserService·OAuthAttributes·OAuth2 핸들러 분기 검증

## 변경 사항
- [ ] 기능
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 문서
- [x] 테스트
- [ ] 기타

### 추가된 테스트 클래스
| 테스트 클래스 | 대상 | 주요 분기 |
| --- | --- | --- |
| `OAuthAttributesTest` | `auth/service/oauth/OAuthAttributes` | provider별 정규화(카카오/구글/네이버) + 필수 필드 누락 → `INVALID_OAUTH_RESPONSE`, 미지원 provider → `UNSUPPORTED_OAUTH_PROVIDER` |
| `CustomOAuth2UserServiceTest` | `auth/service/oauth/CustomOAuth2UserService` | 정규화된 `OAuthAttributes`를 `SocialLoginService.upsertUser`에 위임 + `PrincipalUser` 반환, `BusinessException` → `OAuth2AuthenticationException` 래핑 |
| `AuthServiceTest` | `auth/service/AuthService` | 재발급: null/blank → `REFRESH_TOKEN_REQUIRED`, validate 실패·tokenType ≠ REFRESH → `INVALID_REFRESH_TOKEN`, rotate 성공 시 새 토큰 쌍 반환, rotate 실패 시 `deleteByUserId` 호출 + `INVALID_REFRESH_TOKEN` |
| `SocialLoginServiceTest` | `auth/service/SocialLoginService` | 신규 소셜 계정 → `User` 생성 + `SocialAccount` 저장 (`InOrder`로 순서 검증), 기존 계정 재사용 → `updateEmail` + `recordLogin`만 수행 |
| `TokenDeliveryServiceTest` | `auth/service/TokenDeliveryService` | 쿠키 on → Set-Cookie(`refreshToken`·`Max-Age`·`HttpOnly`·`Secure`·`SameSite=Strict`·`Path=/`) + 본문 refresh=null, 쿠키 off → 본문에 access+refresh 둘 다 |
| `OAuth2LoginSuccessHandlerTest` | `auth/service/oauth/OAuth2LoginSuccessHandler` | 인증 성공 시 토큰 발급·저장 + `TokenDeliveryService.deliver` 위임 + JSON 본문 기록 |
| `OAuth2LoginFailureHandlerTest` | `auth/service/oauth/OAuth2LoginFailureHandler` | 원인 체인에 `BusinessException` → 해당 `ErrorCode`로 응답 + 응답 메시지 마스킹(`providerUid` 미노출, 레거시 회귀 방지), 없으면 `UNAUTHORIZED` 기본 응답 |

### 스타일 규칙 (이 방식 괜찮다면 앞으로도 적용하도록 CONTRIBUTING 추가해도 될 것 같음)
- 전체 테스트 full BDD 스타일 적용
  - 메서드명: `should_<expected>_when_<condition>`
  - `@DisplayName`: "...일 때 ...한다"
  - 본문: `// given` / `// when` / `// then` 블록
  - Mockito BDD API (`given().willReturn()`) + AssertJ fluent 단언

## 테스트
- [x] 로컬 테스트 완료
- 테스트 방법:
  - `./gradlew test --tests "com.groute.groute_server.auth.*"` → BUILD SUCCESSFUL
  - `./gradlew spotlessCheck` → 포맷 통과

### 커버리지 (JaCoCo)
- 라인 커버리지: 84%  (기준: 60% 이상)
- [ ] `./gradlew test` 실행 후 `build/reports/jacoco/index.html`에서 수치 확인
- **참고**: #54(`feat: 내 프로필 조회·수정 API 구현`)가 `build.gradle`의 `jacocoExcludes`에 `**/auth/**` 임시 제외를 추가하는데, 본 PR이 그 제외 항목을 해제하려면 #54 머지 후 rebase가 필요. 별도 커밋(`chore: JaCoCo 제외 목록에서 auth 도메인 제거`)은 #54 머지 이후 append 예정.
  - 완료

## 스크린샷/로그 (선택)
- N/A (테스트 전용)

## 롤백/리스크
- 리스크 포인트: 프로덕션 코드 변경 없으며, 테스트 추가만 진행함. 런타임·API 영향 X.
- 롤백 방법: PR close 또는 `git revert`

## 관련 이슈
Closes #53 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# 릴리스 노트

* **테스트**
  * 인증 서비스 기능에 대한 포괄적인 단위 테스트 추가
  * 소셜 로그인 및 OAuth2 인증 프로세스 테스트 커버리지 확대
  * 토큰 배달 및 핸들링 로직 검증 테스트 구현

* **Chores**
  * 코드 커버리지 측정 설정 조정

<!-- end of auto-generated comment: release notes by coderabbit.ai -->