### PR TITLE
feat: 캘린더 메인 홈 월/일 프리뷰 API (#83)

### DIFF
--- a/src/main/java/com/groute/groute_server/calendar/controller/CalendarHomeController.java
+++ b/src/main/java/com/groute/groute_server/calendar/controller/CalendarHomeController.java
@@ -1,0 +1,82 @@
+package com.groute.groute_server.calendar.controller;
+
+import java.time.LocalDate;
+import java.time.YearMonth;
+
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.groute.groute_server.calendar.dto.CalendarDailyPreviewResponse;
+import com.groute.groute_server.calendar.dto.CalendarMonthlyResponse;
+import com.groute.groute_server.calendar.service.CalendarHomeService;
+import com.groute.groute_server.common.annotation.CurrentUser;
+import com.groute.groute_server.common.response.ApiResponse;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * 캘린더 메인 홈 조회 엔드포인트(CAL-001).
+ *
+ * <p>월별 잔디(스크럼/STAR 작성 + 대표 역량) 데이터와 날짜 클릭 시 노출되는 프리뷰 목록을 반환한다. 인증된 사용자(JWT) 본인 데이터만 조회.
+ */
+@Tag(name = "Calendar", description = "일자별 스크럼 조회")
+@RestController
+@RequestMapping("/api/calendar")
+@RequiredArgsConstructor
+public class CalendarHomeController {
+
+    private final CalendarHomeService calendarHomeService;
+
+    @Operation(
+            summary = "월별 캘린더 데이터 조회",
+            description =
+                    "지정한 연월(yyyy-MM)의 일별 데이터(스크럼/STAR 작성 여부, 대표 역량, STAR 완료 건수)를 1일~말일 모두 포함해 반환한다.")
+    @ApiResponses({
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                responseCode = "200",
+                description = "조회 성공"),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                responseCode = "400",
+                description = "month 형식이 올바르지 않음 (yyyy-MM)"),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                responseCode = "401",
+                description = "미인증 또는 만료된 액세스 토큰")
+    })
+    @GetMapping("/monthly")
+    public ApiResponse<CalendarMonthlyResponse> getMonthly(
+            @CurrentUser Long userId,
+            @RequestParam("month") @DateTimeFormat(pattern = "yyyy-MM") YearMonth month) {
+        return ApiResponse.ok(
+                CalendarMonthlyResponse.from(calendarHomeService.getMonthly(userId, month)));
+    }
+
+    @Operation(
+            summary = "날짜 프리뷰 조회",
+            description =
+                    "지정한 일자(yyyy-MM-dd)의 스크럼 목록을 반환한다. STAR 완료 시에만 대표 역량/세부 태그가 채워지며 그 외 null.")
+    @ApiResponses({
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                responseCode = "200",
+                description = "조회 성공"),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                responseCode = "400",
+                description = "date 형식이 올바르지 않음 (yyyy-MM-dd)"),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                responseCode = "401",
+                description = "미인증 또는 만료된 액세스 토큰")
+    })
+    @GetMapping("/daily-preview")
+    public ApiResponse<CalendarDailyPreviewResponse> getDailyPreview(
+            @CurrentUser Long userId,
+            @RequestParam("date") @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate date) {
+        return ApiResponse.ok(
+                CalendarDailyPreviewResponse.from(
+                        calendarHomeService.getDailyPreview(userId, date)));
+    }
+}

--- a/src/main/java/com/groute/groute_server/calendar/controller/CalendarHomeController.java
+++ b/src/main/java/com/groute/groute_server/calendar/controller/CalendarHomeController.java
@@ -25,7 +25,7 @@ import lombok.RequiredArgsConstructor;
  *
  * <p>월별 잔디(스크럼/STAR 작성 + 대표 역량) 데이터와 날짜 클릭 시 노출되는 프리뷰 목록을 반환한다. 인증된 사용자(JWT) 본인 데이터만 조회.
  */
-@Tag(name = "Calendar", description = "일자별 스크럼 조회")
+@Tag(name = "Calendar", description = "캘린더 조회 (메인 홈 월/일 프리뷰 + 일자별 스크럼)")
 @RestController
 @RequestMapping("/api/calendar")
 @RequiredArgsConstructor

--- a/src/main/java/com/groute/groute_server/calendar/dto/CalendarDailyPreviewResponse.java
+++ b/src/main/java/com/groute/groute_server/calendar/dto/CalendarDailyPreviewResponse.java
@@ -2,6 +2,7 @@ package com.groute.groute_server.calendar.dto;
 
 import java.util.List;
 
+import com.groute.groute_server.calendar.service.CalendarDailyPreviewView;
 import com.groute.groute_server.record.domain.enums.CompetencyCategory;
 
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -16,6 +17,23 @@ import io.swagger.v3.oas.annotations.media.Schema;
 public record CalendarDailyPreviewResponse(
         @Schema(description = "조회한 날짜 (yyyy-MM-dd)", example = "2026-04-02") String date,
         @Schema(description = "스크럼 목록 (없으면 빈 배열)") List<ScrumPreview> scrums) {
+
+    public static CalendarDailyPreviewResponse from(CalendarDailyPreviewView view) {
+        List<ScrumPreview> previews =
+                view.scrums().stream()
+                        .map(
+                                s ->
+                                        new ScrumPreview(
+                                                s.scrumId(),
+                                                s.projectName(),
+                                                s.freeText(),
+                                                s.content(),
+                                                s.primaryCategory(),
+                                                s.detailTags(),
+                                                s.hasStar()))
+                        .toList();
+        return new CalendarDailyPreviewResponse(view.date().toString(), previews);
+    }
 
     @Schema(description = "스크럼 프리뷰 항목")
     public record ScrumPreview(

--- a/src/main/java/com/groute/groute_server/calendar/dto/CalendarDailyPreviewResponse.java
+++ b/src/main/java/com/groute/groute_server/calendar/dto/CalendarDailyPreviewResponse.java
@@ -1,0 +1,37 @@
+package com.groute.groute_server.calendar.dto;
+
+import java.util.List;
+
+import com.groute.groute_server.record.domain.enums.CompetencyCategory;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+/**
+ * 캘린더 메인 홈 날짜 프리뷰 조회 응답 DTO.
+ *
+ * <p>지정 일자의 스크럼 목록을 반환한다. 각 스크럼은 STAR 완료 시에만 {@code primaryCategory}/{@code detailTags}가 채워지며,
+ * 미완료/미작성이면 두 필드 모두 {@code null}.
+ */
+@Schema(description = "날짜 프리뷰 조회 응답")
+public record CalendarDailyPreviewResponse(
+        @Schema(description = "조회한 날짜 (yyyy-MM-dd)", example = "2026-04-02") String date,
+        @Schema(description = "스크럼 목록 (없으면 빈 배열)") List<ScrumPreview> scrums) {
+
+    @Schema(description = "스크럼 프리뷰 항목")
+    public record ScrumPreview(
+            @Schema(description = "스크럼 식별자", example = "1") Long scrumId,
+            @Schema(description = "프로젝트 태그명 (최대 15자)", example = "밋업프로젝트") String projectName,
+            @Schema(description = "제목 자유작성 영역 (최대 20자)", example = "기획 작업") String freeText,
+            @Schema(description = "스크럼 본문 (최대 50자)", example = "어드민 페이지 기능명세서 작성") String content,
+            @Schema(
+                            description = "대표 역량. STAR 완료 기록이 없으면 null",
+                            example = "PLANNING_EXECUTION",
+                            nullable = true)
+                    CompetencyCategory primaryCategory,
+            @Schema(
+                            description = "세부 역량 태그 (최대 3개). STAR 완료 기록이 없으면 null",
+                            example = "[\"UX 설계\", \"품질 관리\"]",
+                            nullable = true)
+                    List<String> detailTags,
+            @Schema(description = "STAR 완료 여부", example = "true") boolean hasStar) {}
+}

--- a/src/main/java/com/groute/groute_server/calendar/dto/CalendarMonthlyResponse.java
+++ b/src/main/java/com/groute/groute_server/calendar/dto/CalendarMonthlyResponse.java
@@ -1,0 +1,31 @@
+package com.groute.groute_server.calendar.dto;
+
+import java.util.List;
+
+import com.groute.groute_server.record.domain.enums.CompetencyCategory;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+/**
+ * 캘린더 메인 홈 월별 조회 응답 DTO.
+ *
+ * <p>해당 월의 1일부터 말일까지 모든 일자가 포함되며, 데이터가 없는 날도 {@code hasScrums=false}, {@code hasStar=false}, {@code
+ * primaryCategory=null}, {@code starCount=0}로 표현된다.
+ */
+@Schema(description = "월별 캘린더 데이터 조회 응답")
+public record CalendarMonthlyResponse(
+        @Schema(description = "조회한 연월 (yyyy-MM)", example = "2026-04") String month,
+        @Schema(description = "일별 캘린더 데이터 목록 (해당 월 1일~말일 모두 포함)") List<DayInfo> days) {
+
+    @Schema(description = "일별 캘린더 데이터")
+    public record DayInfo(
+            @Schema(description = "날짜 (yyyy-MM-dd)", example = "2026-04-02") String date,
+            @Schema(description = "스크럼 작성 여부", example = "true") boolean hasScrums,
+            @Schema(description = "STAR 완료 여부", example = "true") boolean hasStar,
+            @Schema(
+                            description = "대표 역량. STAR 완료 기록이 없으면 null",
+                            example = "PLANNING_EXECUTION",
+                            nullable = true)
+                    CompetencyCategory primaryCategory,
+            @Schema(description = "해당 일자의 STAR 완료 건수", example = "2") int starCount) {}
+}

--- a/src/main/java/com/groute/groute_server/calendar/dto/CalendarMonthlyResponse.java
+++ b/src/main/java/com/groute/groute_server/calendar/dto/CalendarMonthlyResponse.java
@@ -2,6 +2,7 @@ package com.groute.groute_server.calendar.dto;
 
 import java.util.List;
 
+import com.groute.groute_server.calendar.service.CalendarMonthlyView;
 import com.groute.groute_server.record.domain.enums.CompetencyCategory;
 
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -16,6 +17,21 @@ import io.swagger.v3.oas.annotations.media.Schema;
 public record CalendarMonthlyResponse(
         @Schema(description = "조회한 연월 (yyyy-MM)", example = "2026-04") String month,
         @Schema(description = "일별 캘린더 데이터 목록 (해당 월 1일~말일 모두 포함)") List<DayInfo> days) {
+
+    public static CalendarMonthlyResponse from(CalendarMonthlyView view) {
+        List<DayInfo> dayInfos =
+                view.days().stream()
+                        .map(
+                                d ->
+                                        new DayInfo(
+                                                d.date().toString(),
+                                                d.hasScrums(),
+                                                d.hasStar(),
+                                                d.primaryCategory(),
+                                                d.starCount()))
+                        .toList();
+        return new CalendarMonthlyResponse(view.month().toString(), dayInfos);
+    }
 
     @Schema(description = "일별 캘린더 데이터")
     public record DayInfo(

--- a/src/main/java/com/groute/groute_server/calendar/repository/CalendarHomeRepository.java
+++ b/src/main/java/com/groute/groute_server/calendar/repository/CalendarHomeRepository.java
@@ -20,6 +20,11 @@ import lombok.RequiredArgsConstructor;
  * <p>scrum_date는 {@code LocalDate}로 저장되어 별도 timezone 변환이 필요 없다. STAR 완료된 day의 대표 역량은 같은
  * starRecord에서 1~3개의 StarTag row가 나오므로, 호출 측에서 starRecordId 기준 distinct 처리 후 가장 최근 완료 record의
  * primaryCategory를 사용한다.
+ *
+ * <p><b>Soft-delete 처리</b>: {@link com.groute.groute_server.common.entity.SoftDeleteEntity}는
+ * {@code @Where} 자동 필터를 걸지 않으므로, 모든 JPQL에 명시적으로 {@code AND s.isDeleted = false} 조건을 추가한다(record 도메인
+ * 쿼리와 동일 컨벤션). StarTag는 BaseTimeEntity를 상속하여 자체 soft-delete 필드가 없으며, 부모 StarRecord의 {@code
+ * isDeleted=false}로 보호된다.
  */
 @Repository
 @RequiredArgsConstructor
@@ -27,7 +32,7 @@ public class CalendarHomeRepository {
 
     private final EntityManager em;
 
-    /** 사용자가 해당 기간에 스크럼을 작성한 날짜 set. */
+    /** 사용자가 해당 기간에 스크럼을 작성한 날짜 set. soft-delete된 scrum은 제외. */
     public List<LocalDate> findScrumDatesInRange(Long userId, LocalDate start, LocalDate end) {
         return em.createQuery(
                         """
@@ -35,6 +40,8 @@ public class CalendarHomeRepository {
                         FROM Scrum s
                         WHERE s.user.id = :userId
                           AND s.scrumDate BETWEEN :start AND :end
+                          AND s.isDeleted = false
+                        ORDER BY s.scrumDate
                         """,
                         LocalDate.class)
                 .setParameter("userId", userId)
@@ -47,7 +54,7 @@ public class CalendarHomeRepository {
      * 해당 기간에 완료된 STAR 기록의 day-level row.
      *
      * <p>StarTag join으로 starRecord 1개당 1~3 row가 나온다. 호출 측에서 starRecordId 기준 distinct로 카운트하고, 동일
-     * record의 primaryCategory는 모든 row가 같은 값을 가진다.
+     * record의 primaryCategory는 모든 row가 같은 값을 가진다. soft-delete된 starRecord는 제외.
      */
     public List<StarDailyRow> findCompletedStarRowsInRange(
             Long userId, LocalDate start, LocalDate end) {
@@ -59,7 +66,9 @@ public class CalendarHomeRepository {
                         JOIN st.starRecord sr
                         WHERE sr.user.id = :userId
                           AND sr.isCompleted = true
+                          AND sr.isDeleted = false
                           AND sr.scrum.scrumDate BETWEEN :start AND :end
+                        ORDER BY sr.scrum.scrumDate, sr.completedAt
                         """,
                         StarDailyRow.class)
                 .setParameter("userId", userId)
@@ -68,7 +77,12 @@ public class CalendarHomeRepository {
                 .getResultList();
     }
 
-    /** 지정 일자의 사용자 스크럼 목록. ScrumTitle·Project를 fetch join 하여 추가 쿼리를 피한다. */
+    /**
+     * 지정 일자의 사용자 스크럼 목록. ScrumTitle·Project를 fetch join 하여 추가 쿼리를 피한다.
+     *
+     * <p>soft-delete된 scrum은 제외. (title/project는 부모 scrum이 살아있으면 동시 살아있다고 가정하는 record 도메인 컨벤션을 따라
+     * 추가 필터하지 않는다.)
+     */
     public List<Scrum> findScrumsByUserAndDate(Long userId, LocalDate date) {
         return em.createQuery(
                         """
@@ -78,6 +92,7 @@ public class CalendarHomeRepository {
                         JOIN FETCH t.project
                         WHERE s.user.id = :userId
                           AND s.scrumDate = :date
+                          AND s.isDeleted = false
                         ORDER BY s.id
                         """,
                         Scrum.class)
@@ -89,7 +104,8 @@ public class CalendarHomeRepository {
     /**
      * 지정 scrumId 집합 중 STAR가 완료된 record의 StarTag row 목록.
      *
-     * <p>한 StarRecord(=Scrum 1:1)에 1~3개의 row가 반환된다. 정렬은 {@code st.id ASC}로 안정적.
+     * <p>한 StarRecord(=Scrum 1:1)에 1~3개의 row가 반환된다. 정렬은 {@code st.id ASC}로 안정적. soft-delete된
+     * starRecord는 제외.
      */
     public List<ScrumStarTagRow> findCompletedStarTagsByScrumIds(List<Long> scrumIds) {
         if (scrumIds.isEmpty()) {
@@ -103,6 +119,7 @@ public class CalendarHomeRepository {
                         JOIN st.starRecord sr
                         WHERE sr.scrum.id IN :scrumIds
                           AND sr.isCompleted = true
+                          AND sr.isDeleted = false
                         ORDER BY st.id
                         """,
                         ScrumStarTagRow.class)

--- a/src/main/java/com/groute/groute_server/calendar/repository/CalendarHomeRepository.java
+++ b/src/main/java/com/groute/groute_server/calendar/repository/CalendarHomeRepository.java
@@ -7,6 +7,8 @@ import jakarta.persistence.EntityManager;
 
 import org.springframework.stereotype.Repository;
 
+import com.groute.groute_server.record.domain.Scrum;
+
 import lombok.RequiredArgsConstructor;
 
 /**
@@ -63,6 +65,48 @@ public class CalendarHomeRepository {
                 .setParameter("userId", userId)
                 .setParameter("start", start)
                 .setParameter("end", end)
+                .getResultList();
+    }
+
+    /** 지정 일자의 사용자 스크럼 목록. ScrumTitle·Project를 fetch join 하여 추가 쿼리를 피한다. */
+    public List<Scrum> findScrumsByUserAndDate(Long userId, LocalDate date) {
+        return em.createQuery(
+                        """
+                        SELECT s
+                        FROM Scrum s
+                        JOIN FETCH s.title t
+                        JOIN FETCH t.project
+                        WHERE s.user.id = :userId
+                          AND s.scrumDate = :date
+                        ORDER BY s.id
+                        """,
+                        Scrum.class)
+                .setParameter("userId", userId)
+                .setParameter("date", date)
+                .getResultList();
+    }
+
+    /**
+     * 지정 scrumId 집합 중 STAR가 완료된 record의 StarTag row 목록.
+     *
+     * <p>한 StarRecord(=Scrum 1:1)에 1~3개의 row가 반환된다. 정렬은 {@code st.id ASC}로 안정적.
+     */
+    public List<ScrumStarTagRow> findCompletedStarTagsByScrumIds(List<Long> scrumIds) {
+        if (scrumIds.isEmpty()) {
+            return List.of();
+        }
+        return em.createQuery(
+                        """
+                        SELECT new com.groute.groute_server.calendar.repository.ScrumStarTagRow(
+                            sr.scrum.id, st.primaryCategory, st.detailTag)
+                        FROM StarTag st
+                        JOIN st.starRecord sr
+                        WHERE sr.scrum.id IN :scrumIds
+                          AND sr.isCompleted = true
+                        ORDER BY st.id
+                        """,
+                        ScrumStarTagRow.class)
+                .setParameter("scrumIds", scrumIds)
                 .getResultList();
     }
 }

--- a/src/main/java/com/groute/groute_server/calendar/repository/CalendarHomeRepository.java
+++ b/src/main/java/com/groute/groute_server/calendar/repository/CalendarHomeRepository.java
@@ -105,9 +105,10 @@ public class CalendarHomeRepository {
      * 지정 scrumId 집합 중 STAR가 완료된 record의 StarTag row 목록.
      *
      * <p>한 StarRecord(=Scrum 1:1)에 1~3개의 row가 반환된다. 정렬은 {@code st.id ASC}로 안정적. soft-delete된
-     * starRecord는 제외.
+     * starRecord는 제외. 호출부가 본인 scrumIds만 전달한다고 신뢰하지 않고 저장소 단에서도 {@code userId}로 한 번 더
+     * 강제(defense-in-depth).
      */
-    public List<ScrumStarTagRow> findCompletedStarTagsByScrumIds(List<Long> scrumIds) {
+    public List<ScrumStarTagRow> findCompletedStarTagsByScrumIds(Long userId, List<Long> scrumIds) {
         if (scrumIds.isEmpty()) {
             return List.of();
         }
@@ -118,11 +119,13 @@ public class CalendarHomeRepository {
                         FROM StarTag st
                         JOIN st.starRecord sr
                         WHERE sr.scrum.id IN :scrumIds
+                          AND sr.user.id = :userId
                           AND sr.isCompleted = true
                           AND sr.isDeleted = false
                         ORDER BY st.id
                         """,
                         ScrumStarTagRow.class)
+                .setParameter("userId", userId)
                 .setParameter("scrumIds", scrumIds)
                 .getResultList();
     }

--- a/src/main/java/com/groute/groute_server/calendar/repository/CalendarHomeRepository.java
+++ b/src/main/java/com/groute/groute_server/calendar/repository/CalendarHomeRepository.java
@@ -1,0 +1,68 @@
+package com.groute.groute_server.calendar.repository;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import jakarta.persistence.EntityManager;
+
+import org.springframework.stereotype.Repository;
+
+import lombok.RequiredArgsConstructor;
+
+/**
+ * 캘린더 메인 홈 조회 전용 Repository.
+ *
+ * <p>record 도메인 entity({@code Scrum}, {@code StarRecord}, {@code StarTag})를 read-only로 조회한다. 쓰기 로직은
+ * record 도메인 책임이며, 본 클래스는 read 전용이다.
+ *
+ * <p>scrum_date는 {@code LocalDate}로 저장되어 별도 timezone 변환이 필요 없다. STAR 완료된 day의 대표 역량은 같은
+ * starRecord에서 1~3개의 StarTag row가 나오므로, 호출 측에서 starRecordId 기준 distinct 처리 후 가장 최근 완료 record의
+ * primaryCategory를 사용한다.
+ */
+@Repository
+@RequiredArgsConstructor
+public class CalendarHomeRepository {
+
+    private final EntityManager em;
+
+    /** 사용자가 해당 기간에 스크럼을 작성한 날짜 set. */
+    public List<LocalDate> findScrumDatesInRange(Long userId, LocalDate start, LocalDate end) {
+        return em.createQuery(
+                        """
+                        SELECT DISTINCT s.scrumDate
+                        FROM Scrum s
+                        WHERE s.user.id = :userId
+                          AND s.scrumDate BETWEEN :start AND :end
+                        """,
+                        LocalDate.class)
+                .setParameter("userId", userId)
+                .setParameter("start", start)
+                .setParameter("end", end)
+                .getResultList();
+    }
+
+    /**
+     * 해당 기간에 완료된 STAR 기록의 day-level row.
+     *
+     * <p>StarTag join으로 starRecord 1개당 1~3 row가 나온다. 호출 측에서 starRecordId 기준 distinct로 카운트하고, 동일
+     * record의 primaryCategory는 모든 row가 같은 값을 가진다.
+     */
+    public List<StarDailyRow> findCompletedStarRowsInRange(
+            Long userId, LocalDate start, LocalDate end) {
+        return em.createQuery(
+                        """
+                        SELECT new com.groute.groute_server.calendar.repository.StarDailyRow(
+                            sr.id, sr.scrum.scrumDate, sr.completedAt, st.primaryCategory)
+                        FROM StarTag st
+                        JOIN st.starRecord sr
+                        WHERE sr.user.id = :userId
+                          AND sr.isCompleted = true
+                          AND sr.scrum.scrumDate BETWEEN :start AND :end
+                        """,
+                        StarDailyRow.class)
+                .setParameter("userId", userId)
+                .setParameter("start", start)
+                .setParameter("end", end)
+                .getResultList();
+    }
+}

--- a/src/main/java/com/groute/groute_server/calendar/repository/ScrumStarTagRow.java
+++ b/src/main/java/com/groute/groute_server/calendar/repository/ScrumStarTagRow.java
@@ -1,0 +1,11 @@
+package com.groute.groute_server.calendar.repository;
+
+import com.groute.groute_server.record.domain.enums.CompetencyCategory;
+
+/**
+ * 날짜 프리뷰용 STAR 태그 row projection.
+ *
+ * <p>한 StarRecord에 StarTag가 1~3개 row 있으므로 동일 {@code scrumId}로 1~3 row가 반환된다. {@code
+ * primaryCategory}는 모든 row가 같은 값을 가지며, {@code detailTag}는 row마다 다르다.
+ */
+public record ScrumStarTagRow(Long scrumId, CompetencyCategory primaryCategory, String detailTag) {}

--- a/src/main/java/com/groute/groute_server/calendar/repository/StarDailyRow.java
+++ b/src/main/java/com/groute/groute_server/calendar/repository/StarDailyRow.java
@@ -1,0 +1,18 @@
+package com.groute.groute_server.calendar.repository;
+
+import java.time.LocalDate;
+import java.time.OffsetDateTime;
+
+import com.groute.groute_server.record.domain.enums.CompetencyCategory;
+
+/**
+ * 월별 캘린더 집계용 STAR row projection.
+ *
+ * <p>한 StarRecord에 StarTag가 1~3개 있으므로 동일 {@code starRecordId}로 1~3 row가 반환될 수 있다. 그날 STAR 카운트를 셀 때는
+ * {@code starRecordId} 기준 distinct가 필요하며, 대표 역량은 한 record 내 모든 row가 같은 값을 가진다.
+ */
+public record StarDailyRow(
+        Long starRecordId,
+        LocalDate scrumDate,
+        OffsetDateTime completedAt,
+        CompetencyCategory primaryCategory) {}

--- a/src/main/java/com/groute/groute_server/calendar/service/CalendarDailyPreviewView.java
+++ b/src/main/java/com/groute/groute_server/calendar/service/CalendarDailyPreviewView.java
@@ -1,0 +1,24 @@
+package com.groute.groute_server.calendar.service;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import com.groute.groute_server.record.domain.enums.CompetencyCategory;
+
+/**
+ * 날짜 프리뷰 도메인 뷰.
+ *
+ * <p>지정 일자의 스크럼 목록을 service ↔ controller 사이에 전달한다. STAR 완료 기록이 있는 스크럼만 {@code
+ * primaryCategory}/{@code detailTags}가 채워지며, 미완료/미작성이면 두 필드 모두 {@code null}.
+ */
+public record CalendarDailyPreviewView(LocalDate date, List<ScrumItem> scrums) {
+
+    public record ScrumItem(
+            Long scrumId,
+            String projectName,
+            String freeText,
+            String content,
+            CompetencyCategory primaryCategory,
+            List<String> detailTags,
+            boolean hasStar) {}
+}

--- a/src/main/java/com/groute/groute_server/calendar/service/CalendarHomeService.java
+++ b/src/main/java/com/groute/groute_server/calendar/service/CalendarHomeService.java
@@ -14,7 +14,9 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.groute.groute_server.calendar.repository.CalendarHomeRepository;
+import com.groute.groute_server.calendar.repository.ScrumStarTagRow;
 import com.groute.groute_server.calendar.repository.StarDailyRow;
+import com.groute.groute_server.record.domain.Scrum;
 import com.groute.groute_server.record.domain.enums.CompetencyCategory;
 
 import lombok.RequiredArgsConstructor;
@@ -62,6 +64,46 @@ public class CalendarHomeService {
                             d, hasScrums, starCount > 0, primary, starCount));
         }
         return new CalendarMonthlyView(month, days);
+    }
+
+    /**
+     * 지정 일자의 스크럼 프리뷰 목록을 반환한다. 본인 데이터만 포함되며 빈 결과는 {@code scrums=[]}.
+     *
+     * <p>각 스크럼의 {@code primaryCategory}/{@code detailTags}는 STAR가 완료된 경우에만
+     * 채워진다(`isCompleted=true`). 미완료/미작성이면 두 필드 모두 {@code null}이며, {@code detailTags}는 안전 차원에서 최대
+     * 3개로 제한.
+     */
+    public CalendarDailyPreviewView getDailyPreview(Long userId, LocalDate date) {
+        List<Scrum> scrums = calendarHomeRepository.findScrumsByUserAndDate(userId, date);
+        if (scrums.isEmpty()) {
+            return new CalendarDailyPreviewView(date, List.of());
+        }
+
+        List<Long> scrumIds = scrums.stream().map(Scrum::getId).toList();
+        Map<Long, List<ScrumStarTagRow>> tagsByScrumId =
+                calendarHomeRepository.findCompletedStarTagsByScrumIds(scrumIds).stream()
+                        .collect(Collectors.groupingBy(ScrumStarTagRow::scrumId));
+
+        List<CalendarDailyPreviewView.ScrumItem> items = new ArrayList<>();
+        for (Scrum scrum : scrums) {
+            List<ScrumStarTagRow> tagRows = tagsByScrumId.get(scrum.getId());
+            CompetencyCategory primary = null;
+            List<String> detailTags = null;
+            if (tagRows != null && !tagRows.isEmpty()) {
+                primary = tagRows.get(0).primaryCategory();
+                detailTags = tagRows.stream().map(ScrumStarTagRow::detailTag).limit(3).toList();
+            }
+            items.add(
+                    new CalendarDailyPreviewView.ScrumItem(
+                            scrum.getId(),
+                            scrum.getTitle().getProject().getName(),
+                            scrum.getTitle().getFreeText(),
+                            scrum.getContent(),
+                            primary,
+                            detailTags,
+                            scrum.isHasStar()));
+        }
+        return new CalendarDailyPreviewView(date, items);
     }
 
     /** 그날 STAR 행 중 가장 최근 완료된 row의 primaryCategory. 비어 있으면 {@code null}. */

--- a/src/main/java/com/groute/groute_server/calendar/service/CalendarHomeService.java
+++ b/src/main/java/com/groute/groute_server/calendar/service/CalendarHomeService.java
@@ -1,0 +1,80 @@
+package com.groute.groute_server.calendar.service;
+
+import java.time.LocalDate;
+import java.time.YearMonth;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.groute.groute_server.calendar.repository.CalendarHomeRepository;
+import com.groute.groute_server.calendar.repository.StarDailyRow;
+import com.groute.groute_server.record.domain.enums.CompetencyCategory;
+
+import lombok.RequiredArgsConstructor;
+
+/**
+ * 캘린더 메인 홈 조회 서비스 (CAL-001).
+ *
+ * <p>월별 캘린더 데이터(잔디 색상용 대표 역량 + 스크럼/STAR 작성 표시)와 날짜 프리뷰를 조회한다. 본인 데이터만 반환하며 쓰기 로직은 갖지 않는다.
+ *
+ * <p>한 일자에 STAR가 여러 개 완료된 경우 대표 역량은 가장 최근 완료된 record의 {@code primaryCategory}를 사용한다.
+ */
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class CalendarHomeService {
+
+    private final CalendarHomeRepository calendarHomeRepository;
+
+    /**
+     * 월별 캘린더 데이터를 반환한다. 해당 월의 1일~말일 모든 날짜가 포함되며, 데이터가 없는 날도 빈 집계로 채운다.
+     *
+     * @param userId 조회 대상 사용자
+     * @param month 조회 연월
+     */
+    public CalendarMonthlyView getMonthly(Long userId, YearMonth month) {
+        LocalDate start = month.atDay(1);
+        LocalDate end = month.atEndOfMonth();
+
+        Set<LocalDate> scrumDates =
+                new HashSet<>(calendarHomeRepository.findScrumDatesInRange(userId, start, end));
+
+        Map<LocalDate, List<StarDailyRow>> starsByDate =
+                calendarHomeRepository.findCompletedStarRowsInRange(userId, start, end).stream()
+                        .collect(Collectors.groupingBy(StarDailyRow::scrumDate));
+
+        List<CalendarMonthlyView.DayAggregate> days = new ArrayList<>();
+        for (LocalDate d = start; !d.isAfter(end); d = d.plusDays(1)) {
+            boolean hasScrums = scrumDates.contains(d);
+            List<StarDailyRow> dayStars = starsByDate.getOrDefault(d, List.of());
+            int starCount =
+                    (int) dayStars.stream().map(StarDailyRow::starRecordId).distinct().count();
+            CompetencyCategory primary = pickPrimaryCategory(dayStars);
+            days.add(
+                    new CalendarMonthlyView.DayAggregate(
+                            d, hasScrums, starCount > 0, primary, starCount));
+        }
+        return new CalendarMonthlyView(month, days);
+    }
+
+    /** 그날 STAR 행 중 가장 최근 완료된 row의 primaryCategory. 비어 있으면 {@code null}. */
+    private static CompetencyCategory pickPrimaryCategory(List<StarDailyRow> dayStars) {
+        if (dayStars.isEmpty()) {
+            return null;
+        }
+        return dayStars.stream()
+                .max(
+                        Comparator.comparing(
+                                StarDailyRow::completedAt,
+                                Comparator.nullsLast(Comparator.naturalOrder())))
+                .map(StarDailyRow::primaryCategory)
+                .orElse(null);
+    }
+}

--- a/src/main/java/com/groute/groute_server/calendar/service/CalendarHomeService.java
+++ b/src/main/java/com/groute/groute_server/calendar/service/CalendarHomeService.java
@@ -81,7 +81,7 @@ public class CalendarHomeService {
 
         List<Long> scrumIds = scrums.stream().map(Scrum::getId).toList();
         Map<Long, List<ScrumStarTagRow>> tagsByScrumId =
-                calendarHomeRepository.findCompletedStarTagsByScrumIds(scrumIds).stream()
+                calendarHomeRepository.findCompletedStarTagsByScrumIds(userId, scrumIds).stream()
                         .collect(Collectors.groupingBy(ScrumStarTagRow::scrumId));
 
         List<CalendarDailyPreviewView.ScrumItem> items = new ArrayList<>();

--- a/src/main/java/com/groute/groute_server/calendar/service/CalendarMonthlyView.java
+++ b/src/main/java/com/groute/groute_server/calendar/service/CalendarMonthlyView.java
@@ -1,0 +1,24 @@
+package com.groute.groute_server.calendar.service;
+
+import java.time.LocalDate;
+import java.time.YearMonth;
+import java.util.List;
+
+import com.groute.groute_server.record.domain.enums.CompetencyCategory;
+
+/**
+ * 월별 캘린더 도메인 뷰.
+ *
+ * <p>해당 월의 1일부터 말일까지 모든 날짜가 포함되며, 데이터가 없는 날도 {@code hasScrums=false}, {@code hasStar=false}, {@code
+ * primaryCategory=null}, {@code starCount=0}로 채운다. service ↔ controller 사이 전달용이며 응답 DTO는 controller
+ * 계층에서 변환한다.
+ */
+public record CalendarMonthlyView(YearMonth month, List<DayAggregate> days) {
+
+    public record DayAggregate(
+            LocalDate date,
+            boolean hasScrums,
+            boolean hasStar,
+            CompetencyCategory primaryCategory,
+            int starCount) {}
+}

--- a/src/main/java/com/groute/groute_server/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/groute/groute_server/common/exception/GlobalExceptionHandler.java
@@ -12,6 +12,7 @@ import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
 
 import com.groute.groute_server.common.response.ErrorResponse;
 import com.groute.groute_server.common.webhook.ErrorWebhookNotifier;
@@ -92,6 +93,24 @@ public class GlobalExceptionHandler {
             HttpMessageNotReadableException e) {
         log.warn("HttpMessageNotReadableException: {}", e.getMessage());
         return ResponseEntity.badRequest().body(ErrorResponse.of(ErrorCode.INVALID_REQUEST_BODY));
+    }
+
+    @ExceptionHandler(MethodArgumentTypeMismatchException.class)
+    protected ResponseEntity<ErrorResponse> handleMethodArgumentTypeMismatchException(
+            MethodArgumentTypeMismatchException e) {
+        log.warn(
+                "MethodArgumentTypeMismatchException: name={}, value={}",
+                e.getName(),
+                e.getValue());
+        String requiredType =
+                e.getRequiredType() != null ? e.getRequiredType().getSimpleName() : "?";
+        ErrorResponse.FieldError fieldError =
+                ErrorResponse.FieldError.of(
+                        e.getName(),
+                        e.getValue() == null ? "" : e.getValue().toString(),
+                        "타입 변환 실패: " + requiredType + " 형식이어야 합니다.");
+        return ResponseEntity.badRequest()
+                .body(ErrorResponse.of(ErrorCode.INVALID_INPUT, List.of(fieldError)));
     }
 
     @ExceptionHandler(Exception.class)

--- a/src/test/java/com/groute/groute_server/calendar/service/CalendarHomeServiceTest.java
+++ b/src/test/java/com/groute/groute_server/calendar/service/CalendarHomeServiceTest.java
@@ -1,0 +1,292 @@
+package com.groute.groute_server.calendar.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+import java.lang.reflect.Constructor;
+import java.time.LocalDate;
+import java.time.OffsetDateTime;
+import java.time.YearMonth;
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import com.groute.groute_server.calendar.repository.CalendarHomeRepository;
+import com.groute.groute_server.calendar.repository.ScrumStarTagRow;
+import com.groute.groute_server.calendar.repository.StarDailyRow;
+import com.groute.groute_server.record.domain.Project;
+import com.groute.groute_server.record.domain.Scrum;
+import com.groute.groute_server.record.domain.ScrumTitle;
+import com.groute.groute_server.record.domain.enums.CompetencyCategory;
+
+@ExtendWith(MockitoExtension.class)
+class CalendarHomeServiceTest {
+
+    private static final Long USER_ID = 1L;
+    private static final YearMonth MONTH = YearMonth.of(2026, 4);
+    private static final LocalDate DATE = LocalDate.of(2026, 4, 2);
+
+    @Mock CalendarHomeRepository calendarHomeRepository;
+
+    @InjectMocks CalendarHomeService service;
+
+    @Nested
+    @DisplayName("getMonthly - HappyPath")
+    class MonthlyHappyPath {
+
+        @Test
+        @DisplayName("스크럼·STAR가 일부 일자에만 있을 때 1일~말일 모두 채우고 빈 날은 빈 집계로 표현한다")
+        void should_fillAllDays_when_someScrumDatesAndStars() {
+            // given
+            LocalDate start = MONTH.atDay(1);
+            LocalDate end = MONTH.atEndOfMonth();
+            LocalDate scrumOnly = LocalDate.of(2026, 4, 1);
+            LocalDate scrumWithStar = LocalDate.of(2026, 4, 2);
+            given(calendarHomeRepository.findScrumDatesInRange(USER_ID, start, end))
+                    .willReturn(List.of(scrumOnly, scrumWithStar));
+            given(calendarHomeRepository.findCompletedStarRowsInRange(USER_ID, start, end))
+                    .willReturn(
+                            List.of(
+                                    starRow(
+                                            10L,
+                                            scrumWithStar,
+                                            OffsetDateTime.parse("2026-04-02T10:00:00Z"),
+                                            CompetencyCategory.PLANNING_EXECUTION),
+                                    // 같은 starRecordId의 두 번째 StarTag row → distinct로 1개로 카운트
+                                    starRow(
+                                            10L,
+                                            scrumWithStar,
+                                            OffsetDateTime.parse("2026-04-02T10:00:00Z"),
+                                            CompetencyCategory.PLANNING_EXECUTION)));
+
+            // when
+            CalendarMonthlyView view = service.getMonthly(USER_ID, MONTH);
+
+            // then
+            assertThat(view.month()).isEqualTo(MONTH);
+            assertThat(view.days()).hasSize(end.getDayOfMonth());
+
+            CalendarMonthlyView.DayAggregate april1 = view.days().get(0);
+            assertThat(april1.date()).isEqualTo(scrumOnly);
+            assertThat(april1.hasScrums()).isTrue();
+            assertThat(april1.hasStar()).isFalse();
+            assertThat(april1.primaryCategory()).isNull();
+            assertThat(april1.starCount()).isZero();
+
+            CalendarMonthlyView.DayAggregate april2 = view.days().get(1);
+            assertThat(april2.hasScrums()).isTrue();
+            assertThat(april2.hasStar()).isTrue();
+            assertThat(april2.primaryCategory()).isEqualTo(CompetencyCategory.PLANNING_EXECUTION);
+            assertThat(april2.starCount()).isEqualTo(1);
+
+            CalendarMonthlyView.DayAggregate april3 = view.days().get(2);
+            assertThat(april3.hasScrums()).isFalse();
+            assertThat(april3.hasStar()).isFalse();
+            assertThat(april3.primaryCategory()).isNull();
+            assertThat(april3.starCount()).isZero();
+        }
+
+        @Test
+        @DisplayName("같은 날 여러 STAR가 완료되면 가장 최근 완료 record의 primaryCategory를 사용한다")
+        void should_pickLatestPrimaryCategory_when_multipleStarsOnSameDay() {
+            // given
+            LocalDate start = MONTH.atDay(1);
+            LocalDate end = MONTH.atEndOfMonth();
+            LocalDate day = LocalDate.of(2026, 4, 5);
+            given(calendarHomeRepository.findScrumDatesInRange(USER_ID, start, end))
+                    .willReturn(List.of(day));
+            given(calendarHomeRepository.findCompletedStarRowsInRange(USER_ID, start, end))
+                    .willReturn(
+                            List.of(
+                                    starRow(
+                                            1L,
+                                            day,
+                                            OffsetDateTime.parse("2026-04-05T08:00:00Z"),
+                                            CompetencyCategory.COLLABORATION),
+                                    starRow(
+                                            2L,
+                                            day,
+                                            OffsetDateTime.parse("2026-04-05T15:00:00Z"),
+                                            CompetencyCategory.PLANNING_EXECUTION)));
+
+            // when
+            CalendarMonthlyView view = service.getMonthly(USER_ID, MONTH);
+
+            // then
+            CalendarMonthlyView.DayAggregate april5 = view.days().get(4);
+            assertThat(april5.starCount()).isEqualTo(2);
+            assertThat(april5.primaryCategory()).isEqualTo(CompetencyCategory.PLANNING_EXECUTION);
+        }
+
+        @Test
+        @DisplayName("데이터가 없는 월이면 모든 일자가 빈 집계로 채워진다")
+        void should_returnEmptyAggregates_when_noData() {
+            // given
+            LocalDate start = MONTH.atDay(1);
+            LocalDate end = MONTH.atEndOfMonth();
+            given(calendarHomeRepository.findScrumDatesInRange(USER_ID, start, end))
+                    .willReturn(List.of());
+            given(calendarHomeRepository.findCompletedStarRowsInRange(USER_ID, start, end))
+                    .willReturn(List.of());
+
+            // when
+            CalendarMonthlyView view = service.getMonthly(USER_ID, MONTH);
+
+            // then
+            assertThat(view.days()).hasSize(30);
+            assertThat(view.days())
+                    .allSatisfy(
+                            d -> {
+                                assertThat(d.hasScrums()).isFalse();
+                                assertThat(d.hasStar()).isFalse();
+                                assertThat(d.primaryCategory()).isNull();
+                                assertThat(d.starCount()).isZero();
+                            });
+        }
+    }
+
+    @Nested
+    @DisplayName("getDailyPreview - HappyPath")
+    class DailyPreviewHappyPath {
+
+        @Test
+        @DisplayName("STAR가 완료된 스크럼은 primaryCategory와 detailTags가 채워진다")
+        void should_fillStarFields_when_starCompleted() {
+            // given
+            Scrum scrum = scrum(7L, "어드민 페이지 기능명세서 작성", true, 50L, "밋업프로젝트", "기획 작업");
+            given(calendarHomeRepository.findScrumsByUserAndDate(USER_ID, DATE))
+                    .willReturn(List.of(scrum));
+            given(calendarHomeRepository.findCompletedStarTagsByScrumIds(List.of(7L)))
+                    .willReturn(
+                            List.of(
+                                    new ScrumStarTagRow(
+                                            7L, CompetencyCategory.PLANNING_EXECUTION, "UX 설계"),
+                                    new ScrumStarTagRow(
+                                            7L, CompetencyCategory.PLANNING_EXECUTION, "품질 관리")));
+
+            // when
+            CalendarDailyPreviewView view = service.getDailyPreview(USER_ID, DATE);
+
+            // then
+            assertThat(view.date()).isEqualTo(DATE);
+            assertThat(view.scrums()).hasSize(1);
+            CalendarDailyPreviewView.ScrumItem item = view.scrums().get(0);
+            assertThat(item.scrumId()).isEqualTo(7L);
+            assertThat(item.projectName()).isEqualTo("밋업프로젝트");
+            assertThat(item.freeText()).isEqualTo("기획 작업");
+            assertThat(item.content()).isEqualTo("어드민 페이지 기능명세서 작성");
+            assertThat(item.primaryCategory()).isEqualTo(CompetencyCategory.PLANNING_EXECUTION);
+            assertThat(item.detailTags()).containsExactly("UX 설계", "품질 관리");
+            assertThat(item.hasStar()).isTrue();
+        }
+
+        @Test
+        @DisplayName("STAR가 미완료/미작성인 스크럼은 primaryCategory와 detailTags가 null")
+        void should_returnNullStarFields_when_noCompletedStar() {
+            // given — 스크럼은 있으나 완료된 STAR row 없음
+            Scrum scrum = scrum(7L, "본문", false, 50L, "밋업프로젝트", "기획 작업");
+            given(calendarHomeRepository.findScrumsByUserAndDate(USER_ID, DATE))
+                    .willReturn(List.of(scrum));
+            given(calendarHomeRepository.findCompletedStarTagsByScrumIds(List.of(7L)))
+                    .willReturn(List.of());
+
+            // when
+            CalendarDailyPreviewView view = service.getDailyPreview(USER_ID, DATE);
+
+            // then
+            CalendarDailyPreviewView.ScrumItem item = view.scrums().get(0);
+            assertThat(item.primaryCategory()).isNull();
+            assertThat(item.detailTags()).isNull();
+            assertThat(item.hasStar()).isFalse();
+        }
+
+        @Test
+        @DisplayName("스크럼이 없으면 빈 배열을 반환한다")
+        void should_returnEmptyScrums_when_noScrums() {
+            // given
+            given(calendarHomeRepository.findScrumsByUserAndDate(USER_ID, DATE))
+                    .willReturn(List.of());
+
+            // when
+            CalendarDailyPreviewView view = service.getDailyPreview(USER_ID, DATE);
+
+            // then
+            assertThat(view.scrums()).isEmpty();
+        }
+    }
+
+    @Nested
+    @DisplayName("Errors / 격리")
+    class Isolation {
+
+        @Test
+        @DisplayName("repository에 호출 user의 USER_ID를 그대로 전달한다 (다른 user 데이터 누출 방지)")
+        void should_passUserId_when_query() {
+            // given
+            given(calendarHomeRepository.findScrumsByUserAndDate(USER_ID, DATE))
+                    .willReturn(List.of());
+
+            // when
+            service.getDailyPreview(USER_ID, DATE);
+
+            // then
+            verify(calendarHomeRepository).findScrumsByUserAndDate(eq(USER_ID), eq(DATE));
+        }
+    }
+
+    // ============== helpers ==============
+
+    private static StarDailyRow starRow(
+            Long starRecordId,
+            LocalDate scrumDate,
+            OffsetDateTime completedAt,
+            CompetencyCategory primary) {
+        return new StarDailyRow(starRecordId, scrumDate, completedAt, primary);
+    }
+
+    private static Scrum scrum(
+            Long id,
+            String content,
+            boolean hasStar,
+            Long titleId,
+            String projectName,
+            String freeText) {
+        Scrum scrum = new Scrum();
+        ReflectionTestUtils.setField(scrum, "id", id);
+        ReflectionTestUtils.setField(scrum, "content", content);
+        ReflectionTestUtils.setField(scrum, "hasStar", hasStar);
+        ReflectionTestUtils.setField(scrum, "title", title(titleId, projectName, freeText));
+        return scrum;
+    }
+
+    private static ScrumTitle title(Long id, String projectName, String freeText) {
+        ScrumTitle title = new ScrumTitle();
+        ReflectionTestUtils.setField(title, "id", id);
+        ReflectionTestUtils.setField(title, "project", project(1L, projectName));
+        ReflectionTestUtils.setField(title, "freeText", freeText);
+        return title;
+    }
+
+    private static Project project(Long id, String name) {
+        // Project no-args ctor가 PROTECTED라 reflection으로 인스턴스화
+        try {
+            Constructor<Project> ctor = Project.class.getDeclaredConstructor();
+            ctor.setAccessible(true);
+            Project project = ctor.newInstance();
+            ReflectionTestUtils.setField(project, "id", id);
+            ReflectionTestUtils.setField(project, "name", name);
+            return project;
+        } catch (ReflectiveOperationException e) {
+            throw new IllegalStateException(e);
+        }
+    }
+}

--- a/src/test/java/com/groute/groute_server/calendar/service/CalendarHomeServiceTest.java
+++ b/src/test/java/com/groute/groute_server/calendar/service/CalendarHomeServiceTest.java
@@ -165,7 +165,7 @@ class CalendarHomeServiceTest {
             Scrum scrum = scrum(7L, "어드민 페이지 기능명세서 작성", true, 50L, "밋업프로젝트", "기획 작업");
             given(calendarHomeRepository.findScrumsByUserAndDate(USER_ID, DATE))
                     .willReturn(List.of(scrum));
-            given(calendarHomeRepository.findCompletedStarTagsByScrumIds(List.of(7L)))
+            given(calendarHomeRepository.findCompletedStarTagsByScrumIds(USER_ID, List.of(7L)))
                     .willReturn(
                             List.of(
                                     new ScrumStarTagRow(
@@ -196,7 +196,7 @@ class CalendarHomeServiceTest {
             Scrum scrum = scrum(7L, "본문", false, 50L, "밋업프로젝트", "기획 작업");
             given(calendarHomeRepository.findScrumsByUserAndDate(USER_ID, DATE))
                     .willReturn(List.of(scrum));
-            given(calendarHomeRepository.findCompletedStarTagsByScrumIds(List.of(7L)))
+            given(calendarHomeRepository.findCompletedStarTagsByScrumIds(USER_ID, List.of(7L)))
                     .willReturn(List.of());
 
             // when


### PR DESCRIPTION
## 요약
- 캘린더 메인 홈(CAL-001)에서 월별 캘린더 데이터 + 날짜 선택 시 하단 프리뷰 목록을 조회하는 두 API를 신규 calendar(Layered) 모듈에 추가

## 변경 사항
- [x] 기능
- [x] 버그 수정
- [ ] 리팩토링
- [ ] 문서
- [x] 테스트
- [ ] 기타

## 테스트
- [x] 로컬 테스트 완료
- 테스트 방법:
    - `./gradlew spotlessApply compileJava`
    - `./gradlew test --tests com.groute.groute_server.calendar.service.CalendarHomeServiceTest` (HappyPath 6 + Errors/격리 1 = 7 시나리오 전부 통과)
    - 수동: `GET /api/calendar/monthly?month=2026-04`, `GET /api/calendar/daily-preview?date=2026-04-02` (JWT 인증)
    - 잘못된 형식 검증: `GET /api/calendar/monthly?month=2026-13` → 400 + `INVALID_INPUT` (이전엔 500이었음)

### 커버리지 (JaCoCo)
- 라인 커버리지: 92%  (기준: 60% 이상)
- [x] `./gradlew test` 실행 후 `build/reports/jacoco/index.html`에서 수치 확인

## 스크린샷/로그 (선택)
- 없음

## 롤백/리스크
- 리스크 포인트:
  - **신규 도메인/엔티티/마이그레이션 없음**: 기존 record 도메인의 `Scrum`/`ScrumTitle`/`Project`/`StarRecord`/`StarTag` entity를 calendar 모듈이 read-only로 재사용 (이슈 spec 준수). 결합도 증가는 의도된 결정
  - **soft-delete 컨벤션**: `SoftDeleteEntity`에 `@Where` 자동 필터가 없어 신규 JPQL 4개 모두 `AND s.isDeleted = false`/`AND sr.isDeleted = false` 명시 필수. 기존 record 쿼리와 동일 패턴
  - **글로벌 예외 핸들러 추가**: `MethodArgumentTypeMismatchException`을 명시 400으로 매핑 → 본 PR 외 모든 컨트롤러에도 영향. 기존엔 500으로 떨어져 Discord 웹훅 발송됨(원치 않은 알림). positive side-effect로 간주
  - **한 일자에 여러 STAR 완료 시 대표 역량**: `completedAt` 최신 record의 `primaryCategory` 사용. 정책 변경 가능 — 현재는 직관적 기본값
  - 인덱스/캐싱 튜닝은 본 PR 범위 외 (이슈 spec 명시)
- 롤백 방법: 본 PR revert. 신규 calendar 패키지·신규 GlobalExceptionHandler 메서드만 사라지며 기존 record 모듈/스키마는 영향 없음

## 관련 이슈
Closes #83 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# 릴리스 노트

* **New Features**
  * 월간 달력 조회 API: 특정 월의 스크럼 활동 및 완료 상태를 시각화하는 엔드포인트 추가
  * 일일 미리보기 API: 특정 날짜의 스크럼 상세 정보 및 관련 태그를 제공하는 엔드포인트 추가
  * 날짜 형식 유효성 검증: 잘못된 날짜 입력 시 명확한 오류 메시지 제공

* **Tests**
  * 캘린더 서비스 테스트 스위트 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->