### PR TITLE
fix: 소셜 로그인 redirect URI 및 토큰 전달 방식 설정 (#82)

### DIFF
--- a/src/main/java/com/groute/groute_server/auth/config/AuthProperties.java
+++ b/src/main/java/com/groute/groute_server/auth/config/AuthProperties.java
@@ -14,9 +14,17 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
  *
  * <p>Secure 쿠키는 HTTPS 연결에서만 전송되므로, 로컬 HTTP 환경에서 쿠키 방식을 켜면 refresh가 전혀 흐르지 않는다. 이 분기는 그 실수를 피하기 위한
  * 것.
+ *
+ * <p>{@code frontCallbackUrl}은 OAuth2 로그인 완료 후 리다이렉트할 프론트엔드 콜백 URL이다. 환경별로 다음 값을 사용하며, stg/prod는
+ * SSM에서 {@code AUTH_FRONT_CALLBACK_URL} 키로 주입한다(누락 시 부팅 실패로 설정 오류 즉시 노출).
+ *
+ * <ul>
+ *   <li>로컬: {@code http://localhost:3000/auth/callback}
+ *   <li>운영: {@code https://glit.today/auth/callback}
+ * </ul>
  */
 @ConfigurationProperties(prefix = "auth")
-public record AuthProperties(RefreshToken refreshToken) {
+public record AuthProperties(RefreshToken refreshToken, String frontCallbackUrl) {
 
     public record RefreshToken(boolean cookieEnabled) {}
 }

--- a/src/main/java/com/groute/groute_server/auth/config/AuthProperties.java
+++ b/src/main/java/com/groute/groute_server/auth/config/AuthProperties.java
@@ -1,5 +1,7 @@
 package com.groute.groute_server.auth.config;
 
+import java.util.Map;
+
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
 /**
@@ -15,16 +17,48 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
  * <p>Secure 쿠키는 HTTPS 연결에서만 전송되므로, 로컬 HTTP 환경에서 쿠키 방식을 켜면 refresh가 전혀 흐르지 않는다. 이 분기는 그 실수를 피하기 위한
  * 것.
  *
- * <p>{@code frontCallbackUrl}은 OAuth2 로그인 완료 후 리다이렉트할 프론트엔드 콜백 URL이다. 환경별로 다음 값을 사용하며, stg/prod는
- * SSM에서 {@code AUTH_FRONT_CALLBACK_URL} 키로 주입한다(누락 시 부팅 실패로 설정 오류 즉시 노출).
+ * <p>{@code callback}은 OAuth2 로그인 완료 후 redirect할 프론트엔드 콜백 URL을 환경(env) 키 → URL로 매핑한다. key는 프론트가
+ * OAuth2 시작 시 보내는 {@code ?env=...} 값과 일치해야 한다(예: {@code local}, {@code production}). 환경별로 등록되는 key는
+ * 다음과 같다.
  *
  * <ul>
- *   <li>로컬: {@code http://localhost:3000/auth/callback}
- *   <li>운영: {@code https://glit.today/auth/callback}
+ *   <li>local 프로파일: {@code local} (개발자 PC 프론트)
+ *   <li>stg 프로파일: {@code local}, {@code production} (둘 다 허용)
+ *   <li>prod 프로파일: {@code production} (운영 프론트만 허용)
+ * </ul>
+ *
+ * <p>{@code defaultEnv}는 프론트가 env를 전달하지 않거나 등록되지 않은 값을 보냈을 때 fallback으로 사용할 env key. stg/prod는 SSM
+ * {@code AUTH_DEFAULT_ENV}로 주입(누락 시 부팅 실패).
+ *
+ * <p>SSM 키 (stg/prod):
+ *
+ * <ul>
+ *   <li>{@code AUTH_CALLBACK_LOCAL} — local env URL (stg에만)
+ *   <li>{@code AUTH_CALLBACK_PRODUCTION} — production env URL
+ *   <li>{@code AUTH_DEFAULT_ENV} — fallback env key
  * </ul>
  */
 @ConfigurationProperties(prefix = "auth")
-public record AuthProperties(RefreshToken refreshToken, String frontCallbackUrl) {
+public record AuthProperties(
+        RefreshToken refreshToken, Map<String, String> callback, String defaultEnv) {
 
     public record RefreshToken(boolean cookieEnabled) {}
+
+    /** 등록된 env에 매핑된 콜백 URL. 미등록 env면 {@code null}. */
+    public String callbackUrlFor(String env) {
+        return callback.get(env);
+    }
+
+    /** {@link #defaultEnv}에 매핑된 콜백 URL. 설정 정합성이 깨졌으면(매핑 없음) 부팅 단계에서 노출되도록 즉시 예외. */
+    public String defaultCallbackUrl() {
+        String url = callback.get(defaultEnv);
+        if (url == null) {
+            throw new IllegalStateException(
+                    "auth.default-env='"
+                            + defaultEnv
+                            + "' is not present in auth.callback keys "
+                            + callback.keySet());
+        }
+        return url;
+    }
 }

--- a/src/main/java/com/groute/groute_server/auth/config/AuthProperties.java
+++ b/src/main/java/com/groute/groute_server/auth/config/AuthProperties.java
@@ -42,6 +42,26 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 public record AuthProperties(
         RefreshToken refreshToken, Map<String, String> callback, String defaultEnv) {
 
+    /**
+     * Compact ctor — 부팅 단계 fail-fast. callback이 비어 있거나 defaultEnv가 매핑되지 않은 설정은 환경별 yaml/SSM 주입
+     * 누락이므로 트래픽 들어오기 전에 즉시 노출시킨다. (런타임 첫 호출까지 늦추면 설정 사고가 배포 후에 드러남)
+     */
+    public AuthProperties {
+        if (callback == null || callback.isEmpty()) {
+            throw new IllegalStateException("auth.callback must not be empty");
+        }
+        if (defaultEnv == null || defaultEnv.isBlank()) {
+            throw new IllegalStateException("auth.default-env must not be blank");
+        }
+        if (!callback.containsKey(defaultEnv)) {
+            throw new IllegalStateException(
+                    "auth.default-env='"
+                            + defaultEnv
+                            + "' is not present in auth.callback keys "
+                            + callback.keySet());
+        }
+    }
+
     public record RefreshToken(boolean cookieEnabled) {}
 
     /** 등록된 env에 매핑된 콜백 URL. 미등록 env면 {@code null}. */
@@ -49,16 +69,8 @@ public record AuthProperties(
         return callback.get(env);
     }
 
-    /** {@link #defaultEnv}에 매핑된 콜백 URL. 설정 정합성이 깨졌으면(매핑 없음) 부팅 단계에서 노출되도록 즉시 예외. */
+    /** {@link #defaultEnv}에 매핑된 콜백 URL. ctor에서 매핑 존재가 보장되므로 단순 조회. */
     public String defaultCallbackUrl() {
-        String url = callback.get(defaultEnv);
-        if (url == null) {
-            throw new IllegalStateException(
-                    "auth.default-env='"
-                            + defaultEnv
-                            + "' is not present in auth.callback keys "
-                            + callback.keySet());
-        }
-        return url;
+        return callback.get(defaultEnv);
     }
 }

--- a/src/main/java/com/groute/groute_server/auth/config/OAuth2SecurityConfig.java
+++ b/src/main/java/com/groute/groute_server/auth/config/OAuth2SecurityConfig.java
@@ -4,10 +4,13 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.annotation.Order;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository;
+import org.springframework.security.oauth2.client.web.OAuth2AuthorizationRequestResolver;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.web.cors.CorsConfigurationSource;
 
 import com.groute.groute_server.auth.service.oauth.CustomOAuth2UserService;
+import com.groute.groute_server.auth.service.oauth.OAuth2EnvAwareAuthorizationRequestResolver;
 import com.groute.groute_server.auth.service.oauth.OAuth2LoginFailureHandler;
 import com.groute.groute_server.auth.service.oauth.OAuth2LoginSuccessHandler;
 
@@ -20,6 +23,9 @@ import lombok.RequiredArgsConstructor;
  * 교환·user-info 정규화는 {@link CustomOAuth2UserService}가, JWT 발급·응답은 {@link OAuth2LoginSuccessHandler}가
  * 담당한다. JWT 필터는 이 체인에 등록하지 않는다 — OAuth2 플로우 경로는 JWT 인증이 필요 없다.
  *
+ * <p>프론트 시작 origin(env)은 {@link OAuth2EnvAwareAuthorizationRequestResolver}가 OAuth2 시작 시점에 쿠키로
+ * 보존한다. SuccessHandler가 그 쿠키를 사용해 어떤 콜백 URL로 redirect할지 결정한다.
+ *
  * <p>공통 JWT 체인은 {@code common/config/SecurityConfig} (@Order(2))가 담당한다.
  */
 @Configuration
@@ -30,10 +36,21 @@ public class OAuth2SecurityConfig {
     private final OAuth2LoginSuccessHandler oAuth2LoginSuccessHandler;
     private final OAuth2LoginFailureHandler oAuth2LoginFailureHandler;
     private final CorsConfigurationSource corsConfigurationSource;
+    private final AuthProperties authProperties;
+
+    @Bean
+    public OAuth2AuthorizationRequestResolver oAuth2AuthorizationRequestResolver(
+            ClientRegistrationRepository clientRegistrationRepository) {
+        return new OAuth2EnvAwareAuthorizationRequestResolver(
+                clientRegistrationRepository, authProperties);
+    }
 
     @Bean
     @Order(1)
-    public SecurityFilterChain oauth2FilterChain(HttpSecurity http) throws Exception {
+    public SecurityFilterChain oauth2FilterChain(
+            HttpSecurity http,
+            OAuth2AuthorizationRequestResolver oAuth2AuthorizationRequestResolver)
+            throws Exception {
         http.securityMatcher("/oauth2/**", "/login/oauth2/code/**")
                 .csrf(csrf -> csrf.disable())
                 .cors(cors -> cors.configurationSource(corsConfigurationSource))
@@ -42,7 +59,11 @@ public class OAuth2SecurityConfig {
                 .authorizeHttpRequests(auth -> auth.anyRequest().permitAll())
                 .oauth2Login(
                         oauth2 ->
-                                oauth2.userInfoEndpoint(
+                                oauth2.authorizationEndpoint(
+                                                endpoint ->
+                                                        endpoint.authorizationRequestResolver(
+                                                                oAuth2AuthorizationRequestResolver))
+                                        .userInfoEndpoint(
                                                 userInfo ->
                                                         userInfo.userService(
                                                                 customOAuth2UserService))

--- a/src/main/java/com/groute/groute_server/auth/service/oauth/OAuth2EnvAwareAuthorizationRequestResolver.java
+++ b/src/main/java/com/groute/groute_server/auth/service/oauth/OAuth2EnvAwareAuthorizationRequestResolver.java
@@ -1,0 +1,104 @@
+package com.groute.groute_server.auth.service.oauth;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseCookie;
+import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository;
+import org.springframework.security.oauth2.client.web.DefaultOAuth2AuthorizationRequestResolver;
+import org.springframework.security.oauth2.client.web.OAuth2AuthorizationRequestResolver;
+import org.springframework.security.oauth2.core.endpoint.OAuth2AuthorizationRequest;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
+
+import com.groute.groute_server.auth.config.AuthProperties;
+
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * OAuth2 시작 시 프론트 시작 origin(env)을 짧은 수명 쿠키로 보존한다.
+ *
+ * <p>프론트가 {@code GET /oauth2/authorization/{provider}?env=local|production}으로 호출하면, 이 resolver가 env
+ * 값을 {@link AuthProperties#callback()} 화이트리스트와 매칭해 쿠키 {@code oauth_env}로 저장한다. 이후 provider redirect
+ * → callback → {@code OAuth2LoginSuccessHandler}가 쿠키에서 env를 추출해 적절한 콜백 URL을 선택한다(후속 작업 C).
+ *
+ * <p>env 값이 누락되거나 화이트리스트에 없으면 쿠키를 설정하지 않으며 SuccessHandler가 default env로 fallback한다.
+ *
+ * <p><b>SameSite=Lax 선택 이유</b>: OAuth2 provider에서 우리 도메인으로 돌아오는 redirect는 cross-site top-level
+ * navigation이다. {@code Strict}는 그 케이스에 쿠키를 전송하지 않으므로, OAuth2 round-trip을 살리려면 {@code Lax}가 적정.
+ *
+ * <p><b>Secure 플래그</b>: {@link HttpServletRequest#isSecure()} 결과를 따른다. 로컬 HTTP에서는 false (브라우저가
+ * secure 쿠키를 거부하지 않게), HTTPS 환경(stg/prod)에서는 true.
+ */
+@Slf4j
+public class OAuth2EnvAwareAuthorizationRequestResolver
+        implements OAuth2AuthorizationRequestResolver {
+
+    static final String ENV_COOKIE_NAME = "oauth_env";
+    static final String ENV_QUERY_PARAM = "env";
+    static final int COOKIE_MAX_AGE_SECONDS = 300;
+
+    private final OAuth2AuthorizationRequestResolver delegate;
+    private final AuthProperties authProperties;
+
+    public OAuth2EnvAwareAuthorizationRequestResolver(
+            ClientRegistrationRepository clientRegistrationRepository,
+            AuthProperties authProperties) {
+        this.delegate =
+                new DefaultOAuth2AuthorizationRequestResolver(
+                        clientRegistrationRepository, "/oauth2/authorization");
+        this.authProperties = authProperties;
+    }
+
+    @Override
+    public OAuth2AuthorizationRequest resolve(HttpServletRequest request) {
+        OAuth2AuthorizationRequest result = delegate.resolve(request);
+        if (result != null) {
+            captureEnvCookie(request);
+        }
+        return result;
+    }
+
+    @Override
+    public OAuth2AuthorizationRequest resolve(
+            HttpServletRequest request, String clientRegistrationId) {
+        OAuth2AuthorizationRequest result = delegate.resolve(request, clientRegistrationId);
+        if (result != null) {
+            captureEnvCookie(request);
+        }
+        return result;
+    }
+
+    private void captureEnvCookie(HttpServletRequest request) {
+        String env = request.getParameter(ENV_QUERY_PARAM);
+        if (env == null || env.isBlank()) {
+            return;
+        }
+        if (!authProperties.callback().containsKey(env)) {
+            log.warn("OAuth2 시작에서 미등록 env 수신, 쿠키 설정 스킵: env={}", env);
+            return;
+        }
+        HttpServletResponse response = currentResponse();
+        if (response == null) {
+            return;
+        }
+
+        ResponseCookie cookie =
+                ResponseCookie.from(ENV_COOKIE_NAME, env)
+                        .httpOnly(true)
+                        .secure(request.isSecure())
+                        .sameSite("Lax")
+                        .path("/")
+                        .maxAge(COOKIE_MAX_AGE_SECONDS)
+                        .build();
+        response.addHeader(HttpHeaders.SET_COOKIE, cookie.toString());
+    }
+
+    private static HttpServletResponse currentResponse() {
+        if (RequestContextHolder.getRequestAttributes() instanceof ServletRequestAttributes attrs) {
+            return attrs.getResponse();
+        }
+        return null;
+    }
+}

--- a/src/main/java/com/groute/groute_server/auth/service/oauth/OAuth2LoginFailureHandler.java
+++ b/src/main/java/com/groute/groute_server/auth/service/oauth/OAuth2LoginFailureHandler.java
@@ -1,39 +1,41 @@
 package com.groute.groute_server.auth.service.oauth;
 
 import java.io.IOException;
+import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 
-import org.springframework.http.MediaType;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.web.authentication.AuthenticationFailureHandler;
 import org.springframework.stereotype.Component;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.groute.groute_server.common.exception.BusinessException;
 import com.groute.groute_server.common.exception.ErrorCode;
-import com.groute.groute_server.common.response.ErrorResponse;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
 /**
- * OAuth2 로그인 실패(사용자 취소·scope 거부·provider 오류·정규화 예외 등)를 일관된 JSON 에러 응답으로 변환.
+ * OAuth2 로그인 실패(사용자 취소·scope 거부·provider 오류·정규화 예외 등)를 프론트 콜백 URL로 redirect하여 일관된 UX를 제공.
  *
- * <p>기본 스프링 동작은 {@code /login?error}로 302 리다이렉트라 API 클라이언트 입장에서는 HTML이 내려와 혼란스러워진다.
+ * <p>성공 흐름과 동일한 콜백 URL을 사용하되, query에 {@code ?error=<ErrorCode>}를 붙여 프론트가 분기 처리할 수 있게 한다. 콜백 URL은
+ * {@link OAuthCallbackUrlResolver}가 {@code oauth_env} 쿠키 기반으로 결정하며 사용 후 즉시 만료한다.
  *
- * <p>{@link CustomOAuth2UserService}가 {@link BusinessException}을 {@link
- * OAuth2AuthenticationException}의 cause로 감싸 던지기 때문에, 원인 체인에서 {@link BusinessException}을 찾아 해당
- * {@link ErrorCode}를 응답으로 반영한다. 없으면 기본 {@link ErrorCode#UNAUTHORIZED}.
+ * <p>{@code CustomOAuth2UserService}가 {@link BusinessException}을 {@link
+ * org.springframework.security.oauth2.core.OAuth2AuthenticationException}의 cause로 감싸 던지므로, 원인 체인에서
+ * {@link BusinessException}을 찾아 해당 {@link ErrorCode}를 query에 반영한다. 없으면 기본 {@link
+ * ErrorCode#UNAUTHORIZED}.
+ *
+ * <p><b>응답 본문 미사용</b>: 사용자 메시지는 query에 노출하지 않는다(인코딩·정보 노출 부담). code만 전달하고 상세 사유는 서버 로그에 남긴다.
  */
 @Slf4j
 @Component
 @RequiredArgsConstructor
 public class OAuth2LoginFailureHandler implements AuthenticationFailureHandler {
 
-    private final ObjectMapper objectMapper;
+    private final OAuthCallbackUrlResolver oAuthCallbackUrlResolver;
 
     @Override
     public void onAuthenticationFailure(
@@ -42,11 +44,24 @@ public class OAuth2LoginFailureHandler implements AuthenticationFailureHandler {
             AuthenticationException exception)
             throws IOException {
         ErrorCode errorCode = resolveErrorCode(exception);
-        log.warn("OAuth2 로그인 실패: code={}, message={}", errorCode.getCode(), exception.getMessage());
-        response.setStatus(errorCode.getHttpStatus().value());
-        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
-        response.setCharacterEncoding(StandardCharsets.UTF_8.name());
-        objectMapper.writeValue(response.getWriter(), ErrorResponse.of(errorCode));
+        String callbackUrl = oAuthCallbackUrlResolver.resolveAndExpire(request, response);
+        String redirectUrl = buildErrorRedirectUrl(callbackUrl, errorCode.getCode());
+
+        log.warn(
+                "OAuth2 로그인 실패: code={}, message={}, callback={}",
+                errorCode.getCode(),
+                exception.getMessage(),
+                callbackUrl);
+        response.sendRedirect(redirectUrl);
+    }
+
+    private static String buildErrorRedirectUrl(String callbackUrl, String errorCode) {
+        // 콜백 URL이 이미 query를 포함하면 `&`로 이어 붙여 URL이 깨지지 않게 한다.
+        String separator = callbackUrl.contains("?") ? "&" : "?";
+        return callbackUrl
+                + separator
+                + "error="
+                + URLEncoder.encode(errorCode, StandardCharsets.UTF_8);
     }
 
     private ErrorCode resolveErrorCode(AuthenticationException exception) {

--- a/src/main/java/com/groute/groute_server/auth/service/oauth/OAuth2LoginSuccessHandler.java
+++ b/src/main/java/com/groute/groute_server/auth/service/oauth/OAuth2LoginSuccessHandler.java
@@ -4,13 +4,10 @@ import java.io.IOException;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 
-import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.servlet.http.HttpSession;
 
-import org.springframework.http.HttpHeaders;
-import org.springframework.http.ResponseCookie;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
 import org.springframework.stereotype.Component;
@@ -32,9 +29,8 @@ import lombok.extern.slf4j.Slf4j;
  * deliver가 이미 Set-Cookie로 refresh를 전달했으므로 query에는 access만 싣는다. 본문 모드(local)에서는 refresh도 query에 함께
  * 실어 프론트가 즉시 사용할 수 있게 한다.
  *
- * <p>리다이렉트 대상 콜백은 {@link OAuth2EnvAwareAuthorizationRequestResolver}가 OAuth2 시작 시 발행한 {@code
- * oauth_env} 쿠키로 결정한다. 쿠키 값이 {@link AuthProperties#callback()} 화이트리스트에 있으면 그 URL로, 없거나 누락되면 default
- * env로 fallback. 사용 후에는 즉시 만료 처리(Max-Age=0)해 round-trip 흔적을 지운다.
+ * <p>리다이렉트 대상 콜백은 {@link OAuthCallbackUrlResolver}에 위임한다. resolver가 {@code oauth_env} 쿠키로 매칭 URL을
+ * 결정하고 사용 후 쿠키를 만료시킨다.
  *
  * <p>인가 코드 교환 중 잠시 사용된 세션은 더 이상 필요 없으므로 redirect 직전에 invalidate하여 서버 상태를 JWT-only로 복귀시킨다.
  *
@@ -52,6 +48,7 @@ public class OAuth2LoginSuccessHandler implements AuthenticationSuccessHandler {
     private final RefreshTokenRepository refreshTokenRepository;
     private final TokenDeliveryService tokenDeliveryService;
     private final AuthProperties authProperties;
+    private final OAuthCallbackUrlResolver oAuthCallbackUrlResolver;
 
     @Override
     public void onAuthenticationSuccess(
@@ -70,7 +67,7 @@ public class OAuth2LoginSuccessHandler implements AuthenticationSuccessHandler {
             throw new IllegalStateException("accessToken must not be null after deliver");
         }
 
-        String callbackUrl = resolveCallbackUrl(request, response);
+        String callbackUrl = oAuthCallbackUrlResolver.resolveAndExpire(request, response);
         // 쿠키 모드(prod)면 deliver가 이미 Set-Cookie로 refresh를 전달했으므로 query에는 싣지 않는다.
         String refreshForQuery =
                 authProperties.refreshToken().cookieEnabled() ? null : refreshToken;
@@ -83,45 +80,6 @@ public class OAuth2LoginSuccessHandler implements AuthenticationSuccessHandler {
                 principal.getProvider(),
                 callbackUrl);
         response.sendRedirect(redirectUrl);
-    }
-
-    private String resolveCallbackUrl(HttpServletRequest request, HttpServletResponse response) {
-        String env = readEnvCookie(request);
-        String url = (env != null) ? authProperties.callbackUrlFor(env) : null;
-        if (url == null) {
-            if (env != null) {
-                log.warn("oauth_env 쿠키 값이 등록되지 않은 env, default로 fallback: env={}", env);
-            }
-            url = authProperties.defaultCallbackUrl();
-        }
-        expireEnvCookie(request, response);
-        return url;
-    }
-
-    private static String readEnvCookie(HttpServletRequest request) {
-        Cookie[] cookies = request.getCookies();
-        if (cookies == null) {
-            return null;
-        }
-        for (Cookie c : cookies) {
-            if (OAuth2EnvAwareAuthorizationRequestResolver.ENV_COOKIE_NAME.equals(c.getName())) {
-                String value = c.getValue();
-                return (value == null || value.isBlank()) ? null : value;
-            }
-        }
-        return null;
-    }
-
-    private static void expireEnvCookie(HttpServletRequest request, HttpServletResponse response) {
-        ResponseCookie cookie =
-                ResponseCookie.from(OAuth2EnvAwareAuthorizationRequestResolver.ENV_COOKIE_NAME, "")
-                        .maxAge(0)
-                        .httpOnly(true)
-                        .secure(request.isSecure())
-                        .sameSite("Lax")
-                        .path("/")
-                        .build();
-        response.addHeader(HttpHeaders.SET_COOKIE, cookie.toString());
     }
 
     private String buildRedirectUrl(String callbackUrl, String accessToken, String refreshToken) {

--- a/src/main/java/com/groute/groute_server/auth/service/oauth/OAuth2LoginSuccessHandler.java
+++ b/src/main/java/com/groute/groute_server/auth/service/oauth/OAuth2LoginSuccessHandler.java
@@ -1,33 +1,39 @@
 package com.groute.groute_server.auth.service.oauth;
 
 import java.io.IOException;
+import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.servlet.http.HttpSession;
 
-import org.springframework.http.HttpStatus;
-import org.springframework.http.MediaType;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
 import org.springframework.stereotype.Component;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
+import com.groute.groute_server.auth.config.AuthProperties;
 import com.groute.groute_server.auth.dto.TokenResponse;
 import com.groute.groute_server.auth.repository.RefreshTokenRepository;
 import com.groute.groute_server.auth.service.TokenDeliveryService;
 import com.groute.groute_server.common.jwt.JwtTokenProvider;
-import com.groute.groute_server.common.response.ApiResponse;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
 /**
- * OAuth2 로그인 성공 시 JWT를 발급하고 클라이언트에 전달.
+ * OAuth2 로그인 성공 시 JWT를 발급하고 프론트엔드 콜백 URL로 302 redirect.
  *
- * <p>access/refresh 발급 → refresh를 Redis에 저장 → {@link TokenDeliveryService}가 설정(쿠키/본문)에 맞게 응답 구성. 인가
- * 코드 교환 중 잠시 사용된 세션은 더 이상 필요 없으므로 명시적으로 invalidate하여 서버 상태를 JWT-only로 복귀시킨다.
+ * <p>access/refresh 발급 → refresh를 Redis에 저장 → {@link TokenDeliveryService}가 설정(쿠키/본문)에 맞게 응답을 구성.
+ * deliver가 반환한 {@link TokenResponse}의 refresh가 null이면 쿠키 모드(prod)로 이미 Set-Cookie 완료된 상태이므로 query에는
+ * refresh를 싣지 않는다. null이 아니면 본문 모드(local)로, refresh도 query에 추가해 프론트가 즉시 사용할 수 있게 한다.
+ *
+ * <p>인가 코드 교환 중 잠시 사용된 세션은 더 이상 필요 없으므로 redirect 직전에 invalidate하여 서버 상태를 JWT-only로 복귀시킨다.
+ *
+ * <p><b>Open redirect 안전성</b>: 콜백 URL은 {@link AuthProperties#frontCallbackUrl()}에서 고정값으로 주입되며 사용자
+ * 입력을 받지 않는다. redirect target은 외부에서 조작할 수 없다.
+ *
+ * <p><b>로깅 정책</b>: 토큰 값은 절대 로깅하지 않는다. userId·provider·callback URL(host+path)만 출력한다.
  */
 @Slf4j
 @Component
@@ -37,7 +43,7 @@ public class OAuth2LoginSuccessHandler implements AuthenticationSuccessHandler {
     private final JwtTokenProvider jwtTokenProvider;
     private final RefreshTokenRepository refreshTokenRepository;
     private final TokenDeliveryService tokenDeliveryService;
-    private final ObjectMapper objectMapper;
+    private final AuthProperties authProperties;
 
     @Override
     public void onAuthenticationSuccess(
@@ -51,17 +57,30 @@ public class OAuth2LoginSuccessHandler implements AuthenticationSuccessHandler {
         refreshTokenRepository.save(userId, refreshToken);
 
         TokenResponse body = tokenDeliveryService.deliver(response, accessToken, refreshToken);
+        if (body.accessToken() == null) {
+            // 정상 흐름에선 도달 불가. deliver 계약 위반에 대한 방어적 가드.
+            throw new IllegalStateException("accessToken must not be null after deliver");
+        }
 
-        writeJson(response, body);
+        String callbackUrl = authProperties.frontCallbackUrl();
+        String redirectUrl = buildRedirectUrl(callbackUrl, body.accessToken(), body.refreshToken());
+
         invalidateSession(request);
-        log.info("OAuth2 로그인 성공: userId={}, provider={}", userId, principal.getProvider());
+        log.info(
+                "OAuth2 로그인 성공: userId={}, provider={}, callback={}",
+                userId,
+                principal.getProvider(),
+                callbackUrl);
+        response.sendRedirect(redirectUrl);
     }
 
-    private void writeJson(HttpServletResponse response, TokenResponse body) throws IOException {
-        response.setStatus(HttpStatus.OK.value());
-        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
-        response.setCharacterEncoding(StandardCharsets.UTF_8.name());
-        objectMapper.writeValue(response.getWriter(), ApiResponse.ok(body));
+    private String buildRedirectUrl(String callbackUrl, String accessToken, String refreshToken) {
+        StringBuilder sb = new StringBuilder(callbackUrl);
+        sb.append("?access=").append(URLEncoder.encode(accessToken, StandardCharsets.UTF_8));
+        if (refreshToken != null) {
+            sb.append("&refresh=").append(URLEncoder.encode(refreshToken, StandardCharsets.UTF_8));
+        }
+        return sb.toString();
     }
 
     private void invalidateSession(HttpServletRequest request) {

--- a/src/main/java/com/groute/groute_server/auth/service/oauth/OAuth2LoginSuccessHandler.java
+++ b/src/main/java/com/groute/groute_server/auth/service/oauth/OAuth2LoginSuccessHandler.java
@@ -31,8 +31,8 @@ import lombok.extern.slf4j.Slf4j;
  *
  * <p>인가 코드 교환 중 잠시 사용된 세션은 더 이상 필요 없으므로 redirect 직전에 invalidate하여 서버 상태를 JWT-only로 복귀시킨다.
  *
- * <p><b>Open redirect 안전성</b>: 콜백 URL은 {@link AuthProperties#frontCallbackUrl()}에서 고정값으로 주입되며 사용자
- * 입력을 받지 않는다. redirect target은 외부에서 조작할 수 없다.
+ * <p><b>Open redirect 안전성</b>: 콜백 URL은 {@link AuthProperties#callback()} 맵의 값에서만 선택되며 사용자 입력 URL을
+ * 그대로 사용하지 않는다. redirect target은 properties로 등록된 URL 집합 외부로는 나갈 수 없다.
  *
  * <p><b>로깅 정책</b>: 토큰 값은 절대 로깅하지 않는다. userId·provider·callback URL(host+path)만 출력한다.
  */
@@ -63,7 +63,8 @@ public class OAuth2LoginSuccessHandler implements AuthenticationSuccessHandler {
             throw new IllegalStateException("accessToken must not be null after deliver");
         }
 
-        String callbackUrl = authProperties.frontCallbackUrl();
+        // env별 분기는 후속 작업(B/C)에서 도입. 현재는 default env 콜백으로만 redirect.
+        String callbackUrl = authProperties.defaultCallbackUrl();
         // 쿠키 모드(prod)면 deliver가 이미 Set-Cookie로 refresh를 전달했으므로 query에는 싣지 않는다.
         String refreshForQuery =
                 authProperties.refreshToken().cookieEnabled() ? null : refreshToken;

--- a/src/main/java/com/groute/groute_server/auth/service/oauth/OAuth2LoginSuccessHandler.java
+++ b/src/main/java/com/groute/groute_server/auth/service/oauth/OAuth2LoginSuccessHandler.java
@@ -75,8 +75,12 @@ public class OAuth2LoginSuccessHandler implements AuthenticationSuccessHandler {
     }
 
     private String buildRedirectUrl(String callbackUrl, String accessToken, String refreshToken) {
+        // 콜백 URL이 이미 query를 포함하면 `&`로 이어 붙여 URL이 깨지지 않게 한다.
+        String separator = callbackUrl.contains("?") ? "&" : "?";
         StringBuilder sb = new StringBuilder(callbackUrl);
-        sb.append("?access=").append(URLEncoder.encode(accessToken, StandardCharsets.UTF_8));
+        sb.append(separator)
+                .append("access=")
+                .append(URLEncoder.encode(accessToken, StandardCharsets.UTF_8));
         if (refreshToken != null) {
             sb.append("&refresh=").append(URLEncoder.encode(refreshToken, StandardCharsets.UTF_8));
         }

--- a/src/main/java/com/groute/groute_server/auth/service/oauth/OAuth2LoginSuccessHandler.java
+++ b/src/main/java/com/groute/groute_server/auth/service/oauth/OAuth2LoginSuccessHandler.java
@@ -4,10 +4,13 @@ import java.io.IOException;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 
+import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.servlet.http.HttpSession;
 
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseCookie;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
 import org.springframework.stereotype.Component;
@@ -28,6 +31,10 @@ import lombok.extern.slf4j.Slf4j;
  * 이후 query 구성은 {@link AuthProperties.RefreshToken#cookieEnabled()} 플래그를 단일 진실로 분기한다. 쿠키 모드(prod)에서는
  * deliver가 이미 Set-Cookie로 refresh를 전달했으므로 query에는 access만 싣는다. 본문 모드(local)에서는 refresh도 query에 함께
  * 실어 프론트가 즉시 사용할 수 있게 한다.
+ *
+ * <p>리다이렉트 대상 콜백은 {@link OAuth2EnvAwareAuthorizationRequestResolver}가 OAuth2 시작 시 발행한 {@code
+ * oauth_env} 쿠키로 결정한다. 쿠키 값이 {@link AuthProperties#callback()} 화이트리스트에 있으면 그 URL로, 없거나 누락되면 default
+ * env로 fallback. 사용 후에는 즉시 만료 처리(Max-Age=0)해 round-trip 흔적을 지운다.
  *
  * <p>인가 코드 교환 중 잠시 사용된 세션은 더 이상 필요 없으므로 redirect 직전에 invalidate하여 서버 상태를 JWT-only로 복귀시킨다.
  *
@@ -63,8 +70,7 @@ public class OAuth2LoginSuccessHandler implements AuthenticationSuccessHandler {
             throw new IllegalStateException("accessToken must not be null after deliver");
         }
 
-        // env별 분기는 후속 작업(B/C)에서 도입. 현재는 default env 콜백으로만 redirect.
-        String callbackUrl = authProperties.defaultCallbackUrl();
+        String callbackUrl = resolveCallbackUrl(request, response);
         // 쿠키 모드(prod)면 deliver가 이미 Set-Cookie로 refresh를 전달했으므로 query에는 싣지 않는다.
         String refreshForQuery =
                 authProperties.refreshToken().cookieEnabled() ? null : refreshToken;
@@ -77,6 +83,45 @@ public class OAuth2LoginSuccessHandler implements AuthenticationSuccessHandler {
                 principal.getProvider(),
                 callbackUrl);
         response.sendRedirect(redirectUrl);
+    }
+
+    private String resolveCallbackUrl(HttpServletRequest request, HttpServletResponse response) {
+        String env = readEnvCookie(request);
+        String url = (env != null) ? authProperties.callbackUrlFor(env) : null;
+        if (url == null) {
+            if (env != null) {
+                log.warn("oauth_env 쿠키 값이 등록되지 않은 env, default로 fallback: env={}", env);
+            }
+            url = authProperties.defaultCallbackUrl();
+        }
+        expireEnvCookie(request, response);
+        return url;
+    }
+
+    private static String readEnvCookie(HttpServletRequest request) {
+        Cookie[] cookies = request.getCookies();
+        if (cookies == null) {
+            return null;
+        }
+        for (Cookie c : cookies) {
+            if (OAuth2EnvAwareAuthorizationRequestResolver.ENV_COOKIE_NAME.equals(c.getName())) {
+                String value = c.getValue();
+                return (value == null || value.isBlank()) ? null : value;
+            }
+        }
+        return null;
+    }
+
+    private static void expireEnvCookie(HttpServletRequest request, HttpServletResponse response) {
+        ResponseCookie cookie =
+                ResponseCookie.from(OAuth2EnvAwareAuthorizationRequestResolver.ENV_COOKIE_NAME, "")
+                        .maxAge(0)
+                        .httpOnly(true)
+                        .secure(request.isSecure())
+                        .sameSite("Lax")
+                        .path("/")
+                        .build();
+        response.addHeader(HttpHeaders.SET_COOKIE, cookie.toString());
     }
 
     private String buildRedirectUrl(String callbackUrl, String accessToken, String refreshToken) {

--- a/src/main/java/com/groute/groute_server/auth/service/oauth/OAuth2LoginSuccessHandler.java
+++ b/src/main/java/com/groute/groute_server/auth/service/oauth/OAuth2LoginSuccessHandler.java
@@ -25,8 +25,9 @@ import lombok.extern.slf4j.Slf4j;
  * OAuth2 로그인 성공 시 JWT를 발급하고 프론트엔드 콜백 URL로 302 redirect.
  *
  * <p>access/refresh 발급 → refresh를 Redis에 저장 → {@link TokenDeliveryService}가 설정(쿠키/본문)에 맞게 응답을 구성.
- * deliver가 반환한 {@link TokenResponse}의 refresh가 null이면 쿠키 모드(prod)로 이미 Set-Cookie 완료된 상태이므로 query에는
- * refresh를 싣지 않는다. null이 아니면 본문 모드(local)로, refresh도 query에 추가해 프론트가 즉시 사용할 수 있게 한다.
+ * 이후 query 구성은 {@link AuthProperties.RefreshToken#cookieEnabled()} 플래그를 단일 진실로 분기한다. 쿠키 모드(prod)에서는
+ * deliver가 이미 Set-Cookie로 refresh를 전달했으므로 query에는 access만 싣는다. 본문 모드(local)에서는 refresh도 query에 함께
+ * 실어 프론트가 즉시 사용할 수 있게 한다.
  *
  * <p>인가 코드 교환 중 잠시 사용된 세션은 더 이상 필요 없으므로 redirect 직전에 invalidate하여 서버 상태를 JWT-only로 복귀시킨다.
  *
@@ -63,7 +64,10 @@ public class OAuth2LoginSuccessHandler implements AuthenticationSuccessHandler {
         }
 
         String callbackUrl = authProperties.frontCallbackUrl();
-        String redirectUrl = buildRedirectUrl(callbackUrl, body.accessToken(), body.refreshToken());
+        // 쿠키 모드(prod)면 deliver가 이미 Set-Cookie로 refresh를 전달했으므로 query에는 싣지 않는다.
+        String refreshForQuery =
+                authProperties.refreshToken().cookieEnabled() ? null : refreshToken;
+        String redirectUrl = buildRedirectUrl(callbackUrl, body.accessToken(), refreshForQuery);
 
         invalidateSession(request);
         log.info(

--- a/src/main/java/com/groute/groute_server/auth/service/oauth/OAuthCallbackUrlResolver.java
+++ b/src/main/java/com/groute/groute_server/auth/service/oauth/OAuthCallbackUrlResolver.java
@@ -1,0 +1,77 @@
+package com.groute.groute_server.auth.service.oauth;
+
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseCookie;
+import org.springframework.stereotype.Component;
+
+import com.groute.groute_server.auth.config.AuthProperties;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * OAuth2 round-trip 후 프론트 콜백 URL을 결정하는 공용 컴포넌트.
+ *
+ * <p>{@link OAuth2EnvAwareAuthorizationRequestResolver}가 OAuth2 시작 시 발행한 {@code oauth_env} 쿠키를 읽어
+ * {@link AuthProperties#callback()} 화이트리스트와 매칭한다. 매칭 성공이면 그 URL을, 쿠키가 없거나 등록되지 않은 env이면 default로
+ * fallback. 사용 후에는 즉시 만료 처리(Max-Age=0)해 round-trip 흔적을 지운다.
+ *
+ * <p>SuccessHandler·FailureHandler 두 곳에서 동일하게 호출하여 콜백 URL 정책을 단일 진실로 유지한다.
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class OAuthCallbackUrlResolver {
+
+    private final AuthProperties authProperties;
+
+    /**
+     * 콜백 URL을 해석하고 round-trip 쿠키를 만료시킨다.
+     *
+     * @param request 현재 요청 (쿠키 + secure 플래그 추출용)
+     * @param response 만료 쿠키 set-cookie 헤더를 추가할 응답
+     * @return 매칭된 또는 default 콜백 URL
+     */
+    public String resolveAndExpire(HttpServletRequest request, HttpServletResponse response) {
+        String env = readEnvCookie(request);
+        String url = (env != null) ? authProperties.callbackUrlFor(env) : null;
+        if (url == null) {
+            if (env != null) {
+                log.warn("oauth_env 쿠키 값이 등록되지 않은 env, default로 fallback: env={}", env);
+            }
+            url = authProperties.defaultCallbackUrl();
+        }
+        expireEnvCookie(request, response);
+        return url;
+    }
+
+    private static String readEnvCookie(HttpServletRequest request) {
+        Cookie[] cookies = request.getCookies();
+        if (cookies == null) {
+            return null;
+        }
+        for (Cookie c : cookies) {
+            if (OAuth2EnvAwareAuthorizationRequestResolver.ENV_COOKIE_NAME.equals(c.getName())) {
+                String value = c.getValue();
+                return (value == null || value.isBlank()) ? null : value;
+            }
+        }
+        return null;
+    }
+
+    private static void expireEnvCookie(HttpServletRequest request, HttpServletResponse response) {
+        ResponseCookie cookie =
+                ResponseCookie.from(OAuth2EnvAwareAuthorizationRequestResolver.ENV_COOKIE_NAME, "")
+                        .maxAge(0)
+                        .httpOnly(true)
+                        .secure(request.isSecure())
+                        .sameSite("Lax")
+                        .path("/")
+                        .build();
+        response.addHeader(HttpHeaders.SET_COOKIE, cookie.toString());
+    }
+}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -99,9 +99,13 @@ jwt:
 auth:
   refresh-token:
     cookie-enabled: false
-  # stg/prod는 SSM에서 AUTH_FRONT_CALLBACK_URL 주입 필수 — 누락 시 부팅 실패(fail-fast)로 설정 오류 즉시 노출.
-  # 로컬은 하단 local 프로파일에서 http://localhost:3000/auth/callback fallback 허용
-  front-callback-url: ${AUTH_FRONT_CALLBACK_URL}
+  # 프론트 콜백 URL은 env 키 → URL 맵으로 등록.
+  # 프론트가 OAuth2 시작 시 ?env=local|production 으로 어느 콜백을 쓸지 지정.
+  # 환경별 등록 키는 각 프로파일에서 채우며 stg/prod는 SSM 주입 필수(fail-fast).
+  callback: {}
+  # default-env는 프론트가 env를 보내지 않거나 등록되지 않은 값을 보냈을 때 fallback.
+  # stg/prod는 SSM AUTH_DEFAULT_ENV 주입 필수, 로컬은 하단 local 프로파일에서 'local' fallback.
+  default-env: ${AUTH_DEFAULT_ENV}
 
 springdoc:
   swagger-ui:
@@ -161,7 +165,9 @@ app:
     default-profile-image-url: ${USER_DEFAULT_PROFILE_IMAGE_URL:}
 
 auth:
-  front-callback-url: ${AUTH_FRONT_CALLBACK_URL:http://localhost:3000/auth/callback}
+  callback:
+    local: ${AUTH_CALLBACK_LOCAL:http://localhost:3000/auth/callback}
+  default-env: ${AUTH_DEFAULT_ENV:local}
 
 firebase:
   credentials-json: ${FIREBASE_CREDENTIALS_JSON:}
@@ -193,6 +199,12 @@ app:
   swagger:
     server-url: https://stg-api.glit.today
     server-description: Staging
+
+# stg는 프론트 로컬·운영 둘 다 콜백을 허용한다. 프론트가 ?env=local|production 으로 선택.
+auth:
+  callback:
+    local: ${AUTH_CALLBACK_LOCAL}
+    production: ${AUTH_CALLBACK_PRODUCTION}
 
 discord:
   webhook:
@@ -231,6 +243,9 @@ app:
 auth:
   refresh-token:
     cookie-enabled: true
+  # prod는 운영 프론트 콜백 하나만 허용. local 키는 의도적으로 미등록.
+  callback:
+    production: ${AUTH_CALLBACK_PRODUCTION}
 
 discord:
   webhook:

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -99,6 +99,9 @@ jwt:
 auth:
   refresh-token:
     cookie-enabled: false
+  # stg/prod는 SSM에서 AUTH_FRONT_CALLBACK_URL 주입 필수 — 누락 시 부팅 실패(fail-fast)로 설정 오류 즉시 노출.
+  # 로컬은 하단 local 프로파일에서 http://localhost:3000/auth/callback fallback 허용
+  front-callback-url: ${AUTH_FRONT_CALLBACK_URL}
 
 springdoc:
   swagger-ui:
@@ -156,6 +159,9 @@ spring:
 app:
   user:
     default-profile-image-url: ${USER_DEFAULT_PROFILE_IMAGE_URL:}
+
+auth:
+  front-callback-url: ${AUTH_FRONT_CALLBACK_URL:http://localhost:3000/auth/callback}
 
 firebase:
   credentials-json: ${FIREBASE_CREDENTIALS_JSON:}

--- a/src/test/java/com/groute/groute_server/auth/service/TokenDeliveryServiceTest.java
+++ b/src/test/java/com/groute/groute_server/auth/service/TokenDeliveryServiceTest.java
@@ -23,7 +23,9 @@ class TokenDeliveryServiceTest {
     private TokenDeliveryService serviceWithCookieEnabled(boolean enabled) {
         JwtProperties jwtProperties = new JwtProperties("secret", 900_000L, REFRESH_TTL_MILLIS);
         AuthProperties authProperties =
-                new AuthProperties(new AuthProperties.RefreshToken(enabled));
+                new AuthProperties(
+                        new AuthProperties.RefreshToken(enabled),
+                        "http://localhost:3000/auth/callback");
         return new TokenDeliveryService(jwtProperties, authProperties);
     }
 

--- a/src/test/java/com/groute/groute_server/auth/service/TokenDeliveryServiceTest.java
+++ b/src/test/java/com/groute/groute_server/auth/service/TokenDeliveryServiceTest.java
@@ -3,6 +3,7 @@ package com.groute.groute_server.auth.service;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.List;
+import java.util.Map;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -25,7 +26,8 @@ class TokenDeliveryServiceTest {
         AuthProperties authProperties =
                 new AuthProperties(
                         new AuthProperties.RefreshToken(enabled),
-                        "http://localhost:3000/auth/callback");
+                        Map.of("local", "http://localhost:3000/auth/callback"),
+                        "local");
         return new TokenDeliveryService(jwtProperties, authProperties);
     }
 

--- a/src/test/java/com/groute/groute_server/auth/service/oauth/OAuth2LoginFailureHandlerTest.java
+++ b/src/test/java/com/groute/groute_server/auth/service/oauth/OAuth2LoginFailureHandlerTest.java
@@ -1,33 +1,43 @@
 package com.groute.groute_server.auth.service.oauth;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
-import org.springframework.http.MediaType;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
 import org.springframework.security.oauth2.core.OAuth2Error;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.groute.groute_server.common.exception.BusinessException;
 import com.groute.groute_server.common.exception.ErrorCode;
 
+@ExtendWith(MockitoExtension.class)
 class OAuth2LoginFailureHandlerTest {
 
-    private final ObjectMapper objectMapper = new ObjectMapper();
-    private final OAuth2LoginFailureHandler handler = new OAuth2LoginFailureHandler(objectMapper);
+    private static final String CALLBACK_URL = "http://localhost:3000/auth/callback";
+
+    @Mock OAuthCallbackUrlResolver oAuthCallbackUrlResolver;
+
+    @InjectMocks OAuth2LoginFailureHandler handler;
 
     @Nested
-    @DisplayName("onAuthenticationFailure")
-    class OnFailure {
+    @DisplayName("onAuthenticationFailure - HappyPath")
+    class HappyPath {
 
         @Test
-        @DisplayName("원인 체인에 BusinessException이 있을 때 해당 ErrorCode로 응답하고 상세 메시지는 마스킹한다")
-        void should_respondWithMaskedErrorResponse_when_businessExceptionInCauseChain()
+        @DisplayName("원인 체인에 BusinessException이 있을 때 해당 ErrorCode를 error query로 redirect한다")
+        void should_redirectWithBusinessErrorCode_when_businessExceptionInCauseChain()
                 throws Exception {
             // given
             BusinessException businessException =
@@ -41,38 +51,62 @@ class OAuth2LoginFailureHandlerTest {
                             businessException);
             MockHttpServletRequest request = new MockHttpServletRequest();
             MockHttpServletResponse response = new MockHttpServletResponse();
+            given(oAuthCallbackUrlResolver.resolveAndExpire(request, response))
+                    .willReturn(CALLBACK_URL);
 
             // when
             handler.onAuthenticationFailure(request, response, exception);
 
             // then
-            assertThat(response.getStatus())
-                    .isEqualTo(ErrorCode.INVALID_OAUTH_RESPONSE.getHttpStatus().value());
-            assertThat(response.getContentType()).startsWith(MediaType.APPLICATION_JSON_VALUE);
-            assertThat(response.getContentAsString())
-                    .contains("\"code\":\"" + ErrorCode.INVALID_OAUTH_RESPONSE.getCode() + "\"")
-                    .contains(
-                            "\"message\":\"" + ErrorCode.INVALID_OAUTH_RESPONSE.getMessage() + "\"")
-                    .doesNotContain("providerUid");
+            assertThat(response.getRedirectedUrl())
+                    .isEqualTo(
+                            CALLBACK_URL
+                                    + "?error="
+                                    + encode(ErrorCode.INVALID_OAUTH_RESPONSE.getCode()));
         }
 
         @Test
-        @DisplayName("원인 체인에 BusinessException이 없을 때 UNAUTHORIZED 기본 응답을 반환한다")
-        void should_respondWithUnauthorized_when_noBusinessExceptionCause() throws Exception {
+        @DisplayName("원인 체인에 BusinessException이 없을 때 UNAUTHORIZED를 error query로 redirect한다")
+        void should_redirectWithUnauthorized_when_noBusinessExceptionCause() throws Exception {
             // given
             BadCredentialsException exception = new BadCredentialsException("자격 증명 실패");
             MockHttpServletRequest request = new MockHttpServletRequest();
             MockHttpServletResponse response = new MockHttpServletResponse();
+            given(oAuthCallbackUrlResolver.resolveAndExpire(request, response))
+                    .willReturn(CALLBACK_URL);
 
             // when
             handler.onAuthenticationFailure(request, response, exception);
 
             // then
-            assertThat(response.getStatus())
-                    .isEqualTo(ErrorCode.UNAUTHORIZED.getHttpStatus().value());
-            assertThat(response.getContentAsString())
-                    .contains("\"code\":\"" + ErrorCode.UNAUTHORIZED.getCode() + "\"")
-                    .contains("\"message\":\"" + ErrorCode.UNAUTHORIZED.getMessage() + "\"");
+            assertThat(response.getRedirectedUrl())
+                    .isEqualTo(CALLBACK_URL + "?error=" + encode(ErrorCode.UNAUTHORIZED.getCode()));
         }
+
+        @Test
+        @DisplayName("콜백 URL이 이미 query를 포함하면 `&error=...`로 이어 붙인다")
+        void should_appendWithAmpersand_when_callbackHasExistingQuery() throws Exception {
+            // given
+            String callbackWithQuery = "http://localhost:3000/auth/callback?from=signup";
+            BadCredentialsException exception = new BadCredentialsException("자격 증명 실패");
+            MockHttpServletRequest request = new MockHttpServletRequest();
+            MockHttpServletResponse response = new MockHttpServletResponse();
+            given(oAuthCallbackUrlResolver.resolveAndExpire(request, response))
+                    .willReturn(callbackWithQuery);
+
+            // when
+            handler.onAuthenticationFailure(request, response, exception);
+
+            // then
+            assertThat(response.getRedirectedUrl())
+                    .isEqualTo(
+                            callbackWithQuery
+                                    + "&error="
+                                    + encode(ErrorCode.UNAUTHORIZED.getCode()));
+        }
+    }
+
+    private static String encode(String value) {
+        return URLEncoder.encode(value, StandardCharsets.UTF_8);
     }
 }

--- a/src/test/java/com/groute/groute_server/auth/service/oauth/OAuth2LoginSuccessHandlerTest.java
+++ b/src/test/java/com/groute/groute_server/auth/service/oauth/OAuth2LoginSuccessHandlerTest.java
@@ -104,6 +104,35 @@ class OAuth2LoginSuccessHandlerTest {
         }
 
         @Test
+        @DisplayName("콜백 URL이 이미 query를 포함하면 `&`로 이어 붙인다")
+        void should_appendWithAmpersand_when_callbackHasExistingQuery() throws Exception {
+            // given
+            String callbackWithQuery = "http://localhost:3000/auth/callback?from=signup";
+            AuthProperties authProperties =
+                    new AuthProperties(new AuthProperties.RefreshToken(false), callbackWithQuery);
+            OAuth2LoginSuccessHandler localHandler =
+                    new OAuth2LoginSuccessHandler(
+                            jwtTokenProvider,
+                            refreshTokenRepository,
+                            tokenDeliveryService,
+                            authProperties);
+
+            MockHttpServletResponse response = new MockHttpServletResponse();
+            given(jwtTokenProvider.createAccessToken(USER_ID)).willReturn(ACCESS_TOKEN);
+            given(jwtTokenProvider.createRefreshToken(USER_ID)).willReturn(REFRESH_TOKEN);
+            given(tokenDeliveryService.deliver(response, ACCESS_TOKEN, REFRESH_TOKEN))
+                    .willReturn(new TokenResponse(ACCESS_TOKEN, null));
+
+            // when
+            localHandler.onAuthenticationSuccess(
+                    new MockHttpServletRequest(), response, authFor(USER_ID, SocialProvider.KAKAO));
+
+            // then
+            assertThat(response.getRedirectedUrl())
+                    .isEqualTo(callbackWithQuery + "&access=" + encode(ACCESS_TOKEN));
+        }
+
+        @Test
         @DisplayName("redirect 호출 전에 활성 세션을 invalidate한다")
         void should_invalidateSession_before_redirect() throws Exception {
             // given

--- a/src/test/java/com/groute/groute_server/auth/service/oauth/OAuth2LoginSuccessHandlerTest.java
+++ b/src/test/java/com/groute/groute_server/auth/service/oauth/OAuth2LoginSuccessHandlerTest.java
@@ -9,12 +9,15 @@ import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.util.Map;
 
+import jakarta.servlet.http.Cookie;
+
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpHeaders;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.security.core.Authentication;
@@ -30,6 +33,8 @@ import com.groute.groute_server.common.jwt.JwtTokenProvider;
 class OAuth2LoginSuccessHandlerTest {
 
     private static final String CALLBACK_URL = "http://localhost:3000/auth/callback";
+    private static final String LOCAL_URL = "http://localhost:3000/auth/callback";
+    private static final String PROD_URL = "https://glit.today/auth/callback";
     private static final Long USER_ID = 42L;
     private static final String ACCESS_TOKEN = "acc.tok.en";
     private static final String REFRESH_TOKEN = "ref.tok.en";
@@ -39,11 +44,14 @@ class OAuth2LoginSuccessHandlerTest {
     @Mock TokenDeliveryService tokenDeliveryService;
 
     private OAuth2LoginSuccessHandler newHandler(boolean cookieEnabled, String callbackUrl) {
+        return newHandler(cookieEnabled, Map.of("default", callbackUrl), "default");
+    }
+
+    private OAuth2LoginSuccessHandler newHandler(
+            boolean cookieEnabled, Map<String, String> callback, String defaultEnv) {
         AuthProperties authProperties =
                 new AuthProperties(
-                        new AuthProperties.RefreshToken(cookieEnabled),
-                        Map.of("default", callbackUrl),
-                        "default");
+                        new AuthProperties.RefreshToken(cookieEnabled), callback, defaultEnv);
         return new OAuth2LoginSuccessHandler(
                 jwtTokenProvider, refreshTokenRepository, tokenDeliveryService, authProperties);
     }
@@ -141,6 +149,109 @@ class OAuth2LoginSuccessHandlerTest {
             // then
             assertThat(request.getSession(false)).isNull();
             assertThat(response.getRedirectedUrl()).startsWith(CALLBACK_URL + "?access=");
+        }
+    }
+
+    @Nested
+    @DisplayName("onAuthenticationSuccess - EnvCookie")
+    class EnvCookie {
+
+        @Test
+        @DisplayName("oauth_env 쿠키가 production이면 production 콜백 URL로 redirect한다")
+        void should_redirectToProductionCallback_when_envCookieIsProduction() throws Exception {
+            // given
+            OAuth2LoginSuccessHandler handler =
+                    newHandler(true, Map.of("local", LOCAL_URL, "production", PROD_URL), "local");
+            MockHttpServletRequest request = new MockHttpServletRequest();
+            request.setCookies(new Cookie("oauth_env", "production"));
+            MockHttpServletResponse response = new MockHttpServletResponse();
+            stubTokens(response);
+
+            // when
+            handler.onAuthenticationSuccess(
+                    request, response, authFor(USER_ID, SocialProvider.KAKAO));
+
+            // then
+            assertThat(response.getRedirectedUrl())
+                    .isEqualTo(PROD_URL + "?access=" + encode(ACCESS_TOKEN));
+            assertExpiredEnvCookie(response);
+        }
+
+        @Test
+        @DisplayName("oauth_env 쿠키가 local이면 local 콜백 URL로 redirect한다")
+        void should_redirectToLocalCallback_when_envCookieIsLocal() throws Exception {
+            // given
+            OAuth2LoginSuccessHandler handler =
+                    newHandler(
+                            true, Map.of("local", LOCAL_URL, "production", PROD_URL), "production");
+            MockHttpServletRequest request = new MockHttpServletRequest();
+            request.setCookies(new Cookie("oauth_env", "local"));
+            MockHttpServletResponse response = new MockHttpServletResponse();
+            stubTokens(response);
+
+            // when
+            handler.onAuthenticationSuccess(
+                    request, response, authFor(USER_ID, SocialProvider.KAKAO));
+
+            // then
+            assertThat(response.getRedirectedUrl())
+                    .isEqualTo(LOCAL_URL + "?access=" + encode(ACCESS_TOKEN));
+            assertExpiredEnvCookie(response);
+        }
+
+        @Test
+        @DisplayName("oauth_env 쿠키가 없으면 default env 콜백 URL로 redirect한다")
+        void should_redirectToDefaultCallback_when_envCookieMissing() throws Exception {
+            // given — defaultEnv=production
+            OAuth2LoginSuccessHandler handler =
+                    newHandler(
+                            true, Map.of("local", LOCAL_URL, "production", PROD_URL), "production");
+            MockHttpServletRequest request = new MockHttpServletRequest(); // 쿠키 없음
+            MockHttpServletResponse response = new MockHttpServletResponse();
+            stubTokens(response);
+
+            // when
+            handler.onAuthenticationSuccess(
+                    request, response, authFor(USER_ID, SocialProvider.KAKAO));
+
+            // then
+            assertThat(response.getRedirectedUrl())
+                    .isEqualTo(PROD_URL + "?access=" + encode(ACCESS_TOKEN));
+            assertExpiredEnvCookie(response);
+        }
+
+        @Test
+        @DisplayName("oauth_env 쿠키가 등록되지 않은 env이면 default env로 fallback한다")
+        void should_fallbackToDefault_when_envCookieIsUnregistered() throws Exception {
+            // given — env=staging은 매핑에 없음, defaultEnv=production
+            OAuth2LoginSuccessHandler handler =
+                    newHandler(
+                            true, Map.of("local", LOCAL_URL, "production", PROD_URL), "production");
+            MockHttpServletRequest request = new MockHttpServletRequest();
+            request.setCookies(new Cookie("oauth_env", "staging"));
+            MockHttpServletResponse response = new MockHttpServletResponse();
+            stubTokens(response);
+
+            // when
+            handler.onAuthenticationSuccess(
+                    request, response, authFor(USER_ID, SocialProvider.KAKAO));
+
+            // then
+            assertThat(response.getRedirectedUrl())
+                    .isEqualTo(PROD_URL + "?access=" + encode(ACCESS_TOKEN));
+            assertExpiredEnvCookie(response);
+        }
+
+        private void stubTokens(MockHttpServletResponse response) {
+            given(jwtTokenProvider.createAccessToken(USER_ID)).willReturn(ACCESS_TOKEN);
+            given(jwtTokenProvider.createRefreshToken(USER_ID)).willReturn(REFRESH_TOKEN);
+            given(tokenDeliveryService.deliver(response, ACCESS_TOKEN, REFRESH_TOKEN))
+                    .willReturn(new TokenResponse(ACCESS_TOKEN, null));
+        }
+
+        private void assertExpiredEnvCookie(MockHttpServletResponse response) {
+            assertThat(response.getHeaders(HttpHeaders.SET_COOKIE))
+                    .anyMatch(c -> c.startsWith("oauth_env=") && c.contains("Max-Age=0"));
         }
     }
 

--- a/src/test/java/com/groute/groute_server/auth/service/oauth/OAuth2LoginSuccessHandlerTest.java
+++ b/src/test/java/com/groute/groute_server/auth/service/oauth/OAuth2LoginSuccessHandlerTest.java
@@ -5,6 +5,8 @@ import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.util.Map;
 
 import org.junit.jupiter.api.BeforeEach;
@@ -14,13 +16,11 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.http.HttpStatus;
-import org.springframework.http.MediaType;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.security.core.Authentication;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
+import com.groute.groute_server.auth.config.AuthProperties;
 import com.groute.groute_server.auth.dto.TokenResponse;
 import com.groute.groute_server.auth.enums.SocialProvider;
 import com.groute.groute_server.auth.repository.RefreshTokenRepository;
@@ -30,61 +30,109 @@ import com.groute.groute_server.common.jwt.JwtTokenProvider;
 @ExtendWith(MockitoExtension.class)
 class OAuth2LoginSuccessHandlerTest {
 
+    private static final String CALLBACK_URL = "http://localhost:3000/auth/callback";
+    private static final Long USER_ID = 42L;
+    private static final String ACCESS_TOKEN = "acc.tok.en";
+    private static final String REFRESH_TOKEN = "ref.tok.en";
+
     @Mock JwtTokenProvider jwtTokenProvider;
     @Mock RefreshTokenRepository refreshTokenRepository;
     @Mock TokenDeliveryService tokenDeliveryService;
-
-    private final ObjectMapper objectMapper = new ObjectMapper();
 
     private OAuth2LoginSuccessHandler handler;
 
     @BeforeEach
     void setUp() {
+        AuthProperties authProperties =
+                new AuthProperties(new AuthProperties.RefreshToken(false), CALLBACK_URL);
         handler =
                 new OAuth2LoginSuccessHandler(
                         jwtTokenProvider,
                         refreshTokenRepository,
                         tokenDeliveryService,
-                        objectMapper);
+                        authProperties);
     }
 
     @Nested
-    @DisplayName("onAuthenticationSuccess")
-    class OnSuccess {
+    @DisplayName("onAuthenticationSuccess - HappyPath")
+    class HappyPath {
 
         @Test
-        @DisplayName("인증 성공일 때 토큰 쌍을 발급·저장하고 deliver 결과를 JSON 본문으로 기록한다")
-        void should_issueTokensAndWriteJson_when_authenticated() throws Exception {
+        @DisplayName("쿠키 모드(refresh=null)일 때 access만 query에 담아 콜백 URL로 redirect한다")
+        void should_redirectWithAccessOnly_when_cookieMode() throws Exception {
             // given
-            Long userId = 42L;
-            PrincipalUser principal = new PrincipalUser(userId, SocialProvider.KAKAO, Map.of());
-            Authentication authentication = mock(Authentication.class);
-            given(authentication.getPrincipal()).willReturn(principal);
-
-            String access = "access-token";
-            String refresh = "refresh-token";
-            given(jwtTokenProvider.createAccessToken(userId)).willReturn(access);
-            given(jwtTokenProvider.createRefreshToken(userId)).willReturn(refresh);
-
-            MockHttpServletRequest request = new MockHttpServletRequest();
             MockHttpServletResponse response = new MockHttpServletResponse();
-            given(tokenDeliveryService.deliver(response, access, refresh))
-                    .willReturn(new TokenResponse(access, null));
+            given(jwtTokenProvider.createAccessToken(USER_ID)).willReturn(ACCESS_TOKEN);
+            given(jwtTokenProvider.createRefreshToken(USER_ID)).willReturn(REFRESH_TOKEN);
+            given(tokenDeliveryService.deliver(response, ACCESS_TOKEN, REFRESH_TOKEN))
+                    .willReturn(new TokenResponse(ACCESS_TOKEN, null));
 
             // when
-            handler.onAuthenticationSuccess(request, response, authentication);
+            handler.onAuthenticationSuccess(
+                    new MockHttpServletRequest(), response, authFor(USER_ID, SocialProvider.KAKAO));
 
             // then
-            verify(refreshTokenRepository).save(userId, refresh);
-            verify(tokenDeliveryService).deliver(response, access, refresh);
-
-            assertThat(response.getStatus()).isEqualTo(HttpStatus.OK.value());
-            assertThat(response.getContentType()).startsWith(MediaType.APPLICATION_JSON_VALUE);
-            assertThat(response.getCharacterEncoding()).isEqualToIgnoringCase("UTF-8");
-            assertThat(response.getContentAsString())
-                    .contains("\"success\":true")
-                    .contains("\"accessToken\":\"" + access + "\"")
-                    .doesNotContain("\"refreshToken\"");
+            verify(refreshTokenRepository).save(USER_ID, REFRESH_TOKEN);
+            assertThat(response.getRedirectedUrl())
+                    .isEqualTo(CALLBACK_URL + "?access=" + encode(ACCESS_TOKEN));
         }
+
+        @Test
+        @DisplayName("본문 모드(refresh!=null)일 때 access·refresh 모두 query에 담아 redirect한다")
+        void should_redirectWithBothTokens_when_bodyMode() throws Exception {
+            // given
+            MockHttpServletResponse response = new MockHttpServletResponse();
+            given(jwtTokenProvider.createAccessToken(USER_ID)).willReturn(ACCESS_TOKEN);
+            given(jwtTokenProvider.createRefreshToken(USER_ID)).willReturn(REFRESH_TOKEN);
+            given(tokenDeliveryService.deliver(response, ACCESS_TOKEN, REFRESH_TOKEN))
+                    .willReturn(new TokenResponse(ACCESS_TOKEN, REFRESH_TOKEN));
+
+            // when
+            handler.onAuthenticationSuccess(
+                    new MockHttpServletRequest(),
+                    response,
+                    authFor(USER_ID, SocialProvider.GOOGLE));
+
+            // then
+            assertThat(response.getRedirectedUrl())
+                    .isEqualTo(
+                            CALLBACK_URL
+                                    + "?access="
+                                    + encode(ACCESS_TOKEN)
+                                    + "&refresh="
+                                    + encode(REFRESH_TOKEN));
+        }
+
+        @Test
+        @DisplayName("redirect 호출 전에 활성 세션을 invalidate한다")
+        void should_invalidateSession_before_redirect() throws Exception {
+            // given
+            MockHttpServletRequest request = new MockHttpServletRequest();
+            request.getSession(true); // 활성 세션 생성
+            MockHttpServletResponse response = new MockHttpServletResponse();
+            given(jwtTokenProvider.createAccessToken(USER_ID)).willReturn(ACCESS_TOKEN);
+            given(jwtTokenProvider.createRefreshToken(USER_ID)).willReturn(REFRESH_TOKEN);
+            given(tokenDeliveryService.deliver(response, ACCESS_TOKEN, REFRESH_TOKEN))
+                    .willReturn(new TokenResponse(ACCESS_TOKEN, null));
+
+            // when
+            handler.onAuthenticationSuccess(
+                    request, response, authFor(USER_ID, SocialProvider.KAKAO));
+
+            // then
+            assertThat(request.getSession(false)).isNull();
+            assertThat(response.getRedirectedUrl()).startsWith(CALLBACK_URL + "?access=");
+        }
+    }
+
+    private static Authentication authFor(Long userId, SocialProvider provider) {
+        PrincipalUser principal = new PrincipalUser(userId, provider, Map.of());
+        Authentication authentication = mock(Authentication.class);
+        given(authentication.getPrincipal()).willReturn(principal);
+        return authentication;
+    }
+
+    private static String encode(String token) {
+        return URLEncoder.encode(token, StandardCharsets.UTF_8);
     }
 }

--- a/src/test/java/com/groute/groute_server/auth/service/oauth/OAuth2LoginSuccessHandlerTest.java
+++ b/src/test/java/com/groute/groute_server/auth/service/oauth/OAuth2LoginSuccessHandlerTest.java
@@ -40,7 +40,10 @@ class OAuth2LoginSuccessHandlerTest {
 
     private OAuth2LoginSuccessHandler newHandler(boolean cookieEnabled, String callbackUrl) {
         AuthProperties authProperties =
-                new AuthProperties(new AuthProperties.RefreshToken(cookieEnabled), callbackUrl);
+                new AuthProperties(
+                        new AuthProperties.RefreshToken(cookieEnabled),
+                        Map.of("default", callbackUrl),
+                        "default");
         return new OAuth2LoginSuccessHandler(
                 jwtTokenProvider, refreshTokenRepository, tokenDeliveryService, authProperties);
     }

--- a/src/test/java/com/groute/groute_server/auth/service/oauth/OAuth2LoginSuccessHandlerTest.java
+++ b/src/test/java/com/groute/groute_server/auth/service/oauth/OAuth2LoginSuccessHandlerTest.java
@@ -53,7 +53,11 @@ class OAuth2LoginSuccessHandlerTest {
                 new AuthProperties(
                         new AuthProperties.RefreshToken(cookieEnabled), callback, defaultEnv);
         return new OAuth2LoginSuccessHandler(
-                jwtTokenProvider, refreshTokenRepository, tokenDeliveryService, authProperties);
+                jwtTokenProvider,
+                refreshTokenRepository,
+                tokenDeliveryService,
+                authProperties,
+                new OAuthCallbackUrlResolver(authProperties));
     }
 
     @Nested

--- a/src/test/java/com/groute/groute_server/auth/service/oauth/OAuth2LoginSuccessHandlerTest.java
+++ b/src/test/java/com/groute/groute_server/auth/service/oauth/OAuth2LoginSuccessHandlerTest.java
@@ -9,7 +9,6 @@ import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.util.Map;
 
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -39,18 +38,11 @@ class OAuth2LoginSuccessHandlerTest {
     @Mock RefreshTokenRepository refreshTokenRepository;
     @Mock TokenDeliveryService tokenDeliveryService;
 
-    private OAuth2LoginSuccessHandler handler;
-
-    @BeforeEach
-    void setUp() {
+    private OAuth2LoginSuccessHandler newHandler(boolean cookieEnabled, String callbackUrl) {
         AuthProperties authProperties =
-                new AuthProperties(new AuthProperties.RefreshToken(false), CALLBACK_URL);
-        handler =
-                new OAuth2LoginSuccessHandler(
-                        jwtTokenProvider,
-                        refreshTokenRepository,
-                        tokenDeliveryService,
-                        authProperties);
+                new AuthProperties(new AuthProperties.RefreshToken(cookieEnabled), callbackUrl);
+        return new OAuth2LoginSuccessHandler(
+                jwtTokenProvider, refreshTokenRepository, tokenDeliveryService, authProperties);
     }
 
     @Nested
@@ -58,9 +50,10 @@ class OAuth2LoginSuccessHandlerTest {
     class HappyPath {
 
         @Test
-        @DisplayName("쿠키 모드(refresh=null)일 때 access만 query에 담아 콜백 URL로 redirect한다")
+        @DisplayName("쿠키 모드일 때 access만 query에 담아 콜백 URL로 redirect한다")
         void should_redirectWithAccessOnly_when_cookieMode() throws Exception {
-            // given
+            // given — cookieEnabled=true: refresh는 Set-Cookie로만 전달
+            OAuth2LoginSuccessHandler handler = newHandler(true, CALLBACK_URL);
             MockHttpServletResponse response = new MockHttpServletResponse();
             given(jwtTokenProvider.createAccessToken(USER_ID)).willReturn(ACCESS_TOKEN);
             given(jwtTokenProvider.createRefreshToken(USER_ID)).willReturn(REFRESH_TOKEN);
@@ -78,9 +71,10 @@ class OAuth2LoginSuccessHandlerTest {
         }
 
         @Test
-        @DisplayName("본문 모드(refresh!=null)일 때 access·refresh 모두 query에 담아 redirect한다")
+        @DisplayName("본문 모드일 때 access·refresh 모두 query에 담아 redirect한다")
         void should_redirectWithBothTokens_when_bodyMode() throws Exception {
-            // given
+            // given — cookieEnabled=false: refresh는 query로 전달
+            OAuth2LoginSuccessHandler handler = newHandler(false, CALLBACK_URL);
             MockHttpServletResponse response = new MockHttpServletResponse();
             given(jwtTokenProvider.createAccessToken(USER_ID)).willReturn(ACCESS_TOKEN);
             given(jwtTokenProvider.createRefreshToken(USER_ID)).willReturn(REFRESH_TOKEN);
@@ -106,17 +100,9 @@ class OAuth2LoginSuccessHandlerTest {
         @Test
         @DisplayName("콜백 URL이 이미 query를 포함하면 `&`로 이어 붙인다")
         void should_appendWithAmpersand_when_callbackHasExistingQuery() throws Exception {
-            // given
+            // given — 콜백 URL에 기존 query 포함, separator 분기 검증
             String callbackWithQuery = "http://localhost:3000/auth/callback?from=signup";
-            AuthProperties authProperties =
-                    new AuthProperties(new AuthProperties.RefreshToken(false), callbackWithQuery);
-            OAuth2LoginSuccessHandler localHandler =
-                    new OAuth2LoginSuccessHandler(
-                            jwtTokenProvider,
-                            refreshTokenRepository,
-                            tokenDeliveryService,
-                            authProperties);
-
+            OAuth2LoginSuccessHandler handler = newHandler(true, callbackWithQuery);
             MockHttpServletResponse response = new MockHttpServletResponse();
             given(jwtTokenProvider.createAccessToken(USER_ID)).willReturn(ACCESS_TOKEN);
             given(jwtTokenProvider.createRefreshToken(USER_ID)).willReturn(REFRESH_TOKEN);
@@ -124,7 +110,7 @@ class OAuth2LoginSuccessHandlerTest {
                     .willReturn(new TokenResponse(ACCESS_TOKEN, null));
 
             // when
-            localHandler.onAuthenticationSuccess(
+            handler.onAuthenticationSuccess(
                     new MockHttpServletRequest(), response, authFor(USER_ID, SocialProvider.KAKAO));
 
             // then
@@ -136,6 +122,7 @@ class OAuth2LoginSuccessHandlerTest {
         @DisplayName("redirect 호출 전에 활성 세션을 invalidate한다")
         void should_invalidateSession_before_redirect() throws Exception {
             // given
+            OAuth2LoginSuccessHandler handler = newHandler(true, CALLBACK_URL);
             MockHttpServletRequest request = new MockHttpServletRequest();
             request.getSession(true); // 활성 세션 생성
             MockHttpServletResponse response = new MockHttpServletResponse();


### PR DESCRIPTION
## 요약
- OAuth2 로그인 성공·실패 시 환경(env)별 프론트 콜백 URL로 302 redirect
- 성공은 access(+refresh) query·실패는 error code query로 전달

## 변경 사항
- [x] 기능
- [x] 버그 수정
- [x] 리팩토링
- [ ] 문서
- [x] 테스트
- [ ] 기타

## 테스트
- [x] 로컬 테스트 완료
- 테스트 방법:
    - `./gradlew spotlessApply compileJava` (메인 컴파일·포맷)
    - `./gradlew test --tests OAuth2LoginSuccessHandlerTest` (HappyPath 4 + EnvCookie 4 = 8 시나리오)
    - `./gradlew test --tests OAuth2LoginFailureHandlerTest` (HappyPath 3 시나리오 — BusinessException cause / cause 없음 / 기존 query 포함 callback)
    - `./gradlew test --tests TokenDeliveryServiceTest` (deliver/clear 4 시나리오)
    - 수동 성공: `GET /oauth2/authorization/kakao?env=local` → kakao 인증 → `http://localhost:3000/auth/callback?access=...&refresh=...`
    - 수동 실패: 카카오 동의 거부 → `http://localhost:3000/auth/callback?error=AUTH_001` (또는 `INVALID_OAUTH_RESPONSE` 등 정규화 단계 BusinessException)

### 커버리지 (JaCoCo)
- 라인 커버리지: 92%  (기준: 60% 이상)
- [ ] `./gradlew test` 실행 후 `build/reports/jacoco/index.html`에서 수치 확인
- (선택) 리포트 스크린샷 또는 60% 미달/특이사항 공유:

## 스크린샷/로그 (선택)
- 없음

## 롤백/리스크
- 리스크 포인트:
  - **응답 형식 변경 (성공/실패 모두)**: 기존 OAuth2 콜백은 JSON 본문 응답 → 302 redirect로 일원화. 프론트는 콜백 페이지에서 query string의 `access`/`refresh` 또는 `error` 추출 (프론트 합의 완료, 실패 redirect는 프론트 요청으로 추가됨)
  - **프론트 호출 규약**: OAuth2 시작 시 `/oauth2/authorization/{provider}?env=local|production` query 파라미터 추가. 미전송 시 `defaultEnv` fallback (legacy 호환)
  - **콜백 URL 해석 단일 진실**: 성공·실패 두 핸들러 모두 신규 `OAuthCallbackUrlResolver` 컴포넌트에 위임 — env 쿠키 기반 매칭/만료 로직이 한 곳에서 관리됨
  - **실패 시 query**: error code(`AUTH_001` 등)만 노출, 사용자 메시지는 query 미포함 (정보 노출·인코딩 부담 회피, 상세 사유는 서버 로그)
- 롤백 방법: 본 PR revert 후 SSM 키 삭제. 단수형 키(`AUTH_FRONT_CALLBACK_URL`)는 어차피 미사용이라 부팅 영향 없음

## 관련 이슈
Closes #82

> 추가 노트: 실패 redirect는 이슈 본문엔 미명시였으나 프론트의 추가 요청으로 본 PR 범위에 통합. 별도 이슈 없이 #82에서 함께 닫음.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새 기능**
  - OAuth2 인증 흐름을 여러 환경의 콜백 URL로 리다이렉트하도록 개선했습니다.
  - 프론트엔드에서 `?env=` 쿼리 파라미터로 콜백 환경을 선택할 수 있습니다.
  - 지정되지 않은 경우 기본 환경으로 자동 폴백됩니다.

* **개선사항**
  - OAuth2 로그인 성공/실패 응답을 JSON에서 리다이렉트 방식으로 변경했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->