### PR TITLE
feat: GET /api/users/me에 연속 기록 일수/캐릭터 상태 추가 (#93)

### DIFF
--- a/src/main/java/com/groute/groute_server/record/adapter/out/persistence/UserStreakAdapter.java
+++ b/src/main/java/com/groute/groute_server/record/adapter/out/persistence/UserStreakAdapter.java
@@ -1,0 +1,39 @@
+package com.groute.groute_server.record.adapter.out.persistence;
+
+import java.time.LocalDate;
+
+import jakarta.persistence.EntityManager;
+
+import org.springframework.stereotype.Component;
+
+import com.groute.groute_server.common.exception.BusinessException;
+import com.groute.groute_server.common.exception.ErrorCode;
+import com.groute.groute_server.record.application.port.out.user.UserStreakPort;
+import com.groute.groute_server.user.entity.User;
+
+import lombok.RequiredArgsConstructor;
+
+/**
+ * {@link UserStreakPort}의 JPA 어댑터.
+ *
+ * <p>{@link EntityManager#find}로 user를 가져온 뒤 도메인 메서드(연속 기록 갱신)를 호출하기만 한다. 변경 내용은 JPA dirty
+ * checking이 트랜잭션 커밋 시점에 자동으로 DB에 반영하므로, 호출자는 같은 {@code @Transactional} 안에서 본 어댑터를 호출해야 한다.
+ *
+ * <p>존재하지 않는 userId가 들어오면 {@link ErrorCode#USER_NOT_FOUND}로 즉시 실패한다. 작성 use case가 인증된 사용자 ID를 그대로
+ * 넘기는 흐름이라 실 운영에서는 거의 발생하지 않지만, 계약상 명확히 해 둔다.
+ */
+@Component
+@RequiredArgsConstructor
+class UserStreakAdapter implements UserStreakPort {
+
+    private final EntityManager entityManager;
+
+    @Override
+    public void recordOnDate(Long userId, LocalDate kstDate) {
+        User user = entityManager.find(User.class, userId);
+        if (user == null) {
+            throw new BusinessException(ErrorCode.USER_NOT_FOUND);
+        }
+        user.recordOnDate(kstDate);
+    }
+}

--- a/src/main/java/com/groute/groute_server/record/application/port/out/user/UserStreakPort.java
+++ b/src/main/java/com/groute/groute_server/record/application/port/out/user/UserStreakPort.java
@@ -1,0 +1,26 @@
+package com.groute.groute_server.record.application.port.out.user;
+
+import java.time.LocalDate;
+
+/**
+ * 스크럼이 작성됐을 때 user의 연속 기록 일수/마지막 기록일을 갱신해 달라고 알리는 outbound port(REC-001).
+ *
+ * <p>읽기용 {@link UserReferencePort}와 쓰기 책임을 분리했다. 호출자는 "이 user가 이 날짜에 기록했다"는 사실만 전달하고, streak를 어떻게
+ * 증가시키거나 리셋할지는 user 엔티티가 알아서 판단한다.
+ */
+public interface UserStreakPort {
+
+    /**
+     * user가 KST 기준 {@code kstDate}에 기록을 남겼음을 알린다 → 결과로 user의 streak 컬럼이 갱신된다.
+     *
+     * <p>같은 일자로 여러 번 호출돼도 안전하다. entity의 {@link
+     * com.groute.groute_server.user.entity.User#recordOnDate}가 같은 날 중복 호출을 무시하기 때문이다. 과거 일자(백데이트)도
+     * entity가 걸러 streak에는 영향이 없다.
+     *
+     * <p>부분 커밋이 일어나지 않도록 호출자의 {@code @Transactional} 안에서 호출해야 한다.
+     *
+     * @param userId 갱신 대상 user.
+     * @param kstDate 기록이 발생한 KST 일자.
+     */
+    void recordOnDate(Long userId, LocalDate kstDate);
+}

--- a/src/main/java/com/groute/groute_server/user/controller/OnboardingController.java
+++ b/src/main/java/com/groute/groute_server/user/controller/OnboardingController.java
@@ -12,6 +12,7 @@ import com.groute.groute_server.common.response.ApiResponse;
 import com.groute.groute_server.user.config.UserProperties;
 import com.groute.groute_server.user.dto.OnboardCompleteRequest;
 import com.groute.groute_server.user.dto.ProfileResponse;
+import com.groute.groute_server.user.entity.RecordStreakSnapshot;
 import com.groute.groute_server.user.entity.User;
 import com.groute.groute_server.user.service.UserService;
 
@@ -58,6 +59,9 @@ public class OnboardingController {
                         userId, request.nickname(), request.jobRole(), request.userStatus());
         return ApiResponse.ok(
                 "온보딩이 완료되었습니다.",
-                ProfileResponse.from(user, userProperties.defaultProfileImageUrl()));
+                ProfileResponse.from(
+                        user,
+                        userProperties.defaultProfileImageUrl(),
+                        new RecordStreakSnapshot(0, false)));
     }
 }

--- a/src/main/java/com/groute/groute_server/user/controller/OnboardingController.java
+++ b/src/main/java/com/groute/groute_server/user/controller/OnboardingController.java
@@ -1,5 +1,8 @@
 package com.groute.groute_server.user.controller;
 
+import java.time.LocalDate;
+import java.time.ZoneId;
+
 import jakarta.validation.Valid;
 
 import org.springframework.web.bind.annotation.PostMapping;
@@ -12,7 +15,6 @@ import com.groute.groute_server.common.response.ApiResponse;
 import com.groute.groute_server.user.config.UserProperties;
 import com.groute.groute_server.user.dto.OnboardCompleteRequest;
 import com.groute.groute_server.user.dto.ProfileResponse;
-import com.groute.groute_server.user.entity.RecordStreakSnapshot;
 import com.groute.groute_server.user.entity.User;
 import com.groute.groute_server.user.service.UserService;
 
@@ -57,11 +59,12 @@ public class OnboardingController {
         User user =
                 userService.completeOnboarding(
                         userId, request.nickname(), request.jobRole(), request.userStatus());
+        LocalDate kstToday = LocalDate.now(ZoneId.systemDefault());
         return ApiResponse.ok(
                 "온보딩이 완료되었습니다.",
                 ProfileResponse.from(
                         user,
                         userProperties.defaultProfileImageUrl(),
-                        new RecordStreakSnapshot(0, false)));
+                        user.streakSnapshotAsOf(kstToday)));
     }
 }

--- a/src/main/java/com/groute/groute_server/user/controller/OnboardingController.java
+++ b/src/main/java/com/groute/groute_server/user/controller/OnboardingController.java
@@ -1,7 +1,6 @@
 package com.groute.groute_server.user.controller;
 
 import java.time.LocalDate;
-import java.time.ZoneId;
 
 import jakarta.validation.Valid;
 
@@ -12,6 +11,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 import com.groute.groute_server.common.annotation.CurrentUser;
 import com.groute.groute_server.common.response.ApiResponse;
+import com.groute.groute_server.common.util.DateTimeFormatters;
 import com.groute.groute_server.user.config.UserProperties;
 import com.groute.groute_server.user.dto.OnboardCompleteRequest;
 import com.groute.groute_server.user.dto.ProfileResponse;
@@ -59,7 +59,7 @@ public class OnboardingController {
         User user =
                 userService.completeOnboarding(
                         userId, request.nickname(), request.jobRole(), request.userStatus());
-        LocalDate kstToday = LocalDate.now(ZoneId.systemDefault());
+        LocalDate kstToday = LocalDate.now(DateTimeFormatters.ZONE_KST);
         return ApiResponse.ok(
                 "온보딩이 완료되었습니다.",
                 ProfileResponse.from(

--- a/src/main/java/com/groute/groute_server/user/controller/UserController.java
+++ b/src/main/java/com/groute/groute_server/user/controller/UserController.java
@@ -13,6 +13,7 @@ import com.groute.groute_server.common.response.ApiResponse;
 import com.groute.groute_server.user.config.UserProperties;
 import com.groute.groute_server.user.dto.ProfileResponse;
 import com.groute.groute_server.user.dto.ProfileUpdateRequest;
+import com.groute.groute_server.user.entity.RecordStreakSnapshot;
 import com.groute.groute_server.user.entity.User;
 import com.groute.groute_server.user.service.UserService;
 
@@ -51,7 +52,11 @@ public class UserController {
     @GetMapping("/me")
     public ApiResponse<ProfileResponse> getMyProfile(@CurrentUser Long userId) {
         User user = userService.getMyProfile(userId);
-        return ApiResponse.ok(ProfileResponse.from(user, userProperties.defaultProfileImageUrl()));
+        return ApiResponse.ok(
+                ProfileResponse.from(
+                        user,
+                        userProperties.defaultProfileImageUrl(),
+                        new RecordStreakSnapshot(0, false)));
     }
 
     @Operation(summary = "프로필 수정", description = "직군·상태를 덮어쓴다. 변경 사항이 없어도 두 필드 모두 한글 라벨로 포함해 요청한다.")
@@ -73,6 +78,10 @@ public class UserController {
     public ApiResponse<ProfileResponse> updateMyProfile(
             @CurrentUser Long userId, @Valid @RequestBody ProfileUpdateRequest request) {
         User user = userService.updateMyProfile(userId, request.jobRole(), request.userStatus());
-        return ApiResponse.ok(ProfileResponse.from(user, userProperties.defaultProfileImageUrl()));
+        return ApiResponse.ok(
+                ProfileResponse.from(
+                        user,
+                        userProperties.defaultProfileImageUrl(),
+                        new RecordStreakSnapshot(0, false)));
     }
 }

--- a/src/main/java/com/groute/groute_server/user/controller/UserController.java
+++ b/src/main/java/com/groute/groute_server/user/controller/UserController.java
@@ -1,5 +1,8 @@
 package com.groute.groute_server.user.controller;
 
+import java.time.LocalDate;
+import java.time.ZoneId;
+
 import jakarta.validation.Valid;
 
 import org.springframework.web.bind.annotation.GetMapping;
@@ -13,7 +16,6 @@ import com.groute.groute_server.common.response.ApiResponse;
 import com.groute.groute_server.user.config.UserProperties;
 import com.groute.groute_server.user.dto.ProfileResponse;
 import com.groute.groute_server.user.dto.ProfileUpdateRequest;
-import com.groute.groute_server.user.entity.RecordStreakSnapshot;
 import com.groute.groute_server.user.entity.User;
 import com.groute.groute_server.user.service.UserService;
 
@@ -52,11 +54,12 @@ public class UserController {
     @GetMapping("/me")
     public ApiResponse<ProfileResponse> getMyProfile(@CurrentUser Long userId) {
         User user = userService.getMyProfile(userId);
+        LocalDate kstToday = LocalDate.now(ZoneId.systemDefault());
         return ApiResponse.ok(
                 ProfileResponse.from(
                         user,
                         userProperties.defaultProfileImageUrl(),
-                        new RecordStreakSnapshot(0, false)));
+                        user.streakSnapshotAsOf(kstToday)));
     }
 
     @Operation(summary = "프로필 수정", description = "직군·상태를 덮어쓴다. 변경 사항이 없어도 두 필드 모두 한글 라벨로 포함해 요청한다.")
@@ -78,10 +81,11 @@ public class UserController {
     public ApiResponse<ProfileResponse> updateMyProfile(
             @CurrentUser Long userId, @Valid @RequestBody ProfileUpdateRequest request) {
         User user = userService.updateMyProfile(userId, request.jobRole(), request.userStatus());
+        LocalDate kstToday = LocalDate.now(ZoneId.systemDefault());
         return ApiResponse.ok(
                 ProfileResponse.from(
                         user,
                         userProperties.defaultProfileImageUrl(),
-                        new RecordStreakSnapshot(0, false)));
+                        user.streakSnapshotAsOf(kstToday)));
     }
 }

--- a/src/main/java/com/groute/groute_server/user/controller/UserController.java
+++ b/src/main/java/com/groute/groute_server/user/controller/UserController.java
@@ -1,7 +1,6 @@
 package com.groute.groute_server.user.controller;
 
 import java.time.LocalDate;
-import java.time.ZoneId;
 
 import jakarta.validation.Valid;
 
@@ -13,6 +12,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 import com.groute.groute_server.common.annotation.CurrentUser;
 import com.groute.groute_server.common.response.ApiResponse;
+import com.groute.groute_server.common.util.DateTimeFormatters;
 import com.groute.groute_server.user.config.UserProperties;
 import com.groute.groute_server.user.dto.ProfileResponse;
 import com.groute.groute_server.user.dto.ProfileUpdateRequest;
@@ -54,7 +54,7 @@ public class UserController {
     @GetMapping("/me")
     public ApiResponse<ProfileResponse> getMyProfile(@CurrentUser Long userId) {
         User user = userService.getMyProfile(userId);
-        LocalDate kstToday = LocalDate.now(ZoneId.systemDefault());
+        LocalDate kstToday = LocalDate.now(DateTimeFormatters.ZONE_KST);
         return ApiResponse.ok(
                 ProfileResponse.from(
                         user,
@@ -81,7 +81,7 @@ public class UserController {
     public ApiResponse<ProfileResponse> updateMyProfile(
             @CurrentUser Long userId, @Valid @RequestBody ProfileUpdateRequest request) {
         User user = userService.updateMyProfile(userId, request.jobRole(), request.userStatus());
-        LocalDate kstToday = LocalDate.now(ZoneId.systemDefault());
+        LocalDate kstToday = LocalDate.now(DateTimeFormatters.ZONE_KST);
         return ApiResponse.ok(
                 ProfileResponse.from(
                         user,

--- a/src/main/java/com/groute/groute_server/user/dto/ProfileResponse.java
+++ b/src/main/java/com/groute/groute_server/user/dto/ProfileResponse.java
@@ -15,8 +15,7 @@ public record ProfileResponse(
         @Schema(description = "유저 직군", example = "개발자") String jobRole,
         @Schema(description = "유저 상태", example = "재학 중") String userStatus,
         @Schema(
-                        description =
-                                "연속 기록 일수. 끊기지 않은 KST 일자 기준. 0~2일 미기록 시 직전 streak 유지, 3일 이상 미기록·기록 0건은 0(REC-001).",
+                        description = "연속 기록 일수 — 오늘 또는 어제 기록 시 유지, 2일 이상 미기록·기록 0건은 0(REC-001).",
                         example = "8")
                 int consecutiveRecordDays,
         @Schema(

--- a/src/main/java/com/groute/groute_server/user/dto/ProfileResponse.java
+++ b/src/main/java/com/groute/groute_server/user/dto/ProfileResponse.java
@@ -1,5 +1,6 @@
 package com.groute.groute_server.user.dto;
 
+import com.groute.groute_server.user.entity.RecordStreakSnapshot;
 import com.groute.groute_server.user.entity.User;
 
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -12,19 +13,35 @@ public record ProfileResponse(
                 String profileImage,
         @Schema(description = "유저 닉네임", example = "겨레") String nickname,
         @Schema(description = "유저 직군", example = "개발자") String jobRole,
-        @Schema(description = "유저 상태", example = "재학 중") String userStatus) {
+        @Schema(description = "유저 상태", example = "재학 중") String userStatus,
+        @Schema(
+                        description =
+                                "연속 기록 일수. 끊기지 않은 KST 일자 기준. 0~2일 미기록 시 직전 streak 유지, 3일 이상 미기록·기록 0건은 0(REC-001).",
+                        example = "8")
+                int consecutiveRecordDays,
+        @Schema(
+                        description =
+                                "째려보는 캐릭터 노출 여부. 마지막 기록일이 3일 이상 이전이면 true, 그 외/0건은 false(REC-001).",
+                        example = "false")
+                boolean glaring) {
 
     /**
-     * 엔티티와 기본 프로필 이미지 URL로부터 응답 DTO를 생성하는 정적 팩토리.
+     * 엔티티 + 기본 프로필 이미지 URL + streak 산정 결과로부터 응답 DTO를 생성하는 정적 팩토리.
      *
      * <p>enum → 한글 라벨 변환은 이 팩토리에서 수행한다. 온보딩 미완료 상태의 유저는 {@code jobRole}/{@code userStatus}가 DB에서
      * {@code null}일 수 있으므로 방어적으로 null을 허용한다.
      */
-    public static ProfileResponse from(User user, String profileImageUrl) {
+    public static ProfileResponse from(
+            User user, String profileImageUrl, RecordStreakSnapshot streak) {
         String jobRoleLabel = user.getJobRole() != null ? user.getJobRole().getLabel() : null;
         String userStatusLabel =
                 user.getUserStatus() != null ? user.getUserStatus().getLabel() : null;
         return new ProfileResponse(
-                profileImageUrl, user.getNickname(), jobRoleLabel, userStatusLabel);
+                profileImageUrl,
+                user.getNickname(),
+                jobRoleLabel,
+                userStatusLabel,
+                streak.consecutiveDays(),
+                streak.glaring());
     }
 }

--- a/src/main/java/com/groute/groute_server/user/entity/RecordStreakSnapshot.java
+++ b/src/main/java/com/groute/groute_server/user/entity/RecordStreakSnapshot.java
@@ -6,7 +6,8 @@ package com.groute.groute_server.user.entity;
  * <p>API 응답 DTO가 아닌 {@link User}가 자체 상태로부터 산정해 노출하는 도메인 read model. 같은 패키지에 둬 entity → service 역방향
  * import를 피한다. KST 기준이며 산정 책임은 {@link User#streakSnapshotAsOf(java.time.LocalDate)}.
  *
- * @param consecutiveDays 끊기지 않은 기록 연속 일수. 0~2일 미기록은 기존 streak 유지, 3일 이상 미기록·기록 0건은 0.
+ * @param consecutiveDays 오늘 또는 어제(gap ≤ 1) 기록이면 기존 streak 유지, 2일 이상 미기록이거나 기록 0건이면 0. 캐릭터 상태({@code
+ *     glaring})와는 분리된 규칙.
  * @param glaring 째려보는 캐릭터 노출 여부 — 마지막 기록일이 3일 이상 이전이면 true, 그 외/0건은 false.
  */
 public record RecordStreakSnapshot(int consecutiveDays, boolean glaring) {}

--- a/src/main/java/com/groute/groute_server/user/entity/RecordStreakSnapshot.java
+++ b/src/main/java/com/groute/groute_server/user/entity/RecordStreakSnapshot.java
@@ -1,0 +1,12 @@
+package com.groute.groute_server.user.entity;
+
+/**
+ * REC-001 연속 기록 일수 + 째려보는 캐릭터 노출 여부 read model.
+ *
+ * <p>API 응답 DTO가 아닌 {@link User}가 자체 상태로부터 산정해 노출하는 도메인 read model. 같은 패키지에 둬 entity → service 역방향
+ * import를 피한다. KST 기준이며 산정 책임은 {@link User#streakSnapshotAsOf(java.time.LocalDate)}.
+ *
+ * @param consecutiveDays 끊기지 않은 기록 연속 일수. 0~2일 미기록은 기존 streak 유지, 3일 이상 미기록·기록 0건은 0.
+ * @param glaring 째려보는 캐릭터 노출 여부 — 마지막 기록일이 3일 이상 이전이면 true, 그 외/0건은 false.
+ */
+public record RecordStreakSnapshot(int consecutiveDays, boolean glaring) {}

--- a/src/main/java/com/groute/groute_server/user/entity/User.java
+++ b/src/main/java/com/groute/groute_server/user/entity/User.java
@@ -1,6 +1,8 @@
 package com.groute.groute_server.user.entity;
 
+import java.time.LocalDate;
 import java.time.OffsetDateTime;
+import java.time.temporal.ChronoUnit;
 import java.util.Objects;
 
 import jakarta.persistence.*;
@@ -75,6 +77,24 @@ public class User extends SoftDeleteEntity {
     @Column(name = "notification_copy_index", nullable = false)
     private short notificationCopyIndex = 0;
 
+    /**
+     * 끊기지 않은 KST 일자 기준 연속 기록 일수(REC-001).
+     *
+     * <p>가입 시 0. 첫 기록 시 1로 시작, {@code gap == 1} 갱신 시 +1, {@code gap >= 2} 갱신 시 1로 리셋. 갱신 책임은 {@link
+     * #recordOnDate(LocalDate)}, 산정 결과 노출은 {@link #streakSnapshotAsOf(LocalDate)}.
+     */
+    @Column(name = "current_streak", nullable = false)
+    private short currentStreak = 0;
+
+    /**
+     * KST 기준 마지막 기록 일자(REC-001).
+     *
+     * <p>가입 직후 NULL — {@link #streakSnapshotAsOf(LocalDate)}는 NULL 입력 시 streak/glaring 모두 false(기본
+     * 캐릭터)로 산정한다.
+     */
+    @Column(name = "last_record_date")
+    private LocalDate lastRecordDate;
+
     /** 소셜 로그인 신규 가입 시 호출. 온보딩 전이므로 프로필 필드는 모두 NULL로 둔다. */
     public static User createForSocialLogin() {
         return new User();
@@ -116,5 +136,75 @@ public class User extends SoftDeleteEntity {
         }
         int next = Math.floorMod(this.notificationCopyIndex + 1, total);
         this.notificationCopyIndex = (short) next;
+    }
+
+    /**
+     * 스크럼 작성 시 호출 — KST 일자 기준으로 연속 기록 일수와 마지막 기록일을 갱신한다(REC-001).
+     *
+     * <p>분기:
+     *
+     * <ul>
+     *   <li>{@code lastRecordDate}가 NULL → 첫 기록. {@code currentStreak = 1}, {@code lastRecordDate =
+     *       kstDate}.
+     *   <li>{@code kstDate}가 {@code lastRecordDate}와 같거나 이전 → noop(같은 날 멱등 + 백데이트 무시).
+     *   <li>{@code gap == 1} → {@code currentStreak += 1}({@link Short#MAX_VALUE} 도달 시 cap).
+     *   <li>{@code gap >= 2} → {@code currentStreak = 1}로 리셋.
+     * </ul>
+     *
+     * <p>시간대 변환 책임은 호출 측 — KST 기준 {@link LocalDate}를 그대로 받는다. 같은 트랜잭션 내 dirty checking으로 영속화되도록 호출
+     * use case가 설계한다.
+     *
+     * @param kstDate KST 기준 기록 일자.
+     */
+    public void recordOnDate(LocalDate kstDate) {
+        Objects.requireNonNull(kstDate, "kstDate");
+        if (this.lastRecordDate == null) {
+            this.currentStreak = 1;
+            this.lastRecordDate = kstDate;
+            return;
+        }
+        if (!kstDate.isAfter(this.lastRecordDate)) {
+            return;
+        }
+        long gap = ChronoUnit.DAYS.between(this.lastRecordDate, kstDate);
+        if (gap == 1) {
+            if (this.currentStreak < Short.MAX_VALUE) {
+                this.currentStreak = (short) (this.currentStreak + 1);
+            }
+        } else {
+            this.currentStreak = 1;
+        }
+        this.lastRecordDate = kstDate;
+    }
+
+    /**
+     * KST 기준 오늘 시점의 연속 기록 일수와 째려보는 캐릭터 노출 여부 산정(REC-001).
+     *
+     * <p>분기:
+     *
+     * <ul>
+     *   <li>{@code lastRecordDate}가 NULL → {@code (0, false)}(가입 직후 = 기본 캐릭터).
+     *   <li>{@code gap <= 1}(오늘 또는 어제 기록) → {@code (currentStreak, false)} — streak 유지/노출.
+     *   <li>{@code gap == 2}(2일 미기록) → {@code (0, false)} — 기획상 "0~2일 미기록 = 기본 캐릭터".
+     *   <li>{@code gap >= 3}(3일 이상 미기록) → {@code (0, true)} — 째려보는 캐릭터.
+     * </ul>
+     *
+     * <p>시간대 변환 책임은 호출 측 — KST 기준 {@link LocalDate}를 그대로 받는다.
+     *
+     * @param kstToday KST 기준 오늘 날짜.
+     */
+    public RecordStreakSnapshot streakSnapshotAsOf(LocalDate kstToday) {
+        Objects.requireNonNull(kstToday, "kstToday");
+        if (this.lastRecordDate == null) {
+            return new RecordStreakSnapshot(0, false);
+        }
+        long gap = ChronoUnit.DAYS.between(this.lastRecordDate, kstToday);
+        if (gap <= 1) {
+            return new RecordStreakSnapshot(this.currentStreak, false);
+        }
+        if (gap == 2) {
+            return new RecordStreakSnapshot(0, false);
+        }
+        return new RecordStreakSnapshot(0, true);
     }
 }

--- a/src/main/java/com/groute/groute_server/user/entity/User.java
+++ b/src/main/java/com/groute/groute_server/user/entity/User.java
@@ -185,7 +185,8 @@ public class User extends SoftDeleteEntity {
      * <ul>
      *   <li>{@code lastRecordDate}가 NULL → {@code (0, false)}(가입 직후 = 기본 캐릭터).
      *   <li>{@code gap <= 1}(오늘 또는 어제 기록) → {@code (currentStreak, false)} — streak 유지/노출.
-     *   <li>{@code gap == 2}(2일 미기록) → {@code (0, false)} — 기획상 "0~2일 미기록 = 기본 캐릭터".
+     *   <li>{@code gap == 2}(2일 미기록) → {@code (0, false)} — streak는 끊겨 0이지만 캐릭터는 아직
+     *       기본(glaring=false). 기획상 "3일 이상 미기록"부터 째려보는으로 전환되는 분기.
      *   <li>{@code gap >= 3}(3일 이상 미기록) → {@code (0, true)} — 째려보는 캐릭터.
      * </ul>
      *

--- a/src/main/resources/db/migration/V20260510105246__add_users_record_streak.sql
+++ b/src/main/resources/db/migration/V20260510105246__add_users_record_streak.sql
@@ -1,0 +1,7 @@
+-- 연속 기록 일수 / 마지막 기록일 (REC-001 — 배지 [N일 연속 기록 중] + 캐릭터 분기)
+-- current_streak   : 끊기지 않은 KST 일자 기준 연속 기록 일수. 가입 시 0, 첫 기록 시 1, gap 1 → +1, gap ≥ 2 → 1로 리셋.
+-- last_record_date : KST 기준 마지막 기록 일자. 가입 직후 NULL. NULL이면 streak/glaring 모두 false 분기(가입 직후=기본 캐릭터).
+-- 백필은 본 마이그레이션에선 수행하지 않는다. 기존 유저는 default(0/NULL)로 시작하고, 다음 기록 시점부터 정확히 누적된다.
+ALTER TABLE users
+    ADD COLUMN current_streak   SMALLINT NOT NULL DEFAULT 0,
+    ADD COLUMN last_record_date DATE;


### PR DESCRIPTION
## 요약
- 홈/기록하기 상단 `[N일 연속 기록 중]` 배지와 캐릭터 상태(기본/째려보는) 노출을 위해, BE에서 미리 계산한 `consecutiveRecordDays` / `glaring`을 `GET /api/users/me` 응답에 포함하도록 확장.

## 변경 사항
- [x] 기능
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 문서
- [ ] 테스트
- [ ] 기타

상세:
- `users` 테이블에 `current_streak`(SMALLINT NOT NULL DEFAULT 0) / `last_record_date`(DATE NULL) 컬럼 추가 (`V20260510105246__add_users_record_streak.sql`).
- `User` 엔티티 도메인 메서드 추가:
  - `recordOnDate(LocalDate)` — 작성 시 streak 갱신 (null/같은 날/백데이트 noop, gap=1 → +1, gap≥2 → 1로 리셋, `Short.MAX_VALUE` cap).
  - `streakSnapshotAsOf(LocalDate)` — 산정 결과 `RecordStreakSnapshot(consecutiveDays, glaring)` 반환.
- 산정 규칙:
  - `lastRecordDate == null` → `(0, false)` — 가입 직후 = 기본 캐릭터
  - `gap ≤ 1` (오늘/어제 기록) → `(currentStreak, false)` — streak 유지
  - `gap == 2` (2일 미기록) → `(0, false)` — 기본 캐릭터
  - `gap ≥ 3` (3일 이상 미기록) → `(0, true)` — 째려보는 캐릭터
- `record → user` outbound port `UserStreakPort` + JPA 어댑터 신설 — 스크럼 작성 use case가 인젝트해 호출 가능.
- `ProfileResponse`에 `consecutiveRecordDays`/`glaring` 필드 평탄 확장 + `@Schema` 부여. GET/PATCH `/api/users/me`, POST `/api/onboarding/complete` 응답에 streak 합성 (`user.streakSnapshotAsOf(LocalDate.now(ZoneId.systemDefault()))`).

## 테스트
X
서비스 단위가 아니라 미진행

### 커버리지 (JaCoCo)
X
서비스 단위가 아니라 미진행

## 스크린샷/로그 (선택)
- 필요한 경우 첨부

## 🚧 후속 작업: streak 컬럼 갱신 연결 (중요)

> **본 PR은 컬럼/엔티티/응답 노출까지만 포함합니다. 실제로 `current_streak` / `last_record_date`를 채우는 호출은 본 PR에 포함되지 않았습니다.**

streak 컬럼은 스크럼 작성 시점에 `UserStreakPort.recordOnDate(userId, kstDate)` 호출로 갱신됩니다. 호출되어야 할 지점은 두 곳입니다:

- **캘린더 sync (`PUT /api/scrums/daily` · `ScrumSyncService`)** — dev 머지 완료 상태이지만, 기획팀 노티(2026-05-10)에 따라 **추가/수정 기능은 일괄 제외하고 삭제만 가능**하도록 곧 다수 변경 예정. 어차피 sync 자체가 재작업되고 삭제는 streak에 영향이 없어 **본 PR에서는 연결하지 않았습니다.**
- **기록하기 엔드포인트 (별도 작성 use case)** — 현재 **dev 미머지** 상태. 이 PR 머지 후 해당 이슈 작업 시 사용해주시면 됩니다.

따라서 본 PR 단독 머지 직후엔 모든 유저의 응답이 `consecutiveRecordDays=0, glaring=false`로 노출됩니다 (컬럼 default). FE는 응답 형태를 선반영해두고, 실제 값은 위 후속 PR 머지 시점부터 채워집니다.

## 롤백/리스크
- 리스크 포인트: X
- 롤백 방법:
    - 머지 revert 후 마이그레이션(`ALTER TABLE users DROP COLUMN current_streak, DROP COLUMN last_record_date;`)으로 후처리.

## 관련 이슈
Closes #93 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 사용자의 연속 기록 일수를 추적하는 스트릭 기능 추가
  * 사용자 프로필에 연속 기록 일수 및 상태 정보 표시
  * 사용자가 기록한 활동에 따른 스트릭 자동 업데이트 기능 구현

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/2026-KUSITMS-GLIT/2026-KUSITMS-GLIT-BACK/pull/94)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->