### PR TITLE
ci: GitHub Actions Docker 레이어 캐시 활성화로 CI 빌드 속도 개선 (#76)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,9 +35,18 @@ jobs:
       - name: Build with Gradle
         run: ./gradlew build -x test
 
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
       - name: Docker 이미지 빌드 검증 (PR용)
         if: github.event_name == 'pull_request'
-        run: docker build -t test-image .
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: false
+          tags: test-image:latest
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
 
       - name: Set Role ARN by branch
         if: github.event_name == 'push'
@@ -62,14 +71,13 @@ jobs:
 
       - name: Build and Push Docker image
         if: github.event_name == 'push'
-        env:
-          ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
-          ECR_REPOSITORY: groute-ecr
-          IMAGE_TAG: sha-${{ github.sha }}
-        run: |
-          docker build -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG .
-          docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
-          echo "Pushed → $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG"
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.login-ecr.outputs.registry }}/groute-ecr:sha-${{ github.sha }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
 
       - name: docker-compose.yml을 S3에 업로드
         if: github.event_name == 'push'

--- a/.gitignore
+++ b/.gitignore
@@ -64,4 +64,5 @@ application-secret.properties
 # OMC
 .omc/
 
-.claude
+# Claude Code
+.claude/


### PR DESCRIPTION
## 요약
- Docker 빌드 시 apt-get이 매번 새로 실행돼 15분+ 걸리던 CI를 GHA 레이어 캐시로 단축

## 변경 사항
- [ ] 기능
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 문서
- [ ] 테스트
- [x] 기타

## 테스트
- [ ] 로컬 테스트 완료
- 테스트 방법:
    - PR CI 실행 후 Docker 빌드 스텝 시간 확인

## 롤백/리스크
- 롤백 방법:  `ci.yml`을 이전 커밋으로 되돌리기

## 관련 이슈
Closes #76 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Chores
* Docker 빌드 워크플로우를 최신 표준으로 개선하여 Buildx 및 캐시를 활용하도록 최적화했습니다 (PR 검증용과 릴리즈 푸시용 동작 분리, 이미지 태깅 포함).
* 개발 환경 설정을 업데이트하고 .claude 디렉터리를 무시하도록 .gitignore에 항목을 추가했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->