### PR TITLE
feat: 홈 월별 역량 히트맵 조회 API (#84)

### DIFF
--- a/src/main/java/com/groute/groute_server/home/controller/HomeCompetencyStatsController.java
+++ b/src/main/java/com/groute/groute_server/home/controller/HomeCompetencyStatsController.java
@@ -1,0 +1,67 @@
+package com.groute.groute_server.home.controller;
+
+import java.time.YearMonth;
+
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.groute.groute_server.common.annotation.CurrentUser;
+import com.groute.groute_server.common.response.ApiResponse;
+import com.groute.groute_server.home.dto.CompetencyStatsResponse;
+import com.groute.groute_server.home.service.HomeCompetencyStatsService;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * 홈 역량 잔디 조회 컨트롤러(HOM-002).
+ *
+ * <p>월 단위 STAR 완료 건수를 일자별 히트맵 데이터로 반환한다. 인증 사용자 본인의 데이터만 집계하며 {@link CurrentUser}로 userId를 주입받는다.
+ * {@code month} 쿼리 파라미터는 {@link YearMonth}로 바인딩되어 형식 위반 시 Spring이 자동 400 응답을 반환한다.
+ *
+ * <p>서비스 단은 도메인 원시값(Map)만 노출하므로 응답 DTO 조립은 본 컨트롤러 책임이다.
+ */
+@Tag(name = "Home", description = "홈 화면 데이터 조회")
+@RestController
+@RequestMapping("/api/home")
+@RequiredArgsConstructor
+public class HomeCompetencyStatsController {
+
+    private final HomeCompetencyStatsService homeCompetencyStatsService;
+
+    @Operation(
+            summary = "월별 역량 잔디 조회",
+            description =
+                    "요청 월의 일자별 STAR 완료 건수를 4단계 상태(NO_DATA/STAR_LOW/STAR_MID/STAR_HIGH)로 매핑해 반환한다."
+                            + " 데이터 없는 일자도 NO_DATA로 응답에 포함되며, 응답 days[]는 요청 월의 1일~말일을 모두 담는다.")
+    @ApiResponses({
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                responseCode = "200",
+                description = "조회 성공"),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                responseCode = "400",
+                description = "month 파라미터 누락 또는 형식 위반(yyyy-MM)"),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                responseCode = "401",
+                description = "미인증 또는 만료된 액세스 토큰")
+    })
+    @GetMapping("/competency-stats")
+    public ApiResponse<CompetencyStatsResponse> getCompetencyStats(
+            @CurrentUser Long userId,
+            @Parameter(description = "조회 월 (yyyy-MM)", example = "2026-04", required = true)
+                    @RequestParam("month")
+                    @DateTimeFormat(pattern = "yyyy-MM")
+                    YearMonth month) {
+        return ApiResponse.ok(
+                "역량 잔디 조회 성공",
+                CompetencyStatsResponse.from(
+                        month,
+                        homeCompetencyStatsService.getCompletedStarCountsByMonth(userId, month)));
+    }
+}

--- a/src/main/java/com/groute/groute_server/home/dto/CompetencyStatsResponse.java
+++ b/src/main/java/com/groute/groute_server/home/dto/CompetencyStatsResponse.java
@@ -4,6 +4,7 @@ import java.time.LocalDate;
 import java.time.YearMonth;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
 
@@ -35,6 +36,8 @@ public record CompetencyStatsResponse(
      */
     public static CompetencyStatsResponse from(
             YearMonth month, Map<LocalDate, Long> completedCountsByDate) {
+        Objects.requireNonNull(month, "month");
+        Objects.requireNonNull(completedCountsByDate, "completedCountsByDate");
         List<DayItem> days =
                 month.atDay(1)
                         .datesUntil(month.atEndOfMonth().plusDays(1))

--- a/src/main/java/com/groute/groute_server/home/dto/CompetencyStatsResponse.java
+++ b/src/main/java/com/groute/groute_server/home/dto/CompetencyStatsResponse.java
@@ -1,0 +1,91 @@
+package com.groute.groute_server.home.dto;
+
+import java.time.LocalDate;
+import java.time.YearMonth;
+import java.util.List;
+import java.util.Map;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+/**
+ * 홈 역량 잔디 조회 응답(HOM-002).
+ *
+ * <p>월 단위 히트맵용. 요청 월의 모든 일자를 {@code days}로 반환하며, 데이터 없는 날도 NO_DATA로 포함한다(FE 합의).
+ *
+ * <p>일자별 색상 농도는 STAR 완료 건수 기준 4단계 매핑(0=NO_DATA, 1=LOW, 2=MID, 3+=HIGH). 기획상 "스크럼만 있는 상태"가 발생하지 않게
+ * 변경되어 SCRUM_ONLY는 산출 대상에서 제외된다.
+ */
+@Schema(description = "홈 역량 잔디 조회 응답")
+public record CompetencyStatsResponse(
+        @JsonFormat(pattern = "yyyy-MM")
+                @Schema(description = "요청한 월", example = "2026-04", type = "string")
+                YearMonth month,
+        @Schema(description = "일별 데이터 (요청 월의 모든 일자 포함)") List<DayItem> days) {
+
+    /**
+     * 사용자별 STAR 완료 건수 집계 결과로부터 응답을 생성한다.
+     *
+     * <p>{@code completedCountsByDate}는 STAR 완료 1건 이상인 일자만 키로 갖는 sparse map. 빠진 일자는 NO_DATA로 채워 요청
+     * 월의 1일~말일을 빠짐없이 포함시킨다.
+     *
+     * @param month 요청 월
+     * @param completedCountsByDate 일자별 STAR 완료 건수 (없는 일자 키 자체가 누락된 sparse map). null 금지.
+     */
+    public static CompetencyStatsResponse from(
+            YearMonth month, Map<LocalDate, Long> completedCountsByDate) {
+        List<DayItem> days =
+                month.atDay(1)
+                        .datesUntil(month.atEndOfMonth().plusDays(1))
+                        .map(
+                                date ->
+                                        new DayItem(
+                                                date,
+                                                DayStatus.fromCount(
+                                                        completedCountsByDate.getOrDefault(
+                                                                date, 0L))))
+                        .toList();
+        return new CompetencyStatsResponse(month, days);
+    }
+
+    @Schema(description = "일별 항목")
+    public record DayItem(
+            @Schema(description = "일자", example = "2026-04-01", type = "string", format = "date")
+                    LocalDate date,
+            @Schema(description = "일별 상태", example = "STAR_LOW") DayStatus status) {}
+
+    /**
+     * 일별 역량 잔디 상태.
+     *
+     * <p>해당 일자의 STAR 완료 건수에 따라 히트맵 색상 농도를 차등 적용하기 위한 상태값.
+     */
+    public enum DayStatus {
+        /** STAR 완료 0건. */
+        NO_DATA,
+        /** STAR 완료 1건. */
+        STAR_LOW,
+        /** STAR 완료 2건. */
+        STAR_MID,
+        /** STAR 완료 3건 이상. */
+        STAR_HIGH;
+
+        /**
+         * 일자별 STAR 완료 건수를 상태 enum으로 매핑한다.
+         *
+         * <p>임계치: 0건=NO_DATA, 1건=LOW, 2건=MID, 3건 이상=HIGH. 음수는 방어적으로 NO_DATA로 처리한다.
+         */
+        public static DayStatus fromCount(long completedStarCount) {
+            if (completedStarCount <= 0) {
+                return NO_DATA;
+            }
+            if (completedStarCount == 1) {
+                return STAR_LOW;
+            }
+            if (completedStarCount == 2) {
+                return STAR_MID;
+            }
+            return STAR_HIGH;
+        }
+    }
+}

--- a/src/main/java/com/groute/groute_server/home/repository/CompetencyStatsQueryRepository.java
+++ b/src/main/java/com/groute/groute_server/home/repository/CompetencyStatsQueryRepository.java
@@ -1,0 +1,59 @@
+package com.groute.groute_server.home.repository;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.Repository;
+import org.springframework.data.repository.query.Param;
+
+import com.groute.groute_server.record.domain.StarRecord;
+
+/**
+ * 홈 역량 잔디 조회 전용 repository(HOM-002).
+ *
+ * <p>{@code home}은 read-only Layered 모듈이므로 {@link Repository} 마커만 상속해 save/delete 노출을 차단한다. JPQL
+ * 인터페이스 프로젝션으로 일자별 STAR 완료 건수 집계만 반환한다.
+ *
+ * <p>스크럼 일자({@code Scrum.scrumDate})는 사용자가 선택한 KST 기준 {@link LocalDate}라 DB UTC 타임존과 무관하게 직접 비교 가능.
+ * STAR 완료 판정은 {@code is_completed=true} + soft-delete가 아닌 행만 카운트한다.
+ *
+ * <p>인덱스는 Flyway 마이그레이션이 단일 SoT이므로 본 repository에는 선언하지 않는다.
+ */
+public interface CompetencyStatsQueryRepository extends Repository<StarRecord, Long> {
+
+    /**
+     * 사용자의 STAR 완료 기록을 일자별로 카운트한다.
+     *
+     * <p>기간은 {@code [startInclusive, endExclusive)} 반열림 구간. 호출자(service)가 월 첫날과 다음달 첫날로 변환해 전달하여 말일
+     * 경계를 안전하게 포함시킨다. 결과 행은 STAR 완료 1건 이상인 일자만 포함하며, 0건 일자는 키 자체가 누락된 sparse 결과다(서비스 단에서 NO_DATA
+     * 채움).
+     *
+     * @param userId 조회 대상 사용자 ID
+     * @param startInclusive 시작 일자(포함, KST)
+     * @param endExclusive 종료 일자(미포함, KST)
+     * @return 일자 + 완료 건수 행 목록 (0건 일자는 미포함)
+     */
+    @Query(
+            "SELECT s.scrumDate AS date, COUNT(sr.id) AS count "
+                    + "FROM StarRecord sr "
+                    + "JOIN sr.scrum s "
+                    + "WHERE sr.user.id = :userId "
+                    + "AND sr.isCompleted = true "
+                    + "AND sr.isDeleted = false "
+                    + "AND s.isDeleted = false "
+                    + "AND s.scrumDate >= :startInclusive "
+                    + "AND s.scrumDate < :endExclusive "
+                    + "GROUP BY s.scrumDate")
+    List<DateCountRow> findCompletedStarCountsByUserAndDateRange(
+            @Param("userId") Long userId,
+            @Param("startInclusive") LocalDate startInclusive,
+            @Param("endExclusive") LocalDate endExclusive);
+
+    /** 일자별 STAR 완료 건수 행. JPQL alias({@code date}, {@code count})로 매핑되는 인터페이스 프로젝션. */
+    interface DateCountRow {
+        LocalDate getDate();
+
+        Long getCount();
+    }
+}

--- a/src/main/java/com/groute/groute_server/home/service/HomeCompetencyStatsService.java
+++ b/src/main/java/com/groute/groute_server/home/service/HomeCompetencyStatsService.java
@@ -42,7 +42,7 @@ public class HomeCompetencyStatsService {
      */
     public Map<LocalDate, Long> getCompletedStarCountsByMonth(Long userId, YearMonth month) {
         LocalDate startInclusive = month.atDay(1);
-        LocalDate endExclusive = month.atEndOfMonth().plusDays(1);
+        LocalDate endExclusive = month.plusMonths(1).atDay(1);
         return competencyStatsQueryRepository
                 .findCompletedStarCountsByUserAndDateRange(userId, startInclusive, endExclusive)
                 .stream()

--- a/src/main/java/com/groute/groute_server/home/service/HomeCompetencyStatsService.java
+++ b/src/main/java/com/groute/groute_server/home/service/HomeCompetencyStatsService.java
@@ -33,7 +33,8 @@ public class HomeCompetencyStatsService {
      * 사용자의 월별 STAR 완료 건수를 일자별로 집계한다.
      *
      * <p>결과는 STAR 완료 1건 이상인 일자만 키로 갖는 sparse map. 0건 일자는 키 자체가 누락되며 컨트롤러 단에서 응답 변환 시 NO_DATA로 채운다.
-     * 동일 일자 중복 키는 repository GROUP BY로 이미 제거되어 발생하지 않는다.
+     * 동일 일자 중복 키는 repository GROUP BY로 이미 제거되어 발생하지 않으나, 향후 쿼리 변경에 대비해 첫 항목을 유지하는 merge 함수를 두어
+     * {@code IllegalStateException} 회귀를 방어한다.
      *
      * @param userId 조회 대상 사용자 ID
      * @param month 조회 월(KST)
@@ -45,6 +46,10 @@ public class HomeCompetencyStatsService {
         return competencyStatsQueryRepository
                 .findCompletedStarCountsByUserAndDateRange(userId, startInclusive, endExclusive)
                 .stream()
-                .collect(Collectors.toMap(DateCountRow::getDate, DateCountRow::getCount));
+                .collect(
+                        Collectors.toMap(
+                                DateCountRow::getDate,
+                                DateCountRow::getCount,
+                                (existing, ignored) -> existing));
     }
 }

--- a/src/main/java/com/groute/groute_server/home/service/HomeCompetencyStatsService.java
+++ b/src/main/java/com/groute/groute_server/home/service/HomeCompetencyStatsService.java
@@ -1,0 +1,50 @@
+package com.groute.groute_server.home.service;
+
+import java.time.LocalDate;
+import java.time.YearMonth;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.groute.groute_server.home.repository.CompetencyStatsQueryRepository;
+import com.groute.groute_server.home.repository.CompetencyStatsQueryRepository.DateCountRow;
+
+import lombok.RequiredArgsConstructor;
+
+/**
+ * 홈 역량 잔디 조회 서비스(HOM-002).
+ *
+ * <p>요청 월의 일자별 STAR 완료 건수를 집계한다. {@code YearMonth → [월 첫날, 다음달 첫날)} 반열림 구간으로 변환해 repository에 위임하며,
+ * KST 기준 {@code Scrum.scrumDate}를 그대로 사용해 DB UTC 변환과 무관하다.
+ *
+ * <p>서비스 시그니처는 도메인 원시값(Map)만 노출한다 — DTO ↔ 도메인 변환은 컨트롤러 레이어 책임(코드래빗 Layered 룰: service 리턴에 Response
+ * DTO 노출 금지).
+ */
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class HomeCompetencyStatsService {
+
+    private final CompetencyStatsQueryRepository competencyStatsQueryRepository;
+
+    /**
+     * 사용자의 월별 STAR 완료 건수를 일자별로 집계한다.
+     *
+     * <p>결과는 STAR 완료 1건 이상인 일자만 키로 갖는 sparse map. 0건 일자는 키 자체가 누락되며 컨트롤러 단에서 응답 변환 시 NO_DATA로 채운다.
+     * 동일 일자 중복 키는 repository GROUP BY로 이미 제거되어 발생하지 않는다.
+     *
+     * @param userId 조회 대상 사용자 ID
+     * @param month 조회 월(KST)
+     * @return 일자(KST) → STAR 완료 건수 맵. 0건 일자는 미포함.
+     */
+    public Map<LocalDate, Long> getCompletedStarCountsByMonth(Long userId, YearMonth month) {
+        LocalDate startInclusive = month.atDay(1);
+        LocalDate endExclusive = month.atEndOfMonth().plusDays(1);
+        return competencyStatsQueryRepository
+                .findCompletedStarCountsByUserAndDateRange(userId, startInclusive, endExclusive)
+                .stream()
+                .collect(Collectors.toMap(DateCountRow::getDate, DateCountRow::getCount));
+    }
+}

--- a/src/test/java/com/groute/groute_server/home/service/HomeCompetencyStatsServiceTest.java
+++ b/src/test/java/com/groute/groute_server/home/service/HomeCompetencyStatsServiceTest.java
@@ -1,0 +1,135 @@
+package com.groute.groute_server.home.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+import java.time.LocalDate;
+import java.time.YearMonth;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.groute.groute_server.home.repository.CompetencyStatsQueryRepository;
+import com.groute.groute_server.home.repository.CompetencyStatsQueryRepository.DateCountRow;
+
+@ExtendWith(MockitoExtension.class)
+class HomeCompetencyStatsServiceTest {
+
+    private static final Long USER_ID = 1L;
+
+    @Mock CompetencyStatsQueryRepository competencyStatsQueryRepository;
+
+    @InjectMocks HomeCompetencyStatsService homeCompetencyStatsService;
+
+    @Nested
+    @DisplayName("월별 STAR 완료 건수 집계 - 정상")
+    class HappyPath {
+
+        @Test
+        @DisplayName("YearMonth를 [월 첫날, 다음달 첫날) 반열림 구간으로 변환해 repository에 위임한다")
+        void should_callRepoWithHalfOpenMonthRange_when_givenYearMonth() {
+            // given
+            YearMonth month = YearMonth.of(2026, 4);
+
+            // when
+            homeCompetencyStatsService.getCompletedStarCountsByMonth(USER_ID, month);
+
+            // then
+            verify(competencyStatsQueryRepository)
+                    .findCompletedStarCountsByUserAndDateRange(
+                            USER_ID, LocalDate.of(2026, 4, 1), LocalDate.of(2026, 5, 1));
+        }
+
+        @Test
+        @DisplayName("repository 결과 행을 일자→건수 맵으로 수집한다")
+        void should_collectRowsToDateCountMap_when_repoReturnsMultipleRows() {
+            // given
+            YearMonth month = YearMonth.of(2026, 4);
+            // 행 mock의 stubbing이 outer given(...) 안에서 평가되면 Mockito가
+            // UnfinishedStubbingException을 던지므로, 행을 먼저 빌드한 뒤 outer를 stubbing한다.
+            List<DateCountRow> rows =
+                    List.of(
+                            mockRow(LocalDate.of(2026, 4, 3), 1L),
+                            mockRow(LocalDate.of(2026, 4, 7), 2L),
+                            mockRow(LocalDate.of(2026, 4, 15), 5L));
+            given(
+                            competencyStatsQueryRepository
+                                    .findCompletedStarCountsByUserAndDateRange(
+                                            USER_ID,
+                                            LocalDate.of(2026, 4, 1),
+                                            LocalDate.of(2026, 5, 1)))
+                    .willReturn(rows);
+
+            // when
+            Map<LocalDate, Long> result =
+                    homeCompetencyStatsService.getCompletedStarCountsByMonth(USER_ID, month);
+
+            // then
+            assertThat(result)
+                    .containsOnly(
+                            Map.entry(LocalDate.of(2026, 4, 3), 1L),
+                            Map.entry(LocalDate.of(2026, 4, 7), 2L),
+                            Map.entry(LocalDate.of(2026, 4, 15), 5L));
+        }
+
+        @Test
+        @DisplayName("repository 결과가 비어 있으면 빈 맵을 반환한다 (NO_DATA 채움은 컨트롤러 책임)")
+        void should_returnEmptyMap_when_repoReturnsNoRows() {
+            // given
+            YearMonth month = YearMonth.of(2026, 4);
+
+            // when
+            Map<LocalDate, Long> result =
+                    homeCompetencyStatsService.getCompletedStarCountsByMonth(USER_ID, month);
+
+            // then
+            assertThat(result).isEmpty();
+        }
+
+        @Test
+        @DisplayName("윤년 2월은 endExclusive=3/1로 변환되어 29일을 포함한다")
+        void should_resolveLeapFebruaryEndAsMarchFirst_when_given2024Feb() {
+            // given
+            YearMonth month = YearMonth.of(2024, 2);
+
+            // when
+            homeCompetencyStatsService.getCompletedStarCountsByMonth(USER_ID, month);
+
+            // then
+            verify(competencyStatsQueryRepository)
+                    .findCompletedStarCountsByUserAndDateRange(
+                            USER_ID, LocalDate.of(2024, 2, 1), LocalDate.of(2024, 3, 1));
+        }
+
+        @Test
+        @DisplayName("12월은 endExclusive를 다음 해 1/1로 변환해 연 경계를 안전하게 넘는다")
+        void should_resolveDecemberEndAsNextYearJanuaryFirst_when_givenDecember() {
+            // given
+            YearMonth month = YearMonth.of(2026, 12);
+
+            // when
+            homeCompetencyStatsService.getCompletedStarCountsByMonth(USER_ID, month);
+
+            // then
+            verify(competencyStatsQueryRepository)
+                    .findCompletedStarCountsByUserAndDateRange(
+                            USER_ID, LocalDate.of(2026, 12, 1), LocalDate.of(2027, 1, 1));
+        }
+    }
+
+    private static DateCountRow mockRow(LocalDate date, long count) {
+        DateCountRow row = mock(DateCountRow.class);
+        given(row.getDate()).willReturn(date);
+        given(row.getCount()).willReturn(count);
+        return row;
+    }
+}

--- a/src/test/java/com/groute/groute_server/home/service/HomeCompetencyStatsServiceTest.java
+++ b/src/test/java/com/groute/groute_server/home/service/HomeCompetencyStatsServiceTest.java
@@ -86,6 +86,13 @@ class HomeCompetencyStatsServiceTest {
         void should_returnEmptyMap_when_repoReturnsNoRows() {
             // given
             YearMonth month = YearMonth.of(2026, 4);
+            given(
+                            competencyStatsQueryRepository
+                                    .findCompletedStarCountsByUserAndDateRange(
+                                            USER_ID,
+                                            LocalDate.of(2026, 4, 1),
+                                            LocalDate.of(2026, 5, 1)))
+                    .willReturn(List.of());
 
             // when
             Map<LocalDate, Long> result =

--- a/src/test/java/com/groute/groute_server/home/service/HomeCompetencyStatsServiceTest.java
+++ b/src/test/java/com/groute/groute_server/home/service/HomeCompetencyStatsServiceTest.java
@@ -82,6 +82,33 @@ class HomeCompetencyStatsServiceTest {
         }
 
         @Test
+        @DisplayName("동일 일자 중복 행은 첫 값을 유지한다 (defensive merge 회귀 방지)")
+        void should_keepFirstValue_when_repoReturnsDuplicateDates() {
+            // given
+            // 정상 흐름에선 repository GROUP BY로 중복 키가 발생하지 않으나,
+            // 향후 쿼리 변경 시 IllegalStateException 회귀를 방어하는 toMap merge 함수를 검증한다.
+            YearMonth month = YearMonth.of(2026, 4);
+            List<DateCountRow> rows =
+                    List.of(
+                            mockRow(LocalDate.of(2026, 4, 3), 1L),
+                            mockRow(LocalDate.of(2026, 4, 3), 9L));
+            given(
+                            competencyStatsQueryRepository
+                                    .findCompletedStarCountsByUserAndDateRange(
+                                            USER_ID,
+                                            LocalDate.of(2026, 4, 1),
+                                            LocalDate.of(2026, 5, 1)))
+                    .willReturn(rows);
+
+            // when
+            Map<LocalDate, Long> result =
+                    homeCompetencyStatsService.getCompletedStarCountsByMonth(USER_ID, month);
+
+            // then
+            assertThat(result).containsOnly(Map.entry(LocalDate.of(2026, 4, 3), 1L));
+        }
+
+        @Test
         @DisplayName("repository 결과가 비어 있으면 빈 맵을 반환한다 (NO_DATA 채움은 컨트롤러 책임)")
         void should_returnEmptyMap_when_repoReturnsNoRows() {
             // given

--- a/src/test/resources/application.yaml
+++ b/src/test/resources/application.yaml
@@ -1,0 +1,126 @@
+# ===== 테스트 컨텍스트 전용 설정 =====
+# main application.yaml의 default 프로파일은 stg/prod fail-fast를 위해 SSM 주입
+# 필수 placeholder를 그대로 노출한다. 테스트는 외부 env 없이 컨텍스트만 로드해야
+# 하므로 본 yaml이 main yaml을 대체(replace)한다 — Spring Boot는 src/test/resources의
+# application.yaml을 우선 로드한다(같은 위치 중복 시 main 미로드).
+#
+# 외부 인프라 의존(Postgres/Redis)은 main yaml의 로컬 기본값과 동일하게 둔다.
+# 통합 테스트가 늘어나면 testcontainers 도입 검토.
+
+spring:
+  application:
+    name: groute-server-test
+
+  jackson:
+    time-zone: UTC
+
+  data:
+    redis:
+      host: localhost
+      port: 6379
+
+  datasource:
+    url: jdbc:postgresql://localhost:5432/groute_local
+    username: postgres
+    password: postgres
+    driver-class-name: org.postgresql.Driver
+    hikari:
+      maximum-pool-size: 2
+      minimum-idle: 0
+      connection-timeout: 5000
+      initialization-fail-timeout: -1
+
+  jpa:
+    hibernate:
+      ddl-auto: none
+    properties:
+      hibernate:
+        dialect: org.hibernate.dialect.PostgreSQLDialect
+        jdbc.time_zone: UTC
+    open-in-view: false
+
+  flyway:
+    enabled: false
+
+  security:
+    oauth2:
+      client:
+        registration:
+          kakao:
+            client-name: Kakao
+            client-id: test-kakao
+            client-secret: test-secret
+            redirect-uri: http://localhost/login/oauth2/code/kakao
+            client-authentication-method: client_secret_post
+            authorization-grant-type: authorization_code
+            scope:
+              - profile_nickname
+          google:
+            client-name: Google
+            client-id: test-google
+            client-secret: test-secret
+            redirect-uri: http://localhost/login/oauth2/code/google
+            authorization-grant-type: authorization_code
+            scope:
+              - profile
+              - email
+          naver:
+            client-name: Naver
+            client-id: test-naver
+            client-secret: test-secret
+            redirect-uri: http://localhost/login/oauth2/code/naver
+            client-authentication-method: client_secret_post
+            authorization-grant-type: authorization_code
+            scope:
+              - nickname
+              - email
+        provider:
+          kakao:
+            authorization-uri: https://kauth.kakao.com/oauth/authorize
+            token-uri: https://kauth.kakao.com/oauth/token
+            user-info-uri: https://kapi.kakao.com/v2/user/me
+            user-name-attribute: id
+          naver:
+            authorization-uri: https://nid.naver.com/oauth2.0/authorize
+            token-uri: https://nid.naver.com/oauth2.0/token
+            user-info-uri: https://openapi.naver.com/v1/nid/me
+            user-name-attribute: response
+
+server:
+  port: 0
+
+jwt:
+  secret: test-secret-key-must-be-at-least-256-bits-long-for-jjwt-hs256-stub
+  access-token-expiration: 3600000
+  refresh-token-expiration: 1209600000
+
+auth:
+  refresh-token:
+    cookie-enabled: false
+  callback:
+    test: http://localhost/test/callback
+  default-env: test
+
+app:
+  swagger:
+    server-url: http://localhost
+    server-description: Test
+  user:
+    default-profile-image-url: ""
+
+discord:
+  webhook:
+    enabled: false
+    url: ""
+
+firebase:
+  credentials-json: ""
+
+notification:
+  copy-json: ""
+  deep-link-url: ""
+
+logging:
+  level:
+    com.groute: WARN
+    root: WARN


### PR DESCRIPTION
## 요약
- 홈 화면 HOM-002 기록 출석부 - 사용자 월별 STAR 완료 건수를 4단계 상태(`NO_DATA`/`STAR_LOW`/`STAR_MID`/`STAR_HIGH`)로 매핑한 히트맵 데이터를 반환하는 `GET /api/home/competency-stats` 추가

## 변경 사항
- [x] 기능
- [x] 버그 수정
- [ ] 리팩토링
- [ ] 문서
- [x] 테스트
- [ ] 기타

### 상세
- `home/` Layered 모듈 신설 (`controller`/`service`/`repository`/`dto`)
- `CompetencyStatsResponse` (record DTO) - 요청 월의 모든 일자를 `days[]`에 채워 반환, `NO_DATA` 포함 (FE 합의 완료되었습니다!)
- `DayStatus` enum 4단계 + `fromCount(long)` 임계치 매핑 (0=NO_DATA, 1=LOW, 2=MID, 3+=HIGH)
- `CompetencyStatsQueryRepository` - `Repository<StarRecord, Long>` 마커 + JPQL 인터페이스 프로젝션, `[월 첫날, 다음달 첫날)`로 반열림 구간 집계
- `HomeCompetencyStatsService` - `YearMonth → LocalDate` 범위 변환 + `Collectors.toMap` 
- `HomeCompetencyStatsController` - `@RequestParam("month") @DateTimeFormat(pattern="yyyy-MM") YearMonth` (형식 위반 시 자동 400), Swagger 어노테이션 작업
- 단위 테스트 5건 (월 경계 / 수집 / 빈 결과 / 윤년 2월 / 12월 연 경계)

### 이슈 범위 밖 핫픽스 (`fix: 테스트 컨텍스트 로드용 application.yaml 추가`)
- `dev` 브랜치에서 `GrouteServerApplicationTests.contextLoads()`가 `IllegalStateException: auth.callback must not be empty`로 깨져 있던 문제 발견했습니다 (commit 6faf7032의 `AuthProperties` compact ctor fail-fast 검증이 test 환경의 빈 callback에 그대로 걸렸는데, 제 작업 범위였습니다... 죄송합니다...)
- `./gradlew check`를 본 PR에서 통과시키려면 회피가 어려워, `src/test/resources/application.yaml`로 default 프로파일을 대체해 stub 값 주입 오나료했습니다.
- 본 PR 스코프와 무관하지만 동일 모듈의 빌드 게이트 복구 차원으로 추가했습니다. 별도 핫픽스 PR로 분리 가능하니, 검토 의견 주시면 cherry-pick 후 분리도 가능합니다.

## 테스트
- [x] 로컬 테스트 완료
- 테스트 방법:
    - `./gradlew spotlessApply check` — 전체 빌드 + JaCoCo 게이트(60%)
    - `./gradlew test --tests "*HomeCompetencyStatsServiceTest"` — 본 PR 단위 테스트 5건
    - `./gradlew test --tests "*GrouteServerApplicationTests"` — contextLoads 회귀 확인
    - Swagger UI: `http://localhost:8080/swagger-ui.html` → `Home` 태그 → `GET /api/home/competency-stats?month=2026-04` 

### 커버리지 (JaCoCo)
- 라인 커버리지: 75%  (기준: 60% 이상)
- [x] `./gradlew test` 실행 후 `build/reports/jacoco/index.html`에서 수치 확인

## 스크린샷/로그 (선택)
X

## 롤백/리스크
- 리스크 포인트
    - `home/` 신규 모듈이라 기존 API 영향 없습니다
    - JPQL 쿼리는 `Scrum.scrumDate` 인덱스에 의존해 미존재 시 풀스캔 가능하지만, flyway에서 이미 정의된 부분이라 큰 걱정은 안 하셔도 될 듯 합니다!
    - `Repository<StarRecord, Long>` 마커는 기존 도메인의 `JpaRepository` 패턴과 다른데, 이는 `home`이 read-only 모듈임을 컴파일 타임에 강제하기 위한 의도된 차이입니다.
    - `src/test/resources/application.yaml`은 테스트 클래스패스에서 main yaml을 대체하지만, 운영 부팅에는 영향 없습니다!
- 롤백 방법
    - 본 PR을 한 번에 revert 

## 관련 이슈
Closes #84 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 월별 역량 통계 조회 API 추가 — 특정 월의 일별 학습 완료 수를 기반으로 하루 단위 상태(미데이터/낮음/중간/높음)를 반환
  * API에 대한 문서화(스웨거/OpenAPI) 추가

* **Tests**
  * 월별 통계 서비스 단위 테스트 추가(월 경계·윤년 처리 및 빈 결과 검증)

* **Chores**
  * 테스트 전용 애플리케이션 설정 파일 추가(테스트 환경 안정화)

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/2026-KUSITMS-GLIT/2026-KUSITMS-GLIT-BACK/pull/89)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->