### PR TITLE
feat: 심화기록 상세 조회·단독 삭제 API 구현 (#71)

### DIFF
--- a/src/main/java/com/groute/groute_server/common/exception/ErrorCode.java
+++ b/src/main/java/com/groute/groute_server/common/exception/ErrorCode.java
@@ -46,6 +46,8 @@ public enum ErrorCode {
     SCRUM_EDIT_LOCKED_14D(HttpStatus.CONFLICT, "RECORD_003", "2주 이상 지난 스크럼은 수정할 수 없어요."),
     SCRUM_EDIT_LOCKED_STAR(HttpStatus.CONFLICT, "RECORD_004", "심화기록이 작성된 스크럼은 수정할 수 없어요."),
     SCRUM_DATE_LIMIT_EXCEEDED(HttpStatus.BAD_REQUEST, "RECORD_005", "하루에 작성할 수 있는 스크럼은 최대 5개입니다."),
+    STAR_NOT_FOUND(HttpStatus.NOT_FOUND, "RECORD_006", "심화기록을 찾을 수 없습니다."),
+    STAR_FORBIDDEN(HttpStatus.FORBIDDEN, "RECORD_007", "본인의 심화기록만 접근할 수 있습니다."),
 
     // Calendar
     CALENDAR_INVALID_DATE_FORMAT(

--- a/src/main/java/com/groute/groute_server/record/adapter/in/web/StarRecordController.java
+++ b/src/main/java/com/groute/groute_server/record/adapter/in/web/StarRecordController.java
@@ -1,0 +1,89 @@
+package com.groute.groute_server.record.adapter.in.web;
+
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.groute.groute_server.common.annotation.CurrentUser;
+import com.groute.groute_server.common.response.ApiResponse;
+import com.groute.groute_server.record.adapter.in.web.dto.StarDetailResponse;
+import com.groute.groute_server.record.application.port.in.star.DeleteStarCommand;
+import com.groute.groute_server.record.application.port.in.star.DeleteStarUseCase;
+import com.groute.groute_server.record.application.port.in.star.GetStarDetailQuery;
+import com.groute.groute_server.record.application.port.in.star.GetStarDetailUseCase;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * 심화기록 상세 조회·단독 삭제(CAL-003) 엔드포인트.
+ *
+ * <p>본 페이지는 읽기 전용이며 수정 API는 제공하지 않는다. 삭제 시 STAR는 soft-delete 되고 연결된 Scrum의 hasStar 플래그만 false로
+ * 동기화된다 (스크럼 본문 보존).
+ */
+@Tag(name = "StarRecord", description = "심화기록 상세 조회·단독 삭제")
+@RestController
+@RequestMapping("/api/star-records")
+@RequiredArgsConstructor
+public class StarRecordController {
+
+    private final GetStarDetailUseCase getStarDetailUseCase;
+    private final DeleteStarUseCase deleteStarUseCase;
+
+    @Operation(
+            summary = "심화기록 상세 조회",
+            description =
+                    "심화기록 본문(S·T/A/R) + 카테고리·자유작성 + 대표 역량/세부 태그 + 첨부 이미지 목록을 반환한다."
+                            + " 이미지·세부 태그가 없으면 빈 배열로 응답한다.")
+    @ApiResponses({
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                responseCode = "200",
+                description = "조회 성공"),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                responseCode = "401",
+                description = "미인증 또는 만료된 액세스 토큰"),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                responseCode = "403",
+                description = "본인의 심화기록이 아님"),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                responseCode = "404",
+                description = "심화기록을 찾을 수 없음")
+    })
+    @GetMapping("/{starRecordId}")
+    public ApiResponse<StarDetailResponse> getStarDetail(
+            @CurrentUser Long userId, @PathVariable Long starRecordId) {
+        return ApiResponse.ok(
+                "심화 기록 조회 성공",
+                StarDetailResponse.from(
+                        getStarDetailUseCase.getStarDetail(
+                                new GetStarDetailQuery(userId, starRecordId))));
+    }
+
+    @Operation(
+            summary = "심화기록 단독 삭제",
+            description =
+                    "STAR를 soft-delete 하고 연결된 Scrum의 hasStar 플래그를 false로 동기화한다. 스크럼 본문은 보존된다.")
+    @ApiResponses({
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                responseCode = "200",
+                description = "삭제 성공"),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                responseCode = "401",
+                description = "미인증 또는 만료된 액세스 토큰"),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                responseCode = "403",
+                description = "본인의 심화기록이 아님"),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                responseCode = "404",
+                description = "심화기록을 찾을 수 없음")
+    })
+    @DeleteMapping("/{starRecordId}")
+    public ApiResponse<Void> deleteStar(@CurrentUser Long userId, @PathVariable Long starRecordId) {
+        deleteStarUseCase.deleteStar(new DeleteStarCommand(userId, starRecordId));
+        return ApiResponse.ok("심화 기록 삭제 성공");
+    }
+}

--- a/src/main/java/com/groute/groute_server/record/adapter/in/web/dto/StarDetailResponse.java
+++ b/src/main/java/com/groute/groute_server/record/adapter/in/web/dto/StarDetailResponse.java
@@ -1,0 +1,48 @@
+package com.groute.groute_server.record.adapter.in.web.dto;
+
+import java.util.List;
+
+import com.groute.groute_server.record.application.port.in.star.StarDetailView;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+/** 심화기록 상세 조회(CAL-003) 응답 DTO. {@link StarDetailView}의 Web 표현 (flat schema). */
+@Schema(description = "심화기록 상세 조회 응답")
+public record StarDetailResponse(
+        @Schema(description = "심화기록 식별자", example = "1") Long starRecordId,
+        @Schema(description = "프로젝트 태그명 (최대 15자)", example = "밋업 프로젝트") String projectTag,
+        @Schema(description = "제목 자유작성 (최대 20자)", example = "기획 작업") String freeText,
+        @Schema(description = "대표 역량 (5대 역량 enum)", example = "PLANNING_EXECUTION")
+                String primaryCategory,
+        @Schema(description = "세부 역량 태그 목록 (최대 3개, 빈 배열 가능)", example = "[\"UX 설계\", \"품질 관리\"]")
+                List<String> detailTags,
+        @Schema(description = "S·T 단계 내용 (최대 300자)", example = "어드민 페이지 기획을 맡게 되었고...")
+                String situationTask,
+        @Schema(description = "A 단계 내용 (최대 300자)", example = "팀원들과 회의를 통해...") String action,
+        @Schema(description = "R 단계 내용 (최대 300자)", example = "기능명세서를 완성하여...") String result,
+        @Schema(description = "R 단계 첨부 이미지 목록 (최대 2장, 빈 배열 가능)") List<ImageResponse> images) {
+
+    public static StarDetailResponse from(StarDetailView view) {
+        return new StarDetailResponse(
+                view.starRecordId(),
+                view.projectTag(),
+                view.freeText(),
+                view.primaryCategory(),
+                view.detailTags(),
+                view.situationTask(),
+                view.action(),
+                view.result(),
+                view.images().stream().map(ImageResponse::from).toList());
+    }
+
+    @Schema(description = "STAR R 단계 첨부 이미지")
+    public record ImageResponse(
+            @Schema(description = "이미지 식별자", example = "1") Long imageId,
+            @Schema(description = "이미지 URL (최대 500자)", example = "https://...") String imageUrl,
+            @Schema(description = "표시 순서 (0~1)", example = "0") int sortOrder) {
+
+        static ImageResponse from(StarDetailView.ImageView image) {
+            return new ImageResponse(image.imageId(), image.imageUrl(), image.sortOrder());
+        }
+    }
+}

--- a/src/main/java/com/groute/groute_server/record/adapter/out/persistence/ScrumJpaRepository.java
+++ b/src/main/java/com/groute/groute_server/record/adapter/out/persistence/ScrumJpaRepository.java
@@ -48,4 +48,9 @@ public interface ScrumJpaRepository extends JpaRepository<Scrum, Long> {
             "UPDATE Scrum s SET s.isDeleted = true, s.deletedAt = CURRENT_TIMESTAMP "
                     + "WHERE s.id IN :ids AND s.isDeleted = false")
     int softDeleteAllByIdIn(@Param("ids") Collection<Long> ids);
+
+    /** STAR 단독 삭제 시 Scrum.hasStar 플래그 해제. */
+    @Modifying
+    @Query("UPDATE Scrum s SET s.hasStar = false " + "WHERE s.id = :id AND s.isDeleted = false")
+    int clearHasStarById(@Param("id") Long id);
 }

--- a/src/main/java/com/groute/groute_server/record/adapter/out/persistence/ScrumPersistenceAdapter.java
+++ b/src/main/java/com/groute/groute_server/record/adapter/out/persistence/ScrumPersistenceAdapter.java
@@ -56,4 +56,9 @@ class ScrumPersistenceAdapter implements ScrumQueryPort, ScrumWritePort {
         }
         jpaRepository.softDeleteAllByIdIn(ids);
     }
+
+    @Override
+    public void clearHasStar(Long scrumId) {
+        jpaRepository.clearHasStarById(scrumId);
+    }
 }

--- a/src/main/java/com/groute/groute_server/record/adapter/out/persistence/StarImageJpaRepository.java
+++ b/src/main/java/com/groute/groute_server/record/adapter/out/persistence/StarImageJpaRepository.java
@@ -1,0 +1,24 @@
+package com.groute.groute_server.record.adapter.out.persistence;
+
+import java.util.List;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import com.groute.groute_server.record.domain.StarImage;
+
+/**
+ * STAR 첨부 이미지(StarImage) JPA 레포지토리.
+ *
+ * <p>심화기록 상세 응답의 이미지 목록을 sortOrder 오름차순으로 제공한다. StarImage는 BaseTimeEntity 기반이라 soft-delete 필터 없음.
+ */
+public interface StarImageJpaRepository extends JpaRepository<StarImage, Long> {
+
+    @Query(
+            "SELECT i FROM StarImage i "
+                    + "WHERE i.starRecord.id = :starRecordId "
+                    + "ORDER BY i.sortOrder ASC")
+    List<StarImage> findAllByStarRecordIdOrderBySortOrderAsc(
+            @Param("starRecordId") Long starRecordId);
+}

--- a/src/main/java/com/groute/groute_server/record/adapter/out/persistence/StarImagePersistenceAdapter.java
+++ b/src/main/java/com/groute/groute_server/record/adapter/out/persistence/StarImagePersistenceAdapter.java
@@ -1,0 +1,27 @@
+package com.groute.groute_server.record.adapter.out.persistence;
+
+import java.util.List;
+
+import org.springframework.stereotype.Component;
+
+import com.groute.groute_server.record.application.port.out.star.StarImageQueryPort;
+import com.groute.groute_server.record.domain.StarImage;
+
+import lombok.RequiredArgsConstructor;
+
+/**
+ * {@link StarImageQueryPort}의 JPA 어댑터.
+ *
+ * <p>심화기록 상세 응답의 이미지 목록을 sortOrder 오름차순으로 제공한다.
+ */
+@Component
+@RequiredArgsConstructor
+class StarImagePersistenceAdapter implements StarImageQueryPort {
+
+    private final StarImageJpaRepository jpaRepository;
+
+    @Override
+    public List<StarImage> findAllByStarRecordIdOrderBySortOrder(Long starRecordId) {
+        return jpaRepository.findAllByStarRecordIdOrderBySortOrderAsc(starRecordId);
+    }
+}

--- a/src/main/java/com/groute/groute_server/record/adapter/out/persistence/StarRecordJpaRepository.java
+++ b/src/main/java/com/groute/groute_server/record/adapter/out/persistence/StarRecordJpaRepository.java
@@ -1,6 +1,7 @@
 package com.groute.groute_server.record.adapter.out.persistence;
 
 import java.util.Collection;
+import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
@@ -12,7 +13,7 @@ import com.groute.groute_server.record.domain.StarRecord;
 /**
  * 심화 STAR 기록(StarRecord) JPA 레포지토리.
  *
- * <p>스크럼 sync 시 삭제 대상 Scrum의 STAR 기록을 cascade soft-delete 하기 위해 사용한다.
+ * <p>스크럼 sync 시 cascade soft-delete (CAL-002), 단건 상세 조회·삭제 (CAL-003)에 사용한다.
  */
 public interface StarRecordJpaRepository extends JpaRepository<StarRecord, Long> {
 
@@ -29,4 +30,21 @@ public interface StarRecordJpaRepository extends JpaRepository<StarRecord, Long>
                     + "SET sr.isDeleted = true, sr.deletedAt = CURRENT_TIMESTAMP "
                     + "WHERE sr.scrum.id IN :scrumIds AND sr.isDeleted = false")
     int deleteAllByScrumIdIn(@Param("scrumIds") Collection<Long> scrumIds);
+
+    /** 단건 상세 조회. 응답 카테고리·부제목 매핑을 위해 Scrum·Title·Project까지 fetch join. */
+    @Query(
+            "SELECT sr FROM StarRecord sr "
+                    + "JOIN FETCH sr.scrum s "
+                    + "JOIN FETCH s.title t "
+                    + "JOIN FETCH t.project "
+                    + "WHERE sr.id = :id AND sr.isDeleted = false")
+    Optional<StarRecord> findByIdWithScrum(@Param("id") Long id);
+
+    /** 단건 soft-delete. cascade(Scrum.hasStar=false 등)는 호출자가 별도 처리. */
+    @Modifying
+    @Query(
+            "UPDATE StarRecord sr "
+                    + "SET sr.isDeleted = true, sr.deletedAt = CURRENT_TIMESTAMP "
+                    + "WHERE sr.id = :id AND sr.isDeleted = false")
+    int softDeleteById(@Param("id") Long id);
 }

--- a/src/main/java/com/groute/groute_server/record/adapter/out/persistence/StarRecordPersistenceAdapter.java
+++ b/src/main/java/com/groute/groute_server/record/adapter/out/persistence/StarRecordPersistenceAdapter.java
@@ -1,0 +1,32 @@
+package com.groute.groute_server.record.adapter.out.persistence;
+
+import java.util.Optional;
+
+import org.springframework.stereotype.Component;
+
+import com.groute.groute_server.record.application.port.out.star.StarRecordRepositoryPort;
+import com.groute.groute_server.record.domain.StarRecord;
+
+import lombok.RequiredArgsConstructor;
+
+/**
+ * {@link StarRecordRepositoryPort}의 JPA 어댑터.
+ *
+ * <p>심화기록 단건 상세 조회와 단건 soft-delete를 담당한다. 소유권 검증은 호출자 책임.
+ */
+@Component
+@RequiredArgsConstructor
+class StarRecordPersistenceAdapter implements StarRecordRepositoryPort {
+
+    private final StarRecordJpaRepository jpaRepository;
+
+    @Override
+    public Optional<StarRecord> findByIdWithScrum(Long id) {
+        return jpaRepository.findByIdWithScrum(id);
+    }
+
+    @Override
+    public void softDeleteById(Long id) {
+        jpaRepository.softDeleteById(id);
+    }
+}

--- a/src/main/java/com/groute/groute_server/record/adapter/out/persistence/StarTagJpaRepository.java
+++ b/src/main/java/com/groute/groute_server/record/adapter/out/persistence/StarTagJpaRepository.java
@@ -16,6 +16,6 @@ import com.groute.groute_server.record.domain.StarTag;
  */
 public interface StarTagJpaRepository extends JpaRepository<StarTag, Long> {
 
-    @Query("SELECT t FROM StarTag t WHERE t.starRecord.id = :starRecordId")
+    @Query("SELECT t FROM StarTag t WHERE t.starRecord.id = :starRecordId ORDER BY t.id ASC")
     List<StarTag> findAllByStarRecordId(@Param("starRecordId") Long starRecordId);
 }

--- a/src/main/java/com/groute/groute_server/record/adapter/out/persistence/StarTagJpaRepository.java
+++ b/src/main/java/com/groute/groute_server/record/adapter/out/persistence/StarTagJpaRepository.java
@@ -1,0 +1,21 @@
+package com.groute.groute_server.record.adapter.out.persistence;
+
+import java.util.List;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import com.groute.groute_server.record.domain.StarTag;
+
+/**
+ * STAR 역량 태그(StarTag) JPA 레포지토리.
+ *
+ * <p>심화기록 상세 응답의 primary 역량 + detail 해시태그 목록을 제공한다. StarTag는 BaseTimeEntity 기반이라 soft-delete 필터 없음
+ * — 부모(StarRecord) 삭제 시 JOIN 필터로 자연 차단되는 구조.
+ */
+public interface StarTagJpaRepository extends JpaRepository<StarTag, Long> {
+
+    @Query("SELECT t FROM StarTag t WHERE t.starRecord.id = :starRecordId")
+    List<StarTag> findAllByStarRecordId(@Param("starRecordId") Long starRecordId);
+}

--- a/src/main/java/com/groute/groute_server/record/adapter/out/persistence/StarTagPersistenceAdapter.java
+++ b/src/main/java/com/groute/groute_server/record/adapter/out/persistence/StarTagPersistenceAdapter.java
@@ -1,0 +1,27 @@
+package com.groute.groute_server.record.adapter.out.persistence;
+
+import java.util.List;
+
+import org.springframework.stereotype.Component;
+
+import com.groute.groute_server.record.application.port.out.star.StarTagQueryPort;
+import com.groute.groute_server.record.domain.StarTag;
+
+import lombok.RequiredArgsConstructor;
+
+/**
+ * {@link StarTagQueryPort}의 JPA 어댑터.
+ *
+ * <p>심화기록 상세 응답의 primary 역량 + detail 해시태그 목록을 제공한다.
+ */
+@Component
+@RequiredArgsConstructor
+class StarTagPersistenceAdapter implements StarTagQueryPort {
+
+    private final StarTagJpaRepository jpaRepository;
+
+    @Override
+    public List<StarTag> findAllByStarRecordId(Long starRecordId) {
+        return jpaRepository.findAllByStarRecordId(starRecordId);
+    }
+}

--- a/src/main/java/com/groute/groute_server/record/application/port/in/star/DeleteStarCommand.java
+++ b/src/main/java/com/groute/groute_server/record/application/port/in/star/DeleteStarCommand.java
@@ -1,0 +1,4 @@
+package com.groute.groute_server.record.application.port.in.star;
+
+/** 심화기록 단독 삭제 입력. */
+public record DeleteStarCommand(Long userId, Long starRecordId) {}

--- a/src/main/java/com/groute/groute_server/record/application/port/in/star/DeleteStarUseCase.java
+++ b/src/main/java/com/groute/groute_server/record/application/port/in/star/DeleteStarUseCase.java
@@ -1,0 +1,11 @@
+package com.groute.groute_server.record.application.port.in.star;
+
+/**
+ * 심화기록 단독 삭제 유스케이스 (CAL-003, DELETE /api/star-records/{starRecordId}).
+ *
+ * <p>STAR soft-delete + 연결된 Scrum의 hasStar 플래그를 false로 동기화한다. 스크럼 본문은 보존.
+ */
+public interface DeleteStarUseCase {
+
+    void deleteStar(DeleteStarCommand command);
+}

--- a/src/main/java/com/groute/groute_server/record/application/port/in/star/GetStarDetailQuery.java
+++ b/src/main/java/com/groute/groute_server/record/application/port/in/star/GetStarDetailQuery.java
@@ -1,0 +1,4 @@
+package com.groute.groute_server.record.application.port.in.star;
+
+/** 심화기록 상세 조회 입력. */
+public record GetStarDetailQuery(Long userId, Long starRecordId) {}

--- a/src/main/java/com/groute/groute_server/record/application/port/in/star/GetStarDetailUseCase.java
+++ b/src/main/java/com/groute/groute_server/record/application/port/in/star/GetStarDetailUseCase.java
@@ -1,0 +1,7 @@
+package com.groute.groute_server.record.application.port.in.star;
+
+/** 심화기록 상세 조회 유스케이스 (CAL-003, GET /api/star-records/{starRecordId}). */
+public interface GetStarDetailUseCase {
+
+    StarDetailView getStarDetail(GetStarDetailQuery query);
+}

--- a/src/main/java/com/groute/groute_server/record/application/port/in/star/StarDetailView.java
+++ b/src/main/java/com/groute/groute_server/record/application/port/in/star/StarDetailView.java
@@ -1,0 +1,23 @@
+package com.groute.groute_server.record.application.port.in.star;
+
+import java.util.List;
+
+/**
+ * 심화기록 상세 조회(CAL-003) 응답 모델.
+ *
+ * <p>프론트와 합의된 스키마. {@code detailTags}/{@code images} 빈 배열은 UI 영역 숨김 신호로 사용된다.
+ */
+public record StarDetailView(
+        Long starRecordId,
+        String projectTag,
+        String freeText,
+        String primaryCategory,
+        List<String> detailTags,
+        String situationTask,
+        String action,
+        String result,
+        List<ImageView> images) {
+
+    /** STAR R 단계 첨부 이미지. */
+    public record ImageView(Long imageId, String imageUrl, int sortOrder) {}
+}

--- a/src/main/java/com/groute/groute_server/record/application/port/out/scrum/ScrumWritePort.java
+++ b/src/main/java/com/groute/groute_server/record/application/port/out/scrum/ScrumWritePort.java
@@ -16,4 +16,7 @@ public interface ScrumWritePort {
 
     /** soft-delete (is_deleted=true). cascade는 호출자가 별도 포트로 처리. */
     void softDeleteAllByIdIn(Collection<Long> ids);
+
+    /** STAR 단독 삭제 시 Scrum.hasStar 플래그를 false로 동기화. */
+    void clearHasStar(Long scrumId);
 }

--- a/src/main/java/com/groute/groute_server/record/application/port/out/star/StarImageQueryPort.java
+++ b/src/main/java/com/groute/groute_server/record/application/port/out/star/StarImageQueryPort.java
@@ -1,0 +1,11 @@
+package com.groute.groute_server.record.application.port.out.star;
+
+import java.util.List;
+
+import com.groute.groute_server.record.domain.StarImage;
+
+/** StarImage 조회 포트. 심화기록 상세 응답의 이미지 목록(sortOrder 오름차순) 추출에 사용. */
+public interface StarImageQueryPort {
+
+    List<StarImage> findAllByStarRecordIdOrderBySortOrder(Long starRecordId);
+}

--- a/src/main/java/com/groute/groute_server/record/application/port/out/star/StarRecordRepositoryPort.java
+++ b/src/main/java/com/groute/groute_server/record/application/port/out/star/StarRecordRepositoryPort.java
@@ -1,0 +1,20 @@
+package com.groute.groute_server.record.application.port.out.star;
+
+import java.util.Optional;
+
+import com.groute.groute_server.record.domain.StarRecord;
+
+/**
+ * StarRecord 단건 조회·삭제 포트 (CAL-003).
+ *
+ * <p>소유권 검증은 호출자(서비스)가 로드된 엔티티의 user를 비교해 처리한다. 미존재(404)와 타인 소유(403)를 구분하기 위해 ownership 필터를 포트에 두지
+ * 않는다.
+ */
+public interface StarRecordRepositoryPort {
+
+    /** 응답 카테고리·부제목 매핑을 위해 Scrum·Title·Project까지 fetch join 한 단건 조회. */
+    Optional<StarRecord> findByIdWithScrum(Long id);
+
+    /** 단건 soft-delete. cascade(Scrum.hasStar=false 등)는 호출자가 별도 처리. */
+    void softDeleteById(Long id);
+}

--- a/src/main/java/com/groute/groute_server/record/application/port/out/star/StarTagQueryPort.java
+++ b/src/main/java/com/groute/groute_server/record/application/port/out/star/StarTagQueryPort.java
@@ -1,0 +1,11 @@
+package com.groute.groute_server.record.application.port.out.star;
+
+import java.util.List;
+
+import com.groute.groute_server.record.domain.StarTag;
+
+/** StarTag 조회 포트. 심화기록 상세 응답의 primary 역량 + detail 해시태그 추출에 사용. */
+public interface StarTagQueryPort {
+
+    List<StarTag> findAllByStarRecordId(Long starRecordId);
+}

--- a/src/main/java/com/groute/groute_server/record/application/service/StarRecordDeleteService.java
+++ b/src/main/java/com/groute/groute_server/record/application/service/StarRecordDeleteService.java
@@ -1,0 +1,59 @@
+package com.groute.groute_server.record.application.service;
+
+import java.util.Objects;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.groute.groute_server.common.exception.BusinessException;
+import com.groute.groute_server.common.exception.ErrorCode;
+import com.groute.groute_server.record.application.port.in.star.DeleteStarCommand;
+import com.groute.groute_server.record.application.port.in.star.DeleteStarUseCase;
+import com.groute.groute_server.record.application.port.out.scrum.ScrumWritePort;
+import com.groute.groute_server.record.application.port.out.star.StarRecordRepositoryPort;
+import com.groute.groute_server.record.domain.StarRecord;
+
+import lombok.RequiredArgsConstructor;
+
+/**
+ * 심화기록 단독 삭제 서비스 (CAL-003).
+ *
+ * <p>STAR soft-delete + 연결된 Scrum의 hasStar 플래그를 false로 동기화한다. 스크럼 본문은 보존되며 한 트랜잭션에서 원자적으로 처리된다.
+ *
+ * <p>StarTag/StarImage는 자체 soft-delete 필드가 없으므로 별도 cascade 없이 둔다 — 부모(StarRecord)가 isDeleted=true로
+ * 마킹되면 후속 조회에서 JOIN 필터로 자연 차단된다.
+ */
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class StarRecordDeleteService implements DeleteStarUseCase {
+
+    private final StarRecordRepositoryPort starRecordRepositoryPort;
+    private final ScrumWritePort scrumWritePort;
+
+    /**
+     * 심화기록 단독 삭제.
+     *
+     * <p>위반 시 도메인 예외: 미존재(이미 삭제된 경우 포함) → {@code STAR_NOT_FOUND}, 본인 소유 아님 → {@code
+     * STAR_FORBIDDEN}.
+     */
+    @Override
+    public void deleteStar(DeleteStarCommand command) {
+        // 1. STAR + Scrum fetch join 로드, 미존재(또는 이미 삭제)면 404
+        StarRecord starRecord =
+                starRecordRepositoryPort
+                        .findByIdWithScrum(command.starRecordId())
+                        .orElseThrow(() -> new BusinessException(ErrorCode.STAR_NOT_FOUND));
+
+        // 2. 소유권 검증 (FK id만 보므로 user 테이블 조회는 발생하지 않음)
+        if (!Objects.equals(starRecord.getUser().getId(), command.userId())) {
+            throw new BusinessException(ErrorCode.STAR_FORBIDDEN);
+        }
+
+        // 3. STAR soft-delete
+        starRecordRepositoryPort.softDeleteById(command.starRecordId());
+
+        // 4. Scrum.hasStar = false (스크럼 본문은 그대로)
+        scrumWritePort.clearHasStar(starRecord.getScrum().getId());
+    }
+}

--- a/src/main/java/com/groute/groute_server/record/application/service/StarRecordQueryService.java
+++ b/src/main/java/com/groute/groute_server/record/application/service/StarRecordQueryService.java
@@ -1,0 +1,88 @@
+package com.groute.groute_server.record.application.service;
+
+import java.util.List;
+import java.util.Objects;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.groute.groute_server.common.exception.BusinessException;
+import com.groute.groute_server.common.exception.ErrorCode;
+import com.groute.groute_server.record.application.port.in.star.GetStarDetailQuery;
+import com.groute.groute_server.record.application.port.in.star.GetStarDetailUseCase;
+import com.groute.groute_server.record.application.port.in.star.StarDetailView;
+import com.groute.groute_server.record.application.port.out.star.StarImageQueryPort;
+import com.groute.groute_server.record.application.port.out.star.StarRecordRepositoryPort;
+import com.groute.groute_server.record.application.port.out.star.StarTagQueryPort;
+import com.groute.groute_server.record.domain.ScrumTitle;
+import com.groute.groute_server.record.domain.StarImage;
+import com.groute.groute_server.record.domain.StarRecord;
+import com.groute.groute_server.record.domain.StarTag;
+
+import lombok.RequiredArgsConstructor;
+
+/**
+ * 심화기록 상세 조회 서비스 (CAL-003).
+ *
+ * <p>StarRecord + 연결된 Scrum/Title/Project + 역량 태그 + 이미지를 합쳐 프론트 합의 schema(flat)로 반환한다. 미존재(404)와 타인
+ * 소유(403)를 구분한다.
+ */
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class StarRecordQueryService implements GetStarDetailUseCase {
+
+    private final StarRecordRepositoryPort starRecordRepositoryPort;
+    private final StarTagQueryPort starTagQueryPort;
+    private final StarImageQueryPort starImageQueryPort;
+
+    /**
+     * 심화기록 상세 조회.
+     *
+     * <p>위반 시 도메인 예외: 미존재 → {@code STAR_NOT_FOUND}, 본인 소유 아님 → {@code STAR_FORBIDDEN}.
+     */
+    @Override
+    public StarDetailView getStarDetail(GetStarDetailQuery query) {
+        // 1. STAR + Scrum/Title/Project fetch join 로드, 미존재면 404
+        StarRecord starRecord =
+                starRecordRepositoryPort
+                        .findByIdWithScrum(query.starRecordId())
+                        .orElseThrow(() -> new BusinessException(ErrorCode.STAR_NOT_FOUND));
+
+        // 2. 소유권 검증 (FK id만 보므로 user 테이블 조회는 발생하지 않음)
+        if (!Objects.equals(starRecord.getUser().getId(), query.userId())) {
+            throw new BusinessException(ErrorCode.STAR_FORBIDDEN);
+        }
+
+        // 3. 역량 태그: primary 1 + detail 1~3 (모든 row의 primaryCategory는 동일)
+        List<StarTag> tags = starTagQueryPort.findAllByStarRecordId(query.starRecordId());
+        String primaryCategory = tags.isEmpty() ? null : tags.get(0).getPrimaryCategory().name();
+        List<String> detailTags = tags.stream().map(StarTag::getDetailTag).toList();
+
+        // 4. 이미지: sortOrder 오름차순, 없으면 빈 배열
+        List<StarDetailView.ImageView> images =
+                starImageQueryPort
+                        .findAllByStarRecordIdOrderBySortOrder(query.starRecordId())
+                        .stream()
+                        .map(StarRecordQueryService::toImageView)
+                        .toList();
+
+        // 5. View 빌드 (메모리에 저장된 프론트 합의 schema)
+        ScrumTitle title = starRecord.getScrum().getTitle();
+        return new StarDetailView(
+                starRecord.getId(),
+                title.getProject().getName(),
+                title.getFreeText(),
+                primaryCategory,
+                detailTags,
+                starRecord.getSituationTask(),
+                starRecord.getAction(),
+                starRecord.getResult(),
+                images);
+    }
+
+    private static StarDetailView.ImageView toImageView(StarImage image) {
+        return new StarDetailView.ImageView(
+                image.getId(), image.getImageUrl(), image.getSortOrder().intValue());
+    }
+}

--- a/src/test/java/com/groute/groute_server/record/application/service/ScrumSyncServiceTest.java
+++ b/src/test/java/com/groute/groute_server/record/application/service/ScrumSyncServiceTest.java
@@ -157,6 +157,8 @@ class ScrumSyncServiceTest {
             given(scrumQueryPort.findAllByIdInAndUserId(anyCollection(), anyLong()))
                     .willReturn(List.of());
             given(scrumQueryPort.findAllByUserAndDate(USER_ID, DATE)).willReturn(List.of());
+            given(userReferencePort.getReferenceById(USER_ID))
+                    .willReturn(User.createForSocialLogin());
             SyncDailyScrumCommand command = command(group(1L, item(null, "신규")));
 
             // when
@@ -334,6 +336,8 @@ class ScrumSyncServiceTest {
             given(scrumQueryPort.findAllByIdInAndUserId(anyCollection(), anyLong()))
                     .willReturn(List.of(a));
             given(scrumQueryPort.findAllByUserAndDate(USER_ID, DATE)).willReturn(List.of(a, b));
+            given(userReferencePort.getReferenceById(USER_ID))
+                    .willReturn(User.createForSocialLogin());
             SyncDailyScrumCommand command =
                     command(
                             group(1L, item(100L, "A_new")),

--- a/src/test/java/com/groute/groute_server/record/application/service/StarRecordDeleteServiceTest.java
+++ b/src/test/java/com/groute/groute_server/record/application/service/StarRecordDeleteServiceTest.java
@@ -1,0 +1,146 @@
+package com.groute.groute_server.record.application.service;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+import java.lang.reflect.Constructor;
+import java.util.Optional;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import com.groute.groute_server.common.exception.BusinessException;
+import com.groute.groute_server.common.exception.ErrorCode;
+import com.groute.groute_server.record.application.port.in.star.DeleteStarCommand;
+import com.groute.groute_server.record.application.port.out.scrum.ScrumWritePort;
+import com.groute.groute_server.record.application.port.out.star.StarRecordRepositoryPort;
+import com.groute.groute_server.record.domain.Scrum;
+import com.groute.groute_server.record.domain.StarRecord;
+import com.groute.groute_server.user.entity.User;
+
+@ExtendWith(MockitoExtension.class)
+class StarRecordDeleteServiceTest {
+
+    private static final Long USER_ID = 1L;
+    private static final Long OTHER_USER_ID = 99L;
+    private static final Long STAR_ID = 10L;
+    private static final Long SCRUM_ID = 50L;
+
+    @Mock StarRecordRepositoryPort starRecordRepositoryPort;
+    @Mock ScrumWritePort scrumWritePort;
+
+    @InjectMocks StarRecordDeleteService service;
+
+    @Nested
+    @DisplayName("정상 삭제")
+    class HappyPath {
+
+        @Test
+        @DisplayName("STAR soft-delete + Scrum.hasStar=false 호출을 수행한다")
+        void should_softDeleteStarAndClearHasStar_when_owned() {
+            // given
+            StarRecord star = star(STAR_ID, USER_ID, SCRUM_ID);
+            given(starRecordRepositoryPort.findByIdWithScrum(STAR_ID))
+                    .willReturn(Optional.of(star));
+
+            // when
+            assertThatCode(() -> service.deleteStar(new DeleteStarCommand(USER_ID, STAR_ID)))
+                    .doesNotThrowAnyException();
+
+            // then
+            verify(starRecordRepositoryPort).softDeleteById(STAR_ID);
+            verify(scrumWritePort).clearHasStar(SCRUM_ID);
+        }
+    }
+
+    @Nested
+    @DisplayName("예외")
+    class Errors {
+
+        @Test
+        @DisplayName("미존재 STAR면 STAR_NOT_FOUND를 던지고 어떤 쓰기도 하지 않는다")
+        void should_throwStarNotFound_when_missing() {
+            // given
+            given(starRecordRepositoryPort.findByIdWithScrum(STAR_ID)).willReturn(Optional.empty());
+
+            // when & then
+            assertThatThrownBy(() -> service.deleteStar(new DeleteStarCommand(USER_ID, STAR_ID)))
+                    .isInstanceOf(BusinessException.class)
+                    .extracting("errorCode")
+                    .isEqualTo(ErrorCode.STAR_NOT_FOUND);
+            verify(starRecordRepositoryPort, never()).softDeleteById(anyLong());
+            verify(scrumWritePort, never()).clearHasStar(anyLong());
+        }
+
+        @Test
+        @DisplayName("타 유저의 STAR면 STAR_FORBIDDEN을 던지고 어떤 쓰기도 하지 않는다")
+        void should_throwStarForbidden_when_otherUser() {
+            // given — STAR는 OTHER_USER_ID 소유, 요청은 USER_ID
+            StarRecord star = star(STAR_ID, OTHER_USER_ID, SCRUM_ID);
+            given(starRecordRepositoryPort.findByIdWithScrum(STAR_ID))
+                    .willReturn(Optional.of(star));
+
+            // when & then
+            assertThatThrownBy(() -> service.deleteStar(new DeleteStarCommand(USER_ID, STAR_ID)))
+                    .isInstanceOf(BusinessException.class)
+                    .extracting("errorCode")
+                    .isEqualTo(ErrorCode.STAR_FORBIDDEN);
+            verify(starRecordRepositoryPort, never()).softDeleteById(anyLong());
+            verify(scrumWritePort, never()).clearHasStar(anyLong());
+        }
+
+        @Test
+        @DisplayName("이미 soft-delete된 STAR(레포가 isDeleted=false 필터로 빈 결과 반환)는 멱등하게 STAR_NOT_FOUND")
+        void should_throwStarNotFound_when_alreadyDeleted() {
+            // given — 두 번째 삭제 호출 가정: 레포의 findByIdWithScrum이 isDeleted=false 필터로 Optional.empty 반환
+            given(starRecordRepositoryPort.findByIdWithScrum(STAR_ID)).willReturn(Optional.empty());
+
+            // when & then
+            assertThatThrownBy(() -> service.deleteStar(new DeleteStarCommand(USER_ID, STAR_ID)))
+                    .isInstanceOf(BusinessException.class)
+                    .extracting("errorCode")
+                    .isEqualTo(ErrorCode.STAR_NOT_FOUND);
+            verify(starRecordRepositoryPort, never()).softDeleteById(anyLong());
+            verify(scrumWritePort, never()).clearHasStar(anyLong());
+        }
+    }
+
+    // ============== helpers ==============
+
+    private static StarRecord star(Long id, Long ownerUserId, Long scrumId) {
+        StarRecord star = new StarRecord();
+        ReflectionTestUtils.setField(star, "id", id);
+        ReflectionTestUtils.setField(star, "user", user(ownerUserId));
+        ReflectionTestUtils.setField(star, "scrum", scrum(scrumId));
+        return star;
+    }
+
+    private static User user(Long id) {
+        // User no-args ctor가 PROTECTED라 reflection으로 인스턴스화
+        try {
+            Constructor<User> ctor = User.class.getDeclaredConstructor();
+            ctor.setAccessible(true);
+            User user = ctor.newInstance();
+            ReflectionTestUtils.setField(user, "id", id);
+            return user;
+        } catch (ReflectiveOperationException e) {
+            throw new IllegalStateException(e);
+        }
+    }
+
+    private static Scrum scrum(Long id) {
+        Scrum scrum = new Scrum();
+        ReflectionTestUtils.setField(scrum, "id", id);
+        return scrum;
+    }
+}

--- a/src/test/java/com/groute/groute_server/record/application/service/StarRecordQueryServiceTest.java
+++ b/src/test/java/com/groute/groute_server/record/application/service/StarRecordQueryServiceTest.java
@@ -1,0 +1,228 @@
+package com.groute.groute_server.record.application.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import com.groute.groute_server.common.exception.BusinessException;
+import com.groute.groute_server.common.exception.ErrorCode;
+import com.groute.groute_server.record.application.port.in.star.GetStarDetailQuery;
+import com.groute.groute_server.record.application.port.in.star.StarDetailView;
+import com.groute.groute_server.record.application.port.out.star.StarImageQueryPort;
+import com.groute.groute_server.record.application.port.out.star.StarRecordRepositoryPort;
+import com.groute.groute_server.record.application.port.out.star.StarTagQueryPort;
+import com.groute.groute_server.record.domain.Project;
+import com.groute.groute_server.record.domain.Scrum;
+import com.groute.groute_server.record.domain.ScrumTitle;
+import com.groute.groute_server.record.domain.StarImage;
+import com.groute.groute_server.record.domain.StarRecord;
+import com.groute.groute_server.record.domain.StarTag;
+import com.groute.groute_server.record.domain.enums.CompetencyCategory;
+import com.groute.groute_server.user.entity.User;
+
+@ExtendWith(MockitoExtension.class)
+class StarRecordQueryServiceTest {
+
+    private static final Long USER_ID = 1L;
+    private static final Long OTHER_USER_ID = 99L;
+    private static final Long STAR_ID = 10L;
+
+    @Mock StarRecordRepositoryPort starRecordRepositoryPort;
+    @Mock StarTagQueryPort starTagQueryPort;
+    @Mock StarImageQueryPort starImageQueryPort;
+
+    @InjectMocks StarRecordQueryService service;
+
+    @Nested
+    @DisplayName("정상 조회")
+    class HappyPath {
+
+        @Test
+        @DisplayName("이미지·태그가 모두 있을 때 flat schema로 매핑한다")
+        void should_returnFullView_when_tagsAndImagesExist() {
+            // given
+            StarRecord star = star(STAR_ID, USER_ID, "ST", "A", "R");
+            given(starRecordRepositoryPort.findByIdWithScrum(STAR_ID))
+                    .willReturn(Optional.of(star));
+            given(starTagQueryPort.findAllByStarRecordId(STAR_ID))
+                    .willReturn(
+                            List.of(
+                                    tag(CompetencyCategory.PLANNING_EXECUTION, "UX 설계"),
+                                    tag(CompetencyCategory.PLANNING_EXECUTION, "품질 관리")));
+            given(starImageQueryPort.findAllByStarRecordIdOrderBySortOrder(STAR_ID))
+                    .willReturn(
+                            List.of(
+                                    image(100L, "https://a", (short) 0),
+                                    image(101L, "https://b", (short) 1)));
+
+            // when
+            StarDetailView view = service.getStarDetail(new GetStarDetailQuery(USER_ID, STAR_ID));
+
+            // then
+            assertThat(view.starRecordId()).isEqualTo(STAR_ID);
+            assertThat(view.projectTag()).isEqualTo("밋업 프로젝트");
+            assertThat(view.freeText()).isEqualTo("기획 작업");
+            assertThat(view.primaryCategory()).isEqualTo("PLANNING_EXECUTION");
+            assertThat(view.detailTags()).containsExactly("UX 설계", "품질 관리");
+            assertThat(view.situationTask()).isEqualTo("ST");
+            assertThat(view.action()).isEqualTo("A");
+            assertThat(view.result()).isEqualTo("R");
+            assertThat(view.images())
+                    .extracting(
+                            StarDetailView.ImageView::imageId, StarDetailView.ImageView::sortOrder)
+                    .containsExactly(
+                            org.assertj.core.groups.Tuple.tuple(100L, 0),
+                            org.assertj.core.groups.Tuple.tuple(101L, 1));
+        }
+    }
+
+    @Nested
+    @DisplayName("빈 컬렉션 처리")
+    class EmptyCollections {
+
+        @Test
+        @DisplayName("이미지가 없으면 빈 배열을 반환한다")
+        void should_returnEmptyImages_when_noImages() {
+            // given
+            StarRecord star = star(STAR_ID, USER_ID, "ST", "A", "R");
+            given(starRecordRepositoryPort.findByIdWithScrum(STAR_ID))
+                    .willReturn(Optional.of(star));
+            given(starTagQueryPort.findAllByStarRecordId(STAR_ID))
+                    .willReturn(List.of(tag(CompetencyCategory.COLLABORATION, "조율")));
+            given(starImageQueryPort.findAllByStarRecordIdOrderBySortOrder(STAR_ID))
+                    .willReturn(List.of());
+
+            // when
+            StarDetailView view = service.getStarDetail(new GetStarDetailQuery(USER_ID, STAR_ID));
+
+            // then
+            assertThat(view.images()).isEmpty();
+        }
+
+        @Test
+        @DisplayName("태그가 없으면 detailTags 빈 배열·primaryCategory null을 반환한다")
+        void should_returnEmptyTagsAndNullPrimary_when_noTags() {
+            // given
+            StarRecord star = star(STAR_ID, USER_ID, "ST", "A", "R");
+            given(starRecordRepositoryPort.findByIdWithScrum(STAR_ID))
+                    .willReturn(Optional.of(star));
+            given(starTagQueryPort.findAllByStarRecordId(STAR_ID)).willReturn(List.of());
+            given(starImageQueryPort.findAllByStarRecordIdOrderBySortOrder(STAR_ID))
+                    .willReturn(List.of());
+
+            // when
+            StarDetailView view = service.getStarDetail(new GetStarDetailQuery(USER_ID, STAR_ID));
+
+            // then
+            assertThat(view.detailTags()).isEmpty();
+            assertThat(view.primaryCategory()).isNull();
+        }
+    }
+
+    @Nested
+    @DisplayName("예외")
+    class Errors {
+
+        @Test
+        @DisplayName("미존재 또는 이미 삭제된 STAR면 STAR_NOT_FOUND를 던진다")
+        void should_throwStarNotFound_when_missing() {
+            // given
+            given(starRecordRepositoryPort.findByIdWithScrum(STAR_ID)).willReturn(Optional.empty());
+
+            // when & then
+            assertThatThrownBy(
+                            () -> service.getStarDetail(new GetStarDetailQuery(USER_ID, STAR_ID)))
+                    .isInstanceOf(BusinessException.class)
+                    .extracting("errorCode")
+                    .isEqualTo(ErrorCode.STAR_NOT_FOUND);
+        }
+
+        @Test
+        @DisplayName("타 유저의 STAR면 STAR_FORBIDDEN을 던진다")
+        void should_throwStarForbidden_when_otherUser() {
+            // given — STAR는 OTHER_USER_ID 소유, 요청은 USER_ID
+            StarRecord star = star(STAR_ID, OTHER_USER_ID, "ST", "A", "R");
+            given(starRecordRepositoryPort.findByIdWithScrum(STAR_ID))
+                    .willReturn(Optional.of(star));
+
+            // when & then
+            assertThatThrownBy(
+                            () -> service.getStarDetail(new GetStarDetailQuery(USER_ID, STAR_ID)))
+                    .isInstanceOf(BusinessException.class)
+                    .extracting("errorCode")
+                    .isEqualTo(ErrorCode.STAR_FORBIDDEN);
+        }
+    }
+
+    // ============== helpers ==============
+
+    private static StarRecord star(
+            Long id, Long ownerUserId, String situationTask, String action, String result) {
+        StarRecord star = new StarRecord();
+        ReflectionTestUtils.setField(star, "id", id);
+        ReflectionTestUtils.setField(star, "user", user(ownerUserId));
+        ReflectionTestUtils.setField(star, "scrum", scrum(50L));
+        ReflectionTestUtils.setField(star, "situationTask", situationTask);
+        ReflectionTestUtils.setField(star, "action", action);
+        ReflectionTestUtils.setField(star, "result", result);
+        return star;
+    }
+
+    private static User user(Long id) {
+        // User no-args ctor가 PROTECTED라 reflection으로 인스턴스화
+        try {
+            java.lang.reflect.Constructor<User> ctor = User.class.getDeclaredConstructor();
+            ctor.setAccessible(true);
+            User user = ctor.newInstance();
+            ReflectionTestUtils.setField(user, "id", id);
+            return user;
+        } catch (ReflectiveOperationException e) {
+            throw new IllegalStateException(e);
+        }
+    }
+
+    private static Scrum scrum(Long id) {
+        Scrum scrum = new Scrum();
+        ReflectionTestUtils.setField(scrum, "id", id);
+        ReflectionTestUtils.setField(scrum, "title", title());
+        return scrum;
+    }
+
+    private static ScrumTitle title() {
+        Project project = new Project();
+        ReflectionTestUtils.setField(project, "id", 1L);
+        ReflectionTestUtils.setField(project, "name", "밋업 프로젝트");
+        ScrumTitle title = new ScrumTitle();
+        ReflectionTestUtils.setField(title, "id", 5L);
+        ReflectionTestUtils.setField(title, "project", project);
+        ReflectionTestUtils.setField(title, "freeText", "기획 작업");
+        return title;
+    }
+
+    private static StarTag tag(CompetencyCategory primary, String detail) {
+        StarTag tag = new StarTag();
+        ReflectionTestUtils.setField(tag, "primaryCategory", primary);
+        ReflectionTestUtils.setField(tag, "detailTag", detail);
+        return tag;
+    }
+
+    private static StarImage image(Long id, String url, short sortOrder) {
+        StarImage image = new StarImage();
+        ReflectionTestUtils.setField(image, "id", id);
+        ReflectionTestUtils.setField(image, "imageUrl", url);
+        ReflectionTestUtils.setField(image, "sortOrder", sortOrder);
+        return image;
+    }
+}


### PR DESCRIPTION
## 요약
- 캘린더 일자 상세에서 STAR 작성된 항목 클릭 시 진입하는 심화기록 세부 페이지(CAL-003)에 데이터를 제공하고, 단독 삭제 API를 추가한다.

## 변경 사항
- [x] 기능 — `GET /api/star-records/{starRecordId}` (상세 조회), `DELETE /api/star-records/{starRecordId}` (단독 삭제)
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 문서
- [x] 테스트 — `StarRecordQueryServiceTest` 5케이스 / `StarRecordDeleteServiceTest` 4케이스
- [ ] 기타

## 테스트
- [x] 로컬 테스트 완료
- 테스트 방법:
    - `./gradlew check` (전체 단위 테스트 + jacoco 60% 검증 통과)
    - 단위 테스트 케이스
        - `StarRecordQueryServiceTest`: 정상 조회 / 이미지 빈 배열 / 태그 빈 배열(primaryCategory null) / 미존재(404) / 타 유저(403)
        - `StarRecordDeleteServiceTest`: 정상 삭제(STAR soft-delete + Scrum.hasStar=false) / 미존재(404) / 타 유저(403) / 멱등성(이미 삭제된 경우 404)

### 커버리지 (JaCoCo)
- 라인 커버리지: 85% (기준: 60% 이상)
- [x] `./gradlew test` 실행 후 `build/reports/jacoco/index.html`에서 수치 확인
- (선택) 리포트 스크린샷 또는 60% 미달/특이사항 공유:
    - `record.application.service` 패키지 라인 100% (StarRecordQueryService / StarRecordDeleteService 모두)

## 스크린샷/로그 (선택)
- X

## 롤백/리스크
- ⚠️ **Stacked PR 안내**:
    - 본 PR은 **base가 `dev`가 아닌 `feat/GRT-74-scrum-crud`** 입니다.
    - 사유: `ErrorCode`의 `RECORD_006/007`이 GRT-74에서 추가되는 `RECORD_001~005` 블록 위에 쌓임. dev에 GRT-74 머지 전이라 base 분리 불가.
    - **머지 순서**: GRT-74 PR이 먼저 dev에 머지되어야 하며, 이후 GitHub에서 본 PR의 base를 자동(또는 수동)으로 `dev`로 갱신 후 머지.
    - GRT-74 보다 먼저 머지 불가능
- 리스크 포인트:
    - **STAR 단독 삭제 시 `StarTag`/`StarImage`는 자체 soft-delete 필드가 없어 별도 cascade 처리하지 않음 — 부모(`StarRecord`) `isDeleted=true` 마킹 후 후속 JOIN 필터로 자연 차단되는 정책으로 정리. 향후 hard delete 필요 시 별도 이슈.**
- 롤백 방법:
    - 머지 직후라면 GitHub PR Revert로 일괄 되돌림.
    - DB 마이그레이션 없음 → 스키마 롤백 불필요.

## 관련 이슈
Closes #71

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 심화기록 상세 조회 추가 — 프로젝트 태그, 역량 태그, 상황/과제/행동/결과, 첨부 이미지 포함
  * 심화기록 단일 삭제 추가 — 소유권 검증 및 연관 스크럼 상태 동기화 포함
  * 조회/삭제 관련 404(찾을 수 없음) 및 403(접근 금지) 응답 처리 추가

* **Tests**
  * 조회·삭제 서비스 단위 테스트 및 동기화 관련 테스트 보강 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->