### PR TITLE
feat: 회원 탈퇴 API (#86)

### DIFF
--- a/src/main/java/com/groute/groute_server/user/config/UserProperties.java
+++ b/src/main/java/com/groute/groute_server/user/config/UserProperties.java
@@ -8,6 +8,19 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
  * <p>{@code defaultProfileImageUrl}은 모든 유저에게 공통으로 노출되는 기본 캐릭터 프로필 이미지 URL이다. 환경별 값은 SSM Parameter
  * Store의 {@code /groute/{env}/USER_DEFAULT_PROFILE_IMAGE_URL}에서 주입되며, 로컬은 env 미설정 시 빈 문자열로
  * fallback된다 (프론트가 빈값 대체 이미지 처리 책임).
+ *
+ * <p>{@code hardDeleteGraceDays}는 회원 탈퇴 후 물리 삭제까지의 grace period(MYP-005). 기획상 30일 고정이지만 인시던트 대응·테스트
+ * 단축 목적으로 yaml 한 줄로 조정 가능하도록 외부화한다. 0 이하는 부팅 단계에서 거부된다.
  */
 @ConfigurationProperties(prefix = "app.user")
-public record UserProperties(String defaultProfileImageUrl) {}
+public record UserProperties(String defaultProfileImageUrl, int hardDeleteGraceDays) {
+
+    public UserProperties {
+        if (hardDeleteGraceDays <= 0) {
+            throw new IllegalStateException(
+                    "app.user.hard-delete-grace-days는 0보다 커야 합니다 (현재값: "
+                            + hardDeleteGraceDays
+                            + ")");
+        }
+    }
+}

--- a/src/main/java/com/groute/groute_server/user/controller/UserController.java
+++ b/src/main/java/com/groute/groute_server/user/controller/UserController.java
@@ -4,6 +4,7 @@ import java.time.LocalDate;
 
 import jakarta.validation.Valid;
 
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -25,10 +26,10 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 
 /**
- * 마이페이지 내 정보 조회(MYP001) / 프로필 수정(MYP002) 엔드포인트.
+ * 마이페이지 내 정보 조회(MYP001) / 프로필 수정(MYP002) / 회원 탈퇴(MYP005) 엔드포인트.
  *
- * <p>둘 다 로그인 사용자 본인 리소스만 다루므로 {@link CurrentUser}로 userId를 주입받는다. 응답의 {@code profileImage}는 현재 모든
- * 유저 공통 기본 이미지로 고정되어 {@link UserProperties#defaultProfileImageUrl()}에서 주입된다.
+ * <p>모두 로그인 사용자 본인 리소스만 다루므로 {@link CurrentUser}로 userId를 주입받는다. 응답의 {@code profileImage}는 현재 모든 유저
+ * 공통 기본 이미지로 고정되어 {@link UserProperties#defaultProfileImageUrl()}에서 주입된다.
  */
 @Tag(name = "User", description = "마이페이지 내 정보 조회/수정")
 @RestController
@@ -87,5 +88,27 @@ public class UserController {
                         user,
                         userProperties.defaultProfileImageUrl(),
                         user.streakSnapshotAsOf(kstToday)));
+    }
+
+    @Operation(
+            summary = "회원 탈퇴",
+            description =
+                    "본인 계정을 즉시 soft delete하고 30일 뒤 물리 삭제될 시각을 예약한다. 보유 refresh token은 즉시 무효화되며,"
+                            + " 액세스 토큰은 stateless 정책상 만료까지 유효(클라이언트가 보관 토큰을 폐기하는 책임).")
+    @ApiResponses({
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                responseCode = "200",
+                description = "탈퇴 처리 성공 — 이미 탈퇴된 사용자 재호출도 멱등 200(grace 기간 미연장)"),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                responseCode = "401",
+                description = "미인증 또는 만료된 액세스 토큰"),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                responseCode = "404",
+                description = "사용자를 찾을 수 없음")
+    })
+    @DeleteMapping("/me")
+    public ApiResponse<Void> deleteMyAccount(@CurrentUser Long userId) {
+        userService.deleteMyAccount(userId);
+        return ApiResponse.ok("탈퇴 처리 성공");
     }
 }

--- a/src/main/java/com/groute/groute_server/user/entity/User.java
+++ b/src/main/java/com/groute/groute_server/user/entity/User.java
@@ -1,5 +1,7 @@
 package com.groute.groute_server.user.entity;
 
+import java.time.Clock;
+import java.time.Duration;
 import java.time.LocalDate;
 import java.time.OffsetDateTime;
 import java.time.temporal.ChronoUnit;
@@ -113,6 +115,30 @@ public class User extends SoftDeleteEntity {
     public void updateProfile(JobRole jobRole, UserStatus userStatus) {
         this.jobRole = Objects.requireNonNull(jobRole, "jobRole");
         this.userStatus = Objects.requireNonNull(userStatus, "userStatus");
+    }
+
+    /**
+     * 회원 탈퇴 처리(MYP-005). 즉시 soft delete하고, 일정 기간 뒤 물리 삭제될 시각을 {@link #hardDeleteAt}에 예약한다. 실제 물리
+     * 삭제는 후속 배치 잡이 처리한다.
+     *
+     * <p>이미 탈퇴한 사용자가 다시 호출해도 {@code hardDeleteAt}을 덮어쓰지 않는다. 두 번째 호출이 시각을 갱신해버리면 grace 기간이 사실상 연장되어
+     * 복구 윈도우가 늦춰지기 때문 — 첫 요청 시각으로 못 박는 게 사용자 입장에서 안전하다.
+     *
+     * <p>{@code clock}은 호출하는 서비스가 주입한다. 테스트에서 "지금"을 고정해 {@code hardDeleteAt = 기대값}을 검증할 수 있게 하기 위함.
+     * 부모 클래스의 {@code softDelete()}는 시스템 시계({@code OffsetDateTime.now()})를 직접 쓰므로 {@code deletedAt}이
+     * 인자 {@code clock}과 미세하게 다를 수 있지만, 배치는 {@code hardDeleteAt} 컬럼만 보고 움직이니 영향이 없다.
+     *
+     * @param clock 현재 시각 소스. 보통 Spring bean으로 주입된 {@code Clock}.
+     * @param grace 탈퇴 요청부터 물리 삭제까지의 기간 (예: 30일). null 금지.
+     */
+    public void scheduleHardDelete(Clock clock, Duration grace) {
+        Objects.requireNonNull(clock, "clock");
+        Objects.requireNonNull(grace, "grace");
+        if (isDeleted()) {
+            return;
+        }
+        softDelete();
+        this.hardDeleteAt = OffsetDateTime.now(clock).plus(grace);
     }
 
     /**

--- a/src/main/java/com/groute/groute_server/user/service/UserService.java
+++ b/src/main/java/com/groute/groute_server/user/service/UserService.java
@@ -1,10 +1,15 @@
 package com.groute.groute_server.user.service;
 
+import java.time.Clock;
+import java.time.Duration;
+
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.groute.groute_server.auth.repository.RefreshTokenRepository;
 import com.groute.groute_server.common.exception.BusinessException;
 import com.groute.groute_server.common.exception.ErrorCode;
+import com.groute.groute_server.user.config.UserProperties;
 import com.groute.groute_server.user.entity.User;
 import com.groute.groute_server.user.enums.JobRole;
 import com.groute.groute_server.user.enums.UserStatus;
@@ -13,7 +18,7 @@ import com.groute.groute_server.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 
 /**
- * 마이페이지 내 정보 조회(MYP001) / 프로필 수정(MYP002) 서비스.
+ * 마이페이지 내 정보 조회(MYP001) / 프로필 수정(MYP002) / 회원 탈퇴(MYP005) 서비스.
  *
  * <p>DTO ↔ Entity 변환은 컨트롤러·DTO 정적 팩토리가 담당하고, 서비스 시그니처에는 원시 타입·엔티티만 노출한다(Layered 규칙).
  */
@@ -23,6 +28,9 @@ import lombok.RequiredArgsConstructor;
 public class UserService {
 
     private final UserRepository userRepository;
+    private final RefreshTokenRepository refreshTokenRepository;
+    private final UserProperties userProperties;
+    private final Clock clock;
 
     /** 온보딩 완료 여부 — {@code nickname}이 NULL이면 미완료. */
     public boolean isOnboardingCompleted(Long userId) {
@@ -81,6 +89,34 @@ public class UserService {
         return userRepository
                 .findById(userId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
+    }
+
+    /**
+     * 회원 탈퇴 처리(MYP-005). soft delete + 30일(설정값) 후 물리 삭제 예약 + refresh token 즉시 무효화.
+     *
+     * <p>흐름:
+     *
+     * <ol>
+     *   <li>사용자 조회 — 없으면 {@link ErrorCode#USER_NOT_FOUND}.
+     *   <li>{@link User#scheduleHardDelete}로 soft delete + {@code hardDeleteAt} set. 이미 탈퇴한 사용자 재호출
+     *       시 멱등 no-op이라 grace 기간이 연장되지 않는다.
+     *   <li>refresh token Redis 키 삭제 — 보유 토큰으로 액세스 토큰 재발급 시도 시 401. 액세스 토큰 자체는 stateless라 만료까지 유효한
+     *       점은 정책상 허용.
+     * </ol>
+     *
+     * <p>refresh token 무효화는 멱등 케이스(이미 탈퇴된 사용자)에도 그대로 호출한다. Redis {@code DELETE}는 키 없을 때 noop이라
+     * 무해하며, "탈퇴 처리됐지만 refresh token이 어딘가 살아있는" 엣지 케이스(예: 직전 호출이 token 삭제 직전에 실패)를 자동 복구하는 효과가 있다.
+     *
+     * @param userId 탈퇴할 사용자 ID
+     */
+    @Transactional
+    public void deleteMyAccount(Long userId) {
+        User user =
+                userRepository
+                        .findById(userId)
+                        .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
+        user.scheduleHardDelete(clock, Duration.ofDays(userProperties.hardDeleteGraceDays()));
+        refreshTokenRepository.deleteByUserId(userId);
     }
 
     private JobRole parseJobRole(String label) {

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -128,6 +128,9 @@ app:
     # stg/prod는 SSM에서 USER_DEFAULT_PROFILE_IMAGE_URL 주입 필수 — 누락 시 부팅 실패(fail-fast)로 설정 오류 즉시 노출.
     # 로컬은 하단 local 프로파일에서 빈 문자열 fallback 허용
     default-profile-image-url: ${USER_DEFAULT_PROFILE_IMAGE_URL}
+    # 회원 탈퇴 후 물리 삭제까지의 grace period(MYP-005). 기획상 30일 고정.
+    # env 오버라이드는 인시던트 대응·테스트 단축 목적의 안전장치이며 평소엔 default(30) 그대로 사용.
+    hard-delete-grace-days: ${USER_HARD_DELETE_GRACE_DAYS:30}
 
 discord:
   webhook:

--- a/src/test/java/com/groute/groute_server/user/service/UserServiceTest.java
+++ b/src/test/java/com/groute/groute_server/user/service/UserServiceTest.java
@@ -3,11 +3,19 @@ package com.groute.groute_server.user.service;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
 import java.util.Optional;
 
 import org.assertj.core.api.InstanceOfAssertFactories;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -16,8 +24,10 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import com.groute.groute_server.auth.repository.RefreshTokenRepository;
 import com.groute.groute_server.common.exception.BusinessException;
 import com.groute.groute_server.common.exception.ErrorCode;
+import com.groute.groute_server.user.config.UserProperties;
 import com.groute.groute_server.user.entity.User;
 import com.groute.groute_server.user.enums.JobRole;
 import com.groute.groute_server.user.enums.UserStatus;
@@ -27,8 +37,13 @@ import com.groute.groute_server.user.repository.UserRepository;
 class UserServiceTest {
 
     private static final long USER_ID = 1L;
+    private static final Instant FIXED_INSTANT = Instant.parse("2026-05-08T12:00:00Z");
+    private static final int GRACE_DAYS = 30;
 
     @Mock private UserRepository userRepository;
+    @Mock private RefreshTokenRepository refreshTokenRepository;
+    @Mock private UserProperties userProperties;
+    @Mock private Clock clock;
 
     @InjectMocks private UserService userService;
 
@@ -179,6 +194,73 @@ class UserServiceTest {
                     .asInstanceOf(InstanceOfAssertFactories.type(BusinessException.class))
                     .extracting(BusinessException::getErrorCode)
                     .isEqualTo(ErrorCode.USER_NOT_FOUND);
+        }
+    }
+
+    @Nested
+    @DisplayName("회원 탈퇴")
+    class DeleteMyAccount {
+
+        @BeforeEach
+        void setUpClockAndProperties() {
+            // USER_NOT_FOUND 케이스는 clock·properties 도달 전 short-circuit이므로 lenient 처리.
+            lenient().when(clock.instant()).thenReturn(FIXED_INSTANT);
+            lenient().when(clock.getZone()).thenReturn(ZoneOffset.UTC);
+            lenient().when(userProperties.hardDeleteGraceDays()).thenReturn(GRACE_DAYS);
+        }
+
+        @Test
+        @DisplayName("성공 — 활성 유저 soft delete + 30일 뒤 hardDeleteAt 예약")
+        void softDeletesAndSchedulesHardDelete_whenUserActive() {
+            User user = User.createForSocialLogin();
+            given(userRepository.findById(USER_ID)).willReturn(Optional.of(user));
+
+            userService.deleteMyAccount(USER_ID);
+
+            OffsetDateTime expected =
+                    OffsetDateTime.ofInstant(FIXED_INSTANT, ZoneOffset.UTC).plusDays(GRACE_DAYS);
+            assertThat(user.isDeleted()).isTrue();
+            assertThat(user.getHardDeleteAt()).isEqualTo(expected);
+        }
+
+        @Test
+        @DisplayName("성공 — 활성 유저 탈퇴 시 refresh token 즉시 무효화")
+        void invalidatesRefreshToken_whenUserActive() {
+            User user = User.createForSocialLogin();
+            given(userRepository.findById(USER_ID)).willReturn(Optional.of(user));
+
+            userService.deleteMyAccount(USER_ID);
+
+            verify(refreshTokenRepository).deleteByUserId(USER_ID);
+        }
+
+        @Test
+        @DisplayName("성공 — 이미 탈퇴된 유저 재호출 시 hardDeleteAt 미변경 (멱등) + refresh token은 그대로 호출")
+        void remainsIdempotent_whenUserAlreadyDeleted() {
+            User user = User.createForSocialLogin();
+            // 과거 다른 시각으로 이미 탈퇴 처리된 상태를 만들어둔다.
+            Clock earlier = Clock.fixed(Instant.parse("2026-04-01T00:00:00Z"), ZoneOffset.UTC);
+            user.scheduleHardDelete(earlier, Duration.ofDays(GRACE_DAYS));
+            OffsetDateTime originalHardDeleteAt = user.getHardDeleteAt();
+            given(userRepository.findById(USER_ID)).willReturn(Optional.of(user));
+
+            userService.deleteMyAccount(USER_ID);
+
+            assertThat(user.getHardDeleteAt()).isEqualTo(originalHardDeleteAt);
+            verify(refreshTokenRepository).deleteByUserId(USER_ID);
+        }
+
+        @Test
+        @DisplayName("실패 — 유저 없으면 USER_NOT_FOUND, refresh token 미호출")
+        void throwsUserNotFound_whenUserMissing() {
+            given(userRepository.findById(USER_ID)).willReturn(Optional.empty());
+
+            assertThatThrownBy(() -> userService.deleteMyAccount(USER_ID))
+                    .asInstanceOf(InstanceOfAssertFactories.type(BusinessException.class))
+                    .extracting(BusinessException::getErrorCode)
+                    .isEqualTo(ErrorCode.USER_NOT_FOUND);
+
+            verifyNoInteractions(refreshTokenRepository);
         }
     }
 }


### PR DESCRIPTION
## 요약
- MYP-005 회원 탈퇴 - `DELETE /api/users/me` 엔드포인트 추가. 즉시 soft delete + 30일 뒤 물리 삭제 예약 + refresh token Redis 즉시 무효화 (액세스 토큰은 stateless 정책상 만료까지 유효)

## 변경 사항
- [x] 기능
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 문서
- [x] 테스트
- [ ] 기타

### 상세
- `User.scheduleHardDelete(Clock, Duration)` 도메인 메서드 추가 — soft delete + `hardDeleteAt` 예약. 이미 탈퇴한 사용자 재호출 시 멱등 no-op (grace 기간 미연장)
- `UserService.deleteMyAccount(Long)` — 사용자 조회(없으면 USER_NOT_FOUND) → 도메인 메서드 호출 → `RefreshTokenRepository.deleteByUserId` 호출
- `UserProperties.hardDeleteGraceDays` 필드 추가 — yaml `app.user.hard-delete-grace-days: 30`. compact ctor에서 `> 0` 검증 (fail-fast)
- `UserController.deleteMyAccount(@CurrentUser Long)` — `@DeleteMapping("/me")`, body 없음, 응답 `ApiResponse<Void>("탈퇴 처리 성공")`
- Swagger: `@Operation`, `@ApiResponses` (200 멱등 / 401 / 404)
- 단위 테스트 4건 — 활성 유저 soft delete + hardDeleteAt 검증 / refresh token 무효화 호출 / 멱등성(재호출 시 hardDeleteAt 미변경) / USER_NOT_FOUND

## 테스트
- [x] 로컬 테스트 완료
- 테스트 방법:
    - `./gradlew test --tests "com.groute.groute_server.user.service.UserServiceTest"` — 본 PR 단위 테스트 (DeleteMyAccount nested 4건 + 기존 11건 모두 통과)
    - `./gradlew spotlessApply check` — 전체 게이트 (⚠️ contextLoads 회귀 이슈는 아래 "리스크" 참고)
    - Swagger UI: `http://localhost:8080/swagger-ui.html` → `User` 태그 → `DELETE /api/users/me` 실행 → DB에서 `users.is_deleted=true`, `deleted_at`, `hard_delete_at`(약 30일 뒤) 모두 set 확인 → Redis `refresh:{userId}` 키 사라짐 확인 → 보유 refresh token으로 재발급 시도 시 401 확인 → 동일 액세스 토큰으로 재호출 시 멱등 200 + `hard_delete_at` 미변경 확인

### 커버리지 (JaCoCo)
- 라인 커버리지: __%  (기준: 60% 이상)
- [ ] `./gradlew test` 실행 후 `build/reports/jacoco/index.html`에서 수치 확인
- (선택) 리포트 스크린샷 또는 60% 미달/특이사항 공유:
  - 아래 리스크 해결 후 추가 예정

## 스크린샷/로그 (선택)
X

## 롤백/리스크
- 리스크 포인트
    - 새 properties `app.user.hard-delete-grace-days` 추가 — env 미설정 시 default 30. **stg/prod 배포 시 별도 SSM 주입 불필요** (default 30 그대로 사용)
    - `User.java`에 새 도메인 메서드 추가 — 다음 이슈인 hard-delete 배치 PR과 같은 파일을 만질 가능성 → 단순 머지 충돌 (서로 다른 메서드 추가) 수준, 컴파일 의존성 없음
    - 액세스 토큰은 stateless 정책상 만료까지 유효 — 클라이언트가 보관 토큰 폐기 책임. 즉시 차단이 필요하면 후속 이슈로 블랙리스트 도입 검토
    - **⚠️ `./gradlew check` 시 `GrouteServerApplicationTests.contextLoads()`가 dev 브랜치 회귀로 깨져 있음** (commit `6faf7032`의 `AuthProperties` fail-fast 영향). 별도 PR(GRT-100)에서 `src/test/resources/application.yaml` 추가로 수정 중이며, 먼저 머지되는 쪽이 본 PR 머지 후 rebase 시 자동 해결됨. 본 PR이 먼저 머지될 경우 새 `hardDeleteGraceDays` 키도 같은 yaml에 추가 필요. 머지 순서에 따라 후속 1줄 패치
- 롤백 방법
    - 본 PR을 한 번에 revert (`feat: User에 회원 탈퇴 시 hardDelete 예약 도메인 메서드 추가` ~ `test: 회원 탈퇴 service 멱등성/refresh token 무효화 단위 테스트 추가`)
    - revert 후 DB 영향 없음 (탈퇴 처리된 row의 `is_deleted=true`/`hard_delete_at`은 컬럼 그대로 남으나, 배치 잡 미존재 시점이라 물리 삭제는 발생 안 함)
    - 운영 중 탈퇴 처리된 사용자 복구가 필요하면 직접 `is_deleted=false`, `deleted_at=NULL`, `hard_delete_at=NULL` 업데이트로 가능

## 관련 이슈
Closes #86 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 사용자 계정 탈퇴 엔드포인트(자기계정 삭제) 추가.
  * 탈퇴 후 영구삭제 전 유예 기간을 설정 가능하도록 구성 옵션 추가(양수만 허용).
  * 탈퇴 시 활성 세션·토큰이 즉시 무효화되고, 유예 기간 종료 시점에 영구삭제가 예약됨.

* **테스트**
  * 계정 탈퇴 흐름에 대한 단위 테스트 보강.

* **문서**
  * 유예 기간 설정 관련 설명 업데이트.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/2026-KUSITMS-GLIT/2026-KUSITMS-GLIT-BACK/pull/90)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->