### PR TITLE
feat: 리포트 조회 API 구현 (#73)

### DIFF
--- a/src/main/java/com/groute/groute_server/common/exception/ErrorCode.java
+++ b/src/main/java/com/groute/groute_server/common/exception/ErrorCode.java
@@ -78,6 +78,10 @@ public enum ErrorCode {
     PROJECT_NOT_FOUND(HttpStatus.NOT_FOUND, "PROJECT_001", "프로젝트 태그를 찾을 수 없습니다."),
     PROJECT_NAME_DUPLICATE(HttpStatus.CONFLICT, "PROJECT_002", "이미 존재하는 프로젝트 태그 이름입니다."),
     PROJECT_HAS_RECORDS(HttpStatus.CONFLICT, "PROJECT_003", "연결된 기록이 있어 삭제할 수 없습니다."),
+
+    // Report
+    REPORT_NOT_FOUND(HttpStatus.NOT_FOUND, "REPORT_001", "리포트를 찾을 수 없습니다."),
+    REPORT_NOT_COMPLETED(HttpStatus.BAD_REQUEST, "REPORT_002", "아직 생성 완료되지 않은 리포트입니다."),
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/groute/groute_server/record/adapter/out/persistence/StarRecordJpaRepository.java
+++ b/src/main/java/com/groute/groute_server/record/adapter/out/persistence/StarRecordJpaRepository.java
@@ -1,7 +1,7 @@
 package com.groute.groute_server.record.adapter.out.persistence;
 
-import java.time.OffsetDateTime;
 import java.time.LocalDate;
+import java.time.OffsetDateTime;
 import java.util.Collection;
 import java.util.Optional;
 

--- a/src/main/java/com/groute/groute_server/record/adapter/out/persistence/StarRecordJpaRepository.java
+++ b/src/main/java/com/groute/groute_server/record/adapter/out/persistence/StarRecordJpaRepository.java
@@ -1,5 +1,6 @@
 package com.groute.groute_server.record.adapter.out.persistence;
 
+import java.time.OffsetDateTime;
 import java.time.LocalDate;
 import java.util.Collection;
 import java.util.Optional;
@@ -65,4 +66,17 @@ public interface StarRecordJpaRepository extends JpaRepository<StarRecord, Long>
             @Param("userId") Long userId,
             @Param("date") LocalDate date,
             @Param("tagged") StarRecordStatus tagged);
+
+    /**
+     * 특정 시점 이후 완료된 심화기록 수를 카운트한다.
+     *
+     * <p>after가 null이면 전체 완료된 심화기록 수를 반환한다 (신규 유저 케이스).
+     */
+    @Query(
+            "SELECT COUNT(sr) FROM StarRecord sr "
+                    + "WHERE sr.user.id = :userId "
+                    + "AND sr.isCompleted = true "
+                    + "AND sr.isDeleted = false "
+                    + "AND (:after IS NULL OR sr.completedAt > :after)")
+    int countCompletedAfter(@Param("userId") Long userId, @Param("after") OffsetDateTime after);
 }

--- a/src/main/java/com/groute/groute_server/report/adapter/in/web/ReportController.java
+++ b/src/main/java/com/groute/groute_server/report/adapter/in/web/ReportController.java
@@ -1,0 +1,92 @@
+package com.groute.groute_server.report.adapter.in.web;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.groute.groute_server.common.annotation.CurrentUser;
+import com.groute.groute_server.common.response.ApiResponse;
+import com.groute.groute_server.report.adapter.in.web.dto.ReportDetailResponse;
+import com.groute.groute_server.report.adapter.in.web.dto.ReportGaugeResponse;
+import com.groute.groute_server.report.adapter.in.web.dto.ReportListResponse;
+import com.groute.groute_server.report.application.port.in.GetReportDetailUseCase;
+import com.groute.groute_server.report.application.port.in.GetReportGaugeUseCase;
+import com.groute.groute_server.report.application.port.in.GetReportListUseCase;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * 리포트 조회 엔드포인트 (RPT-001).
+ *
+ * <p>게이지·목록·상세 조회를 담당한다.
+ */
+@Tag(name = "Report", description = "리포트 API")
+@RestController
+@RequestMapping("/api/reports")
+@RequiredArgsConstructor
+public class ReportController {
+
+    private final GetReportGaugeUseCase getReportGaugeUseCase;
+    private final GetReportListUseCase getReportListUseCase;
+    private final GetReportDetailUseCase getReportDetailUseCase;
+
+    /** RPT-001: 리포트 게이지 조회. */
+    @Operation(summary = "리포트 게이지 조회", description = "마지막 리포트 생성 이후 완료된 심화기록 수와 다음 생성 임계치를 반환한다.")
+    @ApiResponses({
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                responseCode = "200",
+                description = "게이지 조회 성공"),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                responseCode = "401",
+                description = "미인증 또는 만료된 액세스 토큰")
+    })
+    @GetMapping("/gauge")
+    public ApiResponse<ReportGaugeResponse> getGauge(@CurrentUser Long userId) {
+        return ApiResponse.ok(getReportGaugeUseCase.getGauge(userId));
+    }
+
+    /** RPT-001: 리포트 목록 조회. */
+    @Operation(
+            summary = "리포트 목록 조회",
+            description = "유저의 리포트 목록을 생성일 기준 내림차순으로 반환한다. 이력 없으면 빈 배열 반환.")
+    @ApiResponses({
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                responseCode = "200",
+                description = "목록 조회 성공"),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                responseCode = "401",
+                description = "미인증 또는 만료된 액세스 토큰")
+    })
+    @GetMapping
+    public ApiResponse<ReportListResponse> getList(@CurrentUser Long userId) {
+        return ApiResponse.ok(getReportListUseCase.getList(userId));
+    }
+
+    /** RPT-001: 리포트 상세 조회. */
+    @Operation(
+            summary = "리포트 상세 조회",
+            description = "리포트 단건을 조회한다. MINI/CAREER 타입에 따라 content 구조가 다르다.")
+    @ApiResponses({
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                responseCode = "200",
+                description = "상세 조회 성공"),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                responseCode = "401",
+                description = "미인증 또는 만료된 액세스 토큰"),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                responseCode = "403",
+                description = "본인 소유 리포트가 아님"),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                responseCode = "404",
+                description = "리포트를 찾을 수 없음")
+    })
+    @GetMapping("/{reportId}")
+    public ApiResponse<ReportDetailResponse> getDetail(
+            @PathVariable Long reportId, @CurrentUser Long userId) {
+        return ApiResponse.ok(getReportDetailUseCase.getDetail(reportId, userId));
+    }
+}

--- a/src/main/java/com/groute/groute_server/report/adapter/in/web/ReportController.java
+++ b/src/main/java/com/groute/groute_server/report/adapter/in/web/ReportController.java
@@ -34,7 +34,6 @@ public class ReportController {
     private final GetReportListUseCase getReportListUseCase;
     private final GetReportDetailUseCase getReportDetailUseCase;
 
-    /** RPT-001: 리포트 게이지 조회. */
     @Operation(summary = "리포트 게이지 조회", description = "마지막 리포트 생성 이후 완료된 심화기록 수와 다음 생성 임계치를 반환한다.")
     @ApiResponses({
         @io.swagger.v3.oas.annotations.responses.ApiResponse(
@@ -46,10 +45,9 @@ public class ReportController {
     })
     @GetMapping("/gauge")
     public ApiResponse<ReportGaugeResponse> getGauge(@CurrentUser Long userId) {
-        return ApiResponse.ok(getReportGaugeUseCase.getGauge(userId));
+        return ApiResponse.ok(ReportGaugeResponse.from(getReportGaugeUseCase.getGauge(userId)));
     }
 
-    /** RPT-001: 리포트 목록 조회. */
     @Operation(
             summary = "리포트 목록 조회",
             description = "유저의 리포트 목록을 생성일 기준 내림차순으로 반환한다. 이력 없으면 빈 배열 반환.")
@@ -63,10 +61,9 @@ public class ReportController {
     })
     @GetMapping
     public ApiResponse<ReportListResponse> getList(@CurrentUser Long userId) {
-        return ApiResponse.ok(getReportListUseCase.getList(userId));
+        return ApiResponse.ok(ReportListResponse.from(getReportListUseCase.getList(userId)));
     }
 
-    /** RPT-001: 리포트 상세 조회. */
     @Operation(
             summary = "리포트 상세 조회",
             description = "리포트 단건을 조회한다. MINI/CAREER 타입에 따라 content 구조가 다르다.")
@@ -87,6 +84,7 @@ public class ReportController {
     @GetMapping("/{reportId}")
     public ApiResponse<ReportDetailResponse> getDetail(
             @PathVariable Long reportId, @CurrentUser Long userId) {
-        return ApiResponse.ok(getReportDetailUseCase.getDetail(reportId, userId));
+        return ApiResponse.ok(
+                ReportDetailResponse.from(getReportDetailUseCase.getDetail(reportId, userId)));
     }
 }

--- a/src/main/java/com/groute/groute_server/report/adapter/in/web/dto/ReportDetailResponse.java
+++ b/src/main/java/com/groute/groute_server/report/adapter/in/web/dto/ReportDetailResponse.java
@@ -1,0 +1,28 @@
+package com.groute.groute_server.report.adapter.in.web.dto;
+
+import java.util.Map;
+
+import com.groute.groute_server.report.domain.Report;
+import com.groute.groute_server.report.domain.enums.ReportType;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+/**
+ * RPT-001: 리포트 상세 조회 응답.
+ *
+ * <p>MINI/CAREER 타입에 따라 content 구조가 다르다. content는 content_json을 그대로 반환하며, 역직렬화는 이슈 2(생성) 구조 확정 후
+ * 처리한다.
+ */
+@Schema(description = "리포트 상세 조회 응답")
+public record ReportDetailResponse(
+        @Schema(description = "리포트 식별자", example = "1") Long reportId,
+        @Schema(description = "리포트 종류", example = "CAREER") ReportType reportType,
+        @Schema(description = "리포트 생성일 (yyyy-MM-dd)", example = "2026-04-10") String createdAt,
+        @Schema(description = "리포트 본문. MINI/CAREER 타입별 구조 상이") Map<String, Object> content) {
+
+    public static ReportDetailResponse from(Report report) {
+        String createdAt = report.getCreatedAt().toLocalDate().toString();
+        return new ReportDetailResponse(
+                report.getId(), report.getReportType(), createdAt, report.getContentJson());
+    }
+}

--- a/src/main/java/com/groute/groute_server/report/adapter/in/web/dto/ReportDetailResponse.java
+++ b/src/main/java/com/groute/groute_server/report/adapter/in/web/dto/ReportDetailResponse.java
@@ -2,17 +2,12 @@ package com.groute.groute_server.report.adapter.in.web.dto;
 
 import java.util.Map;
 
-import com.groute.groute_server.report.domain.Report;
+import com.groute.groute_server.report.application.port.in.dto.ReportDetailView;
 import com.groute.groute_server.report.domain.enums.ReportType;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 
-/**
- * RPT-001: 리포트 상세 조회 응답.
- *
- * <p>MINI/CAREER 타입에 따라 content 구조가 다르다. content는 content_json을 그대로 반환하며, 역직렬화는 이슈 2(생성) 구조 확정 후
- * 처리한다.
- */
+/** 리포트 상세 조회 응답 DTO. {@link ReportDetailView}의 Web 표현. */
 @Schema(description = "리포트 상세 조회 응답")
 public record ReportDetailResponse(
         @Schema(description = "리포트 식별자", example = "1") Long reportId,
@@ -20,9 +15,8 @@ public record ReportDetailResponse(
         @Schema(description = "리포트 생성일 (yyyy-MM-dd)", example = "2026-04-10") String createdAt,
         @Schema(description = "리포트 본문. MINI/CAREER 타입별 구조 상이") Map<String, Object> content) {
 
-    public static ReportDetailResponse from(Report report) {
-        String createdAt = report.getCreatedAt().toLocalDate().toString();
+    public static ReportDetailResponse from(ReportDetailView view) {
         return new ReportDetailResponse(
-                report.getId(), report.getReportType(), createdAt, report.getContentJson());
+                view.reportId(), view.reportType(), view.createdAt(), view.content());
     }
 }

--- a/src/main/java/com/groute/groute_server/report/adapter/in/web/dto/ReportGaugeResponse.java
+++ b/src/main/java/com/groute/groute_server/report/adapter/in/web/dto/ReportGaugeResponse.java
@@ -1,0 +1,23 @@
+package com.groute.groute_server.report.adapter.in.web.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+/**
+ * RPT-001: 리포트 게이지 조회 응답.
+ *
+ * <p>마지막 리포트 생성 이후 완료된 심화기록 수와 다음 생성 임계치를 반환한다. progressRate는 1.0 초과 가능 (10회 초과 시에도 카운팅 계속).
+ */
+@Schema(description = "리포트 게이지 조회 응답")
+public record ReportGaugeResponse(
+        @Schema(description = "마지막 리포트 생성 이후 완료된 심화기록 수", example = "7") int currentCount,
+        @Schema(description = "다음 생성 기준 수", example = "10") int nextThreshold,
+        @Schema(description = "currentCount / nextThreshold. 1.0 초과 가능", example = "0.7")
+                double progressRate,
+        @Schema(description = "true → 리포트 생성 버튼 활성화", example = "false") boolean isGeneratable) {
+
+    public static ReportGaugeResponse of(int currentCount, int nextThreshold) {
+        double progressRate = (double) currentCount / nextThreshold;
+        boolean isGeneratable = currentCount >= nextThreshold;
+        return new ReportGaugeResponse(currentCount, nextThreshold, progressRate, isGeneratable);
+    }
+}

--- a/src/main/java/com/groute/groute_server/report/adapter/in/web/dto/ReportGaugeResponse.java
+++ b/src/main/java/com/groute/groute_server/report/adapter/in/web/dto/ReportGaugeResponse.java
@@ -1,12 +1,10 @@
 package com.groute.groute_server.report.adapter.in.web.dto;
 
+import com.groute.groute_server.report.application.port.in.dto.ReportGaugeView;
+
 import io.swagger.v3.oas.annotations.media.Schema;
 
-/**
- * RPT-001: 리포트 게이지 조회 응답.
- *
- * <p>마지막 리포트 생성 이후 완료된 심화기록 수와 다음 생성 임계치를 반환한다. progressRate는 1.0 초과 가능 (10회 초과 시에도 카운팅 계속).
- */
+/** 리포트 게이지 조회 응답 DTO. {@link ReportGaugeView}의 Web 표현. */
 @Schema(description = "리포트 게이지 조회 응답")
 public record ReportGaugeResponse(
         @Schema(description = "마지막 리포트 생성 이후 완료된 심화기록 수", example = "7") int currentCount,
@@ -15,9 +13,11 @@ public record ReportGaugeResponse(
                 double progressRate,
         @Schema(description = "true → 리포트 생성 버튼 활성화", example = "false") boolean isGeneratable) {
 
-    public static ReportGaugeResponse of(int currentCount, int nextThreshold) {
-        double progressRate = (double) currentCount / nextThreshold;
-        boolean isGeneratable = currentCount >= nextThreshold;
-        return new ReportGaugeResponse(currentCount, nextThreshold, progressRate, isGeneratable);
+    public static ReportGaugeResponse from(ReportGaugeView view) {
+        return new ReportGaugeResponse(
+                view.currentCount(),
+                view.nextThreshold(),
+                view.progressRate(),
+                view.isGeneratable());
     }
 }

--- a/src/main/java/com/groute/groute_server/report/adapter/in/web/dto/ReportListResponse.java
+++ b/src/main/java/com/groute/groute_server/report/adapter/in/web/dto/ReportListResponse.java
@@ -2,27 +2,25 @@ package com.groute.groute_server.report.adapter.in.web.dto;
 
 import java.util.List;
 
-import com.groute.groute_server.report.domain.Report;
+import com.groute.groute_server.report.application.port.in.dto.ReportListView;
 import com.groute.groute_server.report.domain.enums.ReportStatus;
 import com.groute.groute_server.report.domain.enums.ReportType;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 
-/**
- * RPT-001: 리포트 목록 조회 응답.
- *
- * <p>생성일 기준 내림차순 정렬. 이력 없으면 빈 배열 반환.
- */
+/** 리포트 목록 조회 응답 DTO. {@link ReportListView}의 Web 표현. */
 @Schema(description = "리포트 목록 조회 응답")
 public record ReportListResponse(
-        @Schema(description = "리포트 목록. 생성일 기준 내림차순. 이력 없으면 빈 배열") List<ReportItem> reports) {
+        @Schema(description = "리포트 목록. 생성일 기준 내림차순. 이력 없으면 빈 배열")
+                List<ReportItemResponse> reports) {
 
-    public static ReportListResponse from(List<Report> reports) {
-        return new ReportListResponse(reports.stream().map(ReportItem::from).toList());
+    public static ReportListResponse from(ReportListView view) {
+        return new ReportListResponse(
+                view.reports().stream().map(ReportItemResponse::from).toList());
     }
 
     @Schema(description = "리포트 목록 카드 아이템")
-    public record ReportItem(
+    public record ReportItemResponse(
             @Schema(description = "리포트 식별자", example = "1") Long reportId,
             @Schema(description = "리포트 종류", example = "CAREER") ReportType reportType,
             @Schema(description = "리포트 상태", example = "SUCCESS") ReportStatus status,
@@ -31,38 +29,21 @@ public record ReportListResponse(
                             description = "커리어 브랜딩 문장. CAREER 타입만 존재",
                             example = "OOO님은 복잡한 문제를 구조로 풀어내는 '설계형 기획자'입니다.")
                     String title,
-            @Schema(description = "목록 카드 텍스트 프리뷰. CAREER는 통합 서사 요약 앞부분, MINI는 활동 요약 앞부분")
-                    String previewText,
+            @Schema(description = "목록 카드 텍스트 프리뷰") String previewText,
             @Schema(
                             description = "MINI 타입만 존재. 역량 기록 현황 1줄 요약",
                             example = "가장 많이 기록한 영역은 기획·실행(6회)")
                     String competencyStatSummary) {
 
-        public static ReportItem from(Report report) {
-            String createdAt = report.getCreatedAt().toLocalDate().toString(); // yyyy-MM-dd
-
-            // content_json에서 previewText, competencyStatSummary 추출
-            String previewText = null;
-            String competencyStatSummary = null;
-
-            if (report.getContentJson() != null) {
-                if (report.getReportType() == ReportType.CAREER) {
-                    previewText = (String) report.getContentJson().get("narrativeSummary");
-                } else {
-                    previewText = (String) report.getContentJson().get("activitySummary");
-                    competencyStatSummary =
-                            (String) report.getContentJson().get("competencyStatSummary");
-                }
-            }
-
-            return new ReportItem(
-                    report.getId(),
-                    report.getReportType(),
-                    report.getStatus(),
-                    createdAt,
-                    report.getTitle(),
-                    previewText,
-                    competencyStatSummary);
+        public static ReportItemResponse from(ReportListView.ReportItemView view) {
+            return new ReportItemResponse(
+                    view.reportId(),
+                    view.reportType(),
+                    view.status(),
+                    view.createdAt(),
+                    view.title(),
+                    view.previewText(),
+                    view.competencyStatSummary());
         }
     }
 }

--- a/src/main/java/com/groute/groute_server/report/adapter/in/web/dto/ReportListResponse.java
+++ b/src/main/java/com/groute/groute_server/report/adapter/in/web/dto/ReportListResponse.java
@@ -1,0 +1,68 @@
+package com.groute.groute_server.report.adapter.in.web.dto;
+
+import java.util.List;
+
+import com.groute.groute_server.report.domain.Report;
+import com.groute.groute_server.report.domain.enums.ReportStatus;
+import com.groute.groute_server.report.domain.enums.ReportType;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+/**
+ * RPT-001: 리포트 목록 조회 응답.
+ *
+ * <p>생성일 기준 내림차순 정렬. 이력 없으면 빈 배열 반환.
+ */
+@Schema(description = "리포트 목록 조회 응답")
+public record ReportListResponse(
+        @Schema(description = "리포트 목록. 생성일 기준 내림차순. 이력 없으면 빈 배열") List<ReportItem> reports) {
+
+    public static ReportListResponse from(List<Report> reports) {
+        return new ReportListResponse(reports.stream().map(ReportItem::from).toList());
+    }
+
+    @Schema(description = "리포트 목록 카드 아이템")
+    public record ReportItem(
+            @Schema(description = "리포트 식별자", example = "1") Long reportId,
+            @Schema(description = "리포트 종류", example = "CAREER") ReportType reportType,
+            @Schema(description = "리포트 상태", example = "SUCCESS") ReportStatus status,
+            @Schema(description = "리포트 생성일 (yyyy-MM-dd)", example = "2026-04-10") String createdAt,
+            @Schema(
+                            description = "커리어 브랜딩 문장. CAREER 타입만 존재",
+                            example = "OOO님은 복잡한 문제를 구조로 풀어내는 '설계형 기획자'입니다.")
+                    String title,
+            @Schema(description = "목록 카드 텍스트 프리뷰. CAREER는 통합 서사 요약 앞부분, MINI는 활동 요약 앞부분")
+                    String previewText,
+            @Schema(
+                            description = "MINI 타입만 존재. 역량 기록 현황 1줄 요약",
+                            example = "가장 많이 기록한 영역은 기획·실행(6회)")
+                    String competencyStatSummary) {
+
+        public static ReportItem from(Report report) {
+            String createdAt = report.getCreatedAt().toLocalDate().toString(); // yyyy-MM-dd
+
+            // content_json에서 previewText, competencyStatSummary 추출
+            String previewText = null;
+            String competencyStatSummary = null;
+
+            if (report.getContentJson() != null) {
+                if (report.getReportType() == ReportType.CAREER) {
+                    previewText = (String) report.getContentJson().get("narrativeSummary");
+                } else {
+                    previewText = (String) report.getContentJson().get("activitySummary");
+                    competencyStatSummary =
+                            (String) report.getContentJson().get("competencyStatSummary");
+                }
+            }
+
+            return new ReportItem(
+                    report.getId(),
+                    report.getReportType(),
+                    report.getStatus(),
+                    createdAt,
+                    report.getTitle(),
+                    previewText,
+                    competencyStatSummary);
+        }
+    }
+}

--- a/src/main/java/com/groute/groute_server/report/adapter/out/client/StarRecordClientAdapter.java
+++ b/src/main/java/com/groute/groute_server/report/adapter/out/client/StarRecordClientAdapter.java
@@ -1,0 +1,28 @@
+package com.groute.groute_server.report.adapter.out.client;
+
+import java.time.OffsetDateTime;
+
+import org.springframework.stereotype.Component;
+
+import com.groute.groute_server.record.adapter.out.persistence.StarRecordJpaRepository;
+import com.groute.groute_server.report.application.port.out.StarRecordCountQueryPort;
+
+import lombok.RequiredArgsConstructor;
+
+/**
+ * {@link StarRecordCountQueryPort}의 구현체.
+ *
+ * <p>report 도메인이 record 도메인 내부에 직접 의존하지 않도록 경계를 분리한다. StarRecordJpaRepository를 주입받아 게이지 계산에 필요한
+ * 심화기록 수만 조회한다(RPT-001).
+ */
+@Component
+@RequiredArgsConstructor
+public class StarRecordClientAdapter implements StarRecordCountQueryPort {
+
+    private final StarRecordJpaRepository starRecordJpaRepository;
+
+    @Override
+    public int countCompletedAfter(Long userId, OffsetDateTime after) {
+        return starRecordJpaRepository.countCompletedAfter(userId, after);
+    }
+}

--- a/src/main/java/com/groute/groute_server/report/adapter/out/persistence/ReportJpaRepository.java
+++ b/src/main/java/com/groute/groute_server/report/adapter/out/persistence/ReportJpaRepository.java
@@ -1,0 +1,23 @@
+package com.groute.groute_server.report.adapter.out.persistence;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.groute.groute_server.report.domain.Report;
+import com.groute.groute_server.report.domain.enums.ReportStatus;
+
+/**
+ * 리포트 JPA 레포지토리.
+ *
+ * <p>목록·상세·게이지 조회에 사용한다(RPT-001).
+ */
+public interface ReportJpaRepository extends JpaRepository<Report, Long> {
+
+    /** 유저의 리포트 목록을 생성일 기준 내림차순으로 조회한다. */
+    List<Report> findAllByUserIdOrderByCreatedAtDesc(Long userId);
+
+    /** 유저의 가장 최근 성공한 리포트를 조회한다. 게이지 계산 기준점으로 사용한다. */
+    Optional<Report> findTopByUserIdAndStatusOrderByCreatedAtDesc(Long userId, ReportStatus status);
+}

--- a/src/main/java/com/groute/groute_server/report/adapter/out/persistence/ReportPersistenceAdapter.java
+++ b/src/main/java/com/groute/groute_server/report/adapter/out/persistence/ReportPersistenceAdapter.java
@@ -1,0 +1,40 @@
+package com.groute.groute_server.report.adapter.out.persistence;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.springframework.stereotype.Component;
+
+import com.groute.groute_server.report.application.port.out.ReportQueryPort;
+import com.groute.groute_server.report.domain.Report;
+import com.groute.groute_server.report.domain.enums.ReportStatus;
+
+import lombok.RequiredArgsConstructor;
+
+/**
+ * {@link ReportQueryPort}의 JPA 어댑터.
+ *
+ * <p>리포트 목록·상세·게이지 계산용 조회를 담당한다(RPT-001).
+ */
+@Component
+@RequiredArgsConstructor
+class ReportPersistenceAdapter implements ReportQueryPort {
+
+    private final ReportJpaRepository jpaRepository;
+
+    @Override
+    public List<Report> findAllByUserIdOrderByCreatedAtDesc(Long userId) {
+        return jpaRepository.findAllByUserIdOrderByCreatedAtDesc(userId);
+    }
+
+    @Override
+    public Optional<Report> findById(Long reportId) {
+        return jpaRepository.findById(reportId);
+    }
+
+    @Override
+    public Optional<Report> findLatestSuccessByUserId(Long userId) {
+        return jpaRepository.findTopByUserIdAndStatusOrderByCreatedAtDesc(
+                userId, ReportStatus.SUCCESS);
+    }
+}

--- a/src/main/java/com/groute/groute_server/report/application/port/in/GetReportDetailUseCase.java
+++ b/src/main/java/com/groute/groute_server/report/application/port/in/GetReportDetailUseCase.java
@@ -1,0 +1,18 @@
+package com.groute.groute_server.report.application.port.in;
+
+import com.groute.groute_server.report.adapter.in.web.dto.ReportDetailResponse;
+
+/**
+ * RPT-001: 리포트 상세 조회 유스케이스.
+ *
+ * <p>리포트 단건을 조회하여 MINI/CAREER 타입에 맞는 상세 내용을 반환한다.
+ */
+public interface GetReportDetailUseCase {
+
+    /**
+     * @param reportId 조회할 리포트 ID
+     * @param userId 현재 로그인한 유저 ID (소유자 검증용)
+     * @return 리포트 상세 (MINI/CAREER 타입별 content 구조 상이)
+     */
+    ReportDetailResponse getDetail(Long reportId, Long userId);
+}

--- a/src/main/java/com/groute/groute_server/report/application/port/in/GetReportDetailUseCase.java
+++ b/src/main/java/com/groute/groute_server/report/application/port/in/GetReportDetailUseCase.java
@@ -1,6 +1,6 @@
 package com.groute.groute_server.report.application.port.in;
 
-import com.groute.groute_server.report.adapter.in.web.dto.ReportDetailResponse;
+import com.groute.groute_server.report.application.port.in.dto.ReportDetailView;
 
 /**
  * RPT-001: 리포트 상세 조회 유스케이스.
@@ -14,5 +14,5 @@ public interface GetReportDetailUseCase {
      * @param userId 현재 로그인한 유저 ID (소유자 검증용)
      * @return 리포트 상세 (MINI/CAREER 타입별 content 구조 상이)
      */
-    ReportDetailResponse getDetail(Long reportId, Long userId);
+    ReportDetailView getDetail(Long reportId, Long userId);
 }

--- a/src/main/java/com/groute/groute_server/report/application/port/in/GetReportGaugeUseCase.java
+++ b/src/main/java/com/groute/groute_server/report/application/port/in/GetReportGaugeUseCase.java
@@ -1,0 +1,17 @@
+package com.groute.groute_server.report.application.port.in;
+
+import com.groute.groute_server.report.adapter.in.web.dto.ReportGaugeResponse;
+
+/**
+ * RPT-001: 리포트 게이지 조회 유스케이스.
+ *
+ * <p>마지막 리포트 생성 이후 완료된 심화기록 수와 다음 생성 임계치를 반환한다.
+ */
+public interface GetReportGaugeUseCase {
+
+    /**
+     * @param userId 현재 로그인한 유저 ID
+     * @return 게이지 정보 (currentCount, nextThreshold, progressRate, isGeneratable)
+     */
+    ReportGaugeResponse getGauge(Long userId);
+}

--- a/src/main/java/com/groute/groute_server/report/application/port/in/GetReportGaugeUseCase.java
+++ b/src/main/java/com/groute/groute_server/report/application/port/in/GetReportGaugeUseCase.java
@@ -1,6 +1,6 @@
 package com.groute.groute_server.report.application.port.in;
 
-import com.groute.groute_server.report.adapter.in.web.dto.ReportGaugeResponse;
+import com.groute.groute_server.report.application.port.in.dto.ReportGaugeView;
 
 /**
  * RPT-001: 리포트 게이지 조회 유스케이스.
@@ -13,5 +13,5 @@ public interface GetReportGaugeUseCase {
      * @param userId 현재 로그인한 유저 ID
      * @return 게이지 정보 (currentCount, nextThreshold, progressRate, isGeneratable)
      */
-    ReportGaugeResponse getGauge(Long userId);
+    ReportGaugeView getGauge(Long userId);
 }

--- a/src/main/java/com/groute/groute_server/report/application/port/in/GetReportListUseCase.java
+++ b/src/main/java/com/groute/groute_server/report/application/port/in/GetReportListUseCase.java
@@ -1,6 +1,6 @@
 package com.groute.groute_server.report.application.port.in;
 
-import com.groute.groute_server.report.adapter.in.web.dto.ReportListResponse;
+import com.groute.groute_server.report.application.port.in.dto.ReportListView;
 
 /**
  * RPT-001: 리포트 목록 조회 유스케이스.
@@ -13,5 +13,5 @@ public interface GetReportListUseCase {
      * @param userId 현재 로그인한 유저 ID
      * @return 리포트 목록 (생성일 내림차순)
      */
-    ReportListResponse getList(Long userId);
+    ReportListView getList(Long userId);
 }

--- a/src/main/java/com/groute/groute_server/report/application/port/in/GetReportListUseCase.java
+++ b/src/main/java/com/groute/groute_server/report/application/port/in/GetReportListUseCase.java
@@ -1,0 +1,17 @@
+package com.groute.groute_server.report.application.port.in;
+
+import com.groute.groute_server.report.adapter.in.web.dto.ReportListResponse;
+
+/**
+ * RPT-001: 리포트 목록 조회 유스케이스.
+ *
+ * <p>유저의 리포트 목록을 생성일 기준 내림차순으로 반환한다. 이력 없으면 빈 배열 반환.
+ */
+public interface GetReportListUseCase {
+
+    /**
+     * @param userId 현재 로그인한 유저 ID
+     * @return 리포트 목록 (생성일 내림차순)
+     */
+    ReportListResponse getList(Long userId);
+}

--- a/src/main/java/com/groute/groute_server/report/application/port/in/dto/ReportDetailView.java
+++ b/src/main/java/com/groute/groute_server/report/application/port/in/dto/ReportDetailView.java
@@ -1,0 +1,25 @@
+package com.groute.groute_server.report.application.port.in.dto;
+
+import java.util.Collections;
+import java.util.Map;
+
+import com.groute.groute_server.report.domain.Report;
+import com.groute.groute_server.report.domain.enums.ReportType;
+
+/**
+ * RPT-001: 리포트 상세 조회 뷰.
+ *
+ * <p>MINI/CAREER 타입에 따라 content 구조가 다르다.
+ */
+public record ReportDetailView(
+        Long reportId, ReportType reportType, String createdAt, Map<String, Object> content) {
+
+    public static ReportDetailView from(Report report) {
+        String createdAt = report.getCreatedAt().toLocalDate().toString();
+        Map<String, Object> content =
+                report.getContentJson() != null
+                        ? Collections.unmodifiableMap(report.getContentJson())
+                        : Collections.emptyMap();
+        return new ReportDetailView(report.getId(), report.getReportType(), createdAt, content);
+    }
+}

--- a/src/main/java/com/groute/groute_server/report/application/port/in/dto/ReportDetailView.java
+++ b/src/main/java/com/groute/groute_server/report/application/port/in/dto/ReportDetailView.java
@@ -1,5 +1,6 @@
 package com.groute.groute_server.report.application.port.in.dto;
 
+import java.time.ZoneId;
 import java.util.Collections;
 import java.util.Map;
 
@@ -15,7 +16,11 @@ public record ReportDetailView(
         Long reportId, ReportType reportType, String createdAt, Map<String, Object> content) {
 
     public static ReportDetailView from(Report report) {
-        String createdAt = report.getCreatedAt().toLocalDate().toString();
+        String createdAt =
+                report.getCreatedAt()
+                        .atZoneSameInstant(ZoneId.of("Asia/Seoul"))
+                        .toLocalDate()
+                        .toString();
         Map<String, Object> content =
                 report.getContentJson() != null
                         ? Collections.unmodifiableMap(report.getContentJson())

--- a/src/main/java/com/groute/groute_server/report/application/port/in/dto/ReportGaugeView.java
+++ b/src/main/java/com/groute/groute_server/report/application/port/in/dto/ReportGaugeView.java
@@ -1,0 +1,16 @@
+package com.groute.groute_server.report.application.port.in.dto;
+
+/**
+ * RPT-001: 리포트 게이지 조회 뷰.
+ *
+ * <p>마지막 리포트 생성 이후 완료된 심화기록 수와 다음 생성 임계치를 담는다.
+ */
+public record ReportGaugeView(
+        int currentCount, int nextThreshold, double progressRate, boolean isGeneratable) {
+
+    public static ReportGaugeView of(int currentCount, int nextThreshold) {
+        double progressRate = (double) currentCount / nextThreshold;
+        boolean isGeneratable = currentCount >= nextThreshold;
+        return new ReportGaugeView(currentCount, nextThreshold, progressRate, isGeneratable);
+    }
+}

--- a/src/main/java/com/groute/groute_server/report/application/port/in/dto/ReportListView.java
+++ b/src/main/java/com/groute/groute_server/report/application/port/in/dto/ReportListView.java
@@ -1,0 +1,58 @@
+package com.groute.groute_server.report.application.port.in.dto;
+
+import java.util.List;
+
+import com.groute.groute_server.report.domain.Report;
+import com.groute.groute_server.report.domain.enums.ReportStatus;
+import com.groute.groute_server.report.domain.enums.ReportType;
+
+/**
+ * RPT-001: 리포트 목록 조회 뷰.
+ *
+ * <p>생성일 기준 내림차순 정렬. 이력 없으면 빈 배열.
+ */
+public record ReportListView(List<ReportItemView> reports) {
+
+    public static ReportListView from(List<Report> reports) {
+        return new ReportListView(reports.stream().map(ReportItemView::from).toList());
+    }
+
+    public record ReportItemView(
+            Long reportId,
+            ReportType reportType,
+            ReportStatus status,
+            String createdAt,
+            String title,
+            String previewText,
+            String competencyStatSummary) {
+
+        public static ReportItemView from(Report report) {
+            String createdAt = report.getCreatedAt().toLocalDate().toString();
+
+            String previewText = null;
+            String competencyStatSummary = null;
+
+            if (report.getContentJson() != null) {
+                Object previewRaw =
+                        report.getReportType() == ReportType.CAREER
+                                ? report.getContentJson().get("narrativeSummary")
+                                : report.getContentJson().get("activitySummary");
+                previewText = previewRaw instanceof String s ? s : null;
+
+                if (report.getReportType() == ReportType.MINI) {
+                    Object summaryRaw = report.getContentJson().get("competencyStatSummary");
+                    competencyStatSummary = summaryRaw instanceof String s ? s : null;
+                }
+            }
+
+            return new ReportItemView(
+                    report.getId(),
+                    report.getReportType(),
+                    report.getStatus(),
+                    createdAt,
+                    report.getTitle(),
+                    previewText,
+                    competencyStatSummary);
+        }
+    }
+}

--- a/src/main/java/com/groute/groute_server/report/application/port/in/dto/ReportListView.java
+++ b/src/main/java/com/groute/groute_server/report/application/port/in/dto/ReportListView.java
@@ -1,5 +1,6 @@
 package com.groute.groute_server.report.application.port.in.dto;
 
+import java.time.ZoneId;
 import java.util.List;
 
 import com.groute.groute_server.report.domain.Report;
@@ -27,7 +28,11 @@ public record ReportListView(List<ReportItemView> reports) {
             String competencyStatSummary) {
 
         public static ReportItemView from(Report report) {
-            String createdAt = report.getCreatedAt().toLocalDate().toString();
+            String createdAt =
+                    report.getCreatedAt()
+                            .atZoneSameInstant(ZoneId.of("Asia/Seoul"))
+                            .toLocalDate()
+                            .toString();
 
             String previewText = null;
             String competencyStatSummary = null;

--- a/src/main/java/com/groute/groute_server/report/application/port/out/ReportQueryPort.java
+++ b/src/main/java/com/groute/groute_server/report/application/port/out/ReportQueryPort.java
@@ -1,0 +1,23 @@
+package com.groute.groute_server.report.application.port.out;
+
+import java.util.List;
+import java.util.Optional;
+
+import com.groute.groute_server.report.domain.Report;
+
+/**
+ * 리포트 조회 포트.
+ *
+ * <p>reports 테이블 조회 전용. 목록·상세·마지막 리포트 조회를 담당한다(RPT-001).
+ */
+public interface ReportQueryPort {
+
+    /** 유저의 리포트 목록을 생성일 기준 내림차순으로 조회한다. */
+    List<Report> findAllByUserIdOrderByCreatedAtDesc(Long userId);
+
+    /** 리포트 단건 조회. */
+    Optional<Report> findById(Long reportId);
+
+    /** 유저의 가장 최근 성공한 리포트를 조회한다. 게이지 계산 기준점으로 사용한다. */
+    Optional<Report> findLatestSuccessByUserId(Long userId);
+}

--- a/src/main/java/com/groute/groute_server/report/application/port/out/StarRecordCountQueryPort.java
+++ b/src/main/java/com/groute/groute_server/report/application/port/out/StarRecordCountQueryPort.java
@@ -1,0 +1,22 @@
+package com.groute.groute_server.report.application.port.out;
+
+import java.time.OffsetDateTime;
+
+/**
+ * 리포트 도메인에서 심화기록 수를 조회하기 위한 포트.
+ *
+ * <p>report 도메인이 record 도메인 내부에 직접 의존하지 않도록 경계를 분리한다. 구현체는 adapter/out/client에 위치한다.
+ */
+public interface StarRecordCountQueryPort {
+
+    /**
+     * 특정 시점 이후 완료된 심화기록 수를 조회한다.
+     *
+     * <p>게이지 계산 시 마지막 리포트 생성 이후 완료된 심화기록 수를 구하는 데 사용한다(RPT-001).
+     *
+     * @param userId 유저 ID
+     * @param after 이 시점 이후 완료된 것만 카운트. null이면 전체 카운트
+     * @return 완료된 심화기록 수
+     */
+    int countCompletedAfter(Long userId, OffsetDateTime after);
+}

--- a/src/main/java/com/groute/groute_server/report/application/service/ReportQueryService.java
+++ b/src/main/java/com/groute/groute_server/report/application/service/ReportQueryService.java
@@ -2,18 +2,19 @@ package com.groute.groute_server.report.application.service;
 
 import java.time.OffsetDateTime;
 import java.util.List;
+import java.util.Objects;
 
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.groute.groute_server.common.exception.BusinessException;
 import com.groute.groute_server.common.exception.ErrorCode;
-import com.groute.groute_server.report.adapter.in.web.dto.ReportDetailResponse;
-import com.groute.groute_server.report.adapter.in.web.dto.ReportGaugeResponse;
-import com.groute.groute_server.report.adapter.in.web.dto.ReportListResponse;
 import com.groute.groute_server.report.application.port.in.GetReportDetailUseCase;
 import com.groute.groute_server.report.application.port.in.GetReportGaugeUseCase;
 import com.groute.groute_server.report.application.port.in.GetReportListUseCase;
+import com.groute.groute_server.report.application.port.in.dto.ReportDetailView;
+import com.groute.groute_server.report.application.port.in.dto.ReportGaugeView;
+import com.groute.groute_server.report.application.port.in.dto.ReportListView;
 import com.groute.groute_server.report.application.port.out.ReportQueryPort;
 import com.groute.groute_server.report.application.port.out.StarRecordCountQueryPort;
 import com.groute.groute_server.report.domain.Report;
@@ -44,18 +45,16 @@ public class ReportQueryService
      * 한다.
      */
     @Override
-    public ReportGaugeResponse getGauge(Long userId) {
-        // 1. 마지막 성공한 리포트 조회 → 기준 시점 추출
+    public ReportGaugeView getGauge(Long userId) {
         OffsetDateTime after =
                 reportQueryPort
                         .findLatestSuccessByUserId(userId)
                         .map(Report::getCreatedAt)
                         .orElse(null);
 
-        // 2. 기준 시점 이후 완료된 심화기록 수 조회 (10 초과 시에도 계속 누적)
         int currentCount = starRecordCountQueryPort.countCompletedAfter(userId, after);
 
-        return ReportGaugeResponse.of(currentCount, NEXT_THRESHOLD);
+        return ReportGaugeView.of(currentCount, NEXT_THRESHOLD);
     }
 
     /**
@@ -64,9 +63,9 @@ public class ReportQueryService
      * <p>생성일 기준 내림차순 정렬. 이력 없으면 빈 배열 반환.
      */
     @Override
-    public ReportListResponse getList(Long userId) {
+    public ReportListView getList(Long userId) {
         List<Report> reports = reportQueryPort.findAllByUserIdOrderByCreatedAtDesc(userId);
-        return ReportListResponse.from(reports);
+        return ReportListView.from(reports);
     }
 
     /**
@@ -75,23 +74,20 @@ public class ReportQueryService
      * <p>소유자 검증 후 MINI/CAREER 타입별 content를 반환한다.
      */
     @Override
-    public ReportDetailResponse getDetail(Long reportId, Long userId) {
-        // 1. 리포트 조회
+    public ReportDetailView getDetail(Long reportId, Long userId) {
         Report report =
                 reportQueryPort
                         .findById(reportId)
                         .orElseThrow(() -> new BusinessException(ErrorCode.REPORT_NOT_FOUND));
 
-        // 2. 소유자 검증
-        if (!report.getUser().getId().equals(userId)) {
+        if (!Objects.equals(report.getUser().getId(), userId)) {
             throw new BusinessException(ErrorCode.FORBIDDEN);
         }
 
-        // 3. 생성 완료된 리포트만 조회 가능
         if (report.getStatus() != ReportStatus.SUCCESS) {
             throw new BusinessException(ErrorCode.REPORT_NOT_COMPLETED);
         }
 
-        return ReportDetailResponse.from(report);
+        return ReportDetailView.from(report);
     }
 }

--- a/src/main/java/com/groute/groute_server/report/application/service/ReportQueryService.java
+++ b/src/main/java/com/groute/groute_server/report/application/service/ReportQueryService.java
@@ -1,0 +1,97 @@
+package com.groute.groute_server.report.application.service;
+
+import java.time.OffsetDateTime;
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.groute.groute_server.common.exception.BusinessException;
+import com.groute.groute_server.common.exception.ErrorCode;
+import com.groute.groute_server.report.adapter.in.web.dto.ReportDetailResponse;
+import com.groute.groute_server.report.adapter.in.web.dto.ReportGaugeResponse;
+import com.groute.groute_server.report.adapter.in.web.dto.ReportListResponse;
+import com.groute.groute_server.report.application.port.in.GetReportDetailUseCase;
+import com.groute.groute_server.report.application.port.in.GetReportGaugeUseCase;
+import com.groute.groute_server.report.application.port.in.GetReportListUseCase;
+import com.groute.groute_server.report.application.port.out.ReportQueryPort;
+import com.groute.groute_server.report.application.port.out.StarRecordCountQueryPort;
+import com.groute.groute_server.report.domain.Report;
+import com.groute.groute_server.report.domain.enums.ReportStatus;
+
+import lombok.RequiredArgsConstructor;
+
+/**
+ * 리포트 조회 서비스 (RPT-001).
+ *
+ * <p>게이지·목록·상세 조회 유스케이스를 구현한다. 외부 의존성은 포트 인터페이스를 통해서만 접근한다.
+ */
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ReportQueryService
+        implements GetReportGaugeUseCase, GetReportListUseCase, GetReportDetailUseCase {
+
+    private static final int NEXT_THRESHOLD = 10;
+
+    private final ReportQueryPort reportQueryPort;
+    private final StarRecordCountQueryPort starRecordCountQueryPort;
+
+    /**
+     * RPT-001: 리포트 게이지 조회.
+     *
+     * <p>마지막 성공한 리포트 생성 시점 이후 완료된 심화기록 수를 반환한다. 분모는 항상 10 고정. 리포트가 없는 신규 유저는 전체 완료된 심화기록 수를 기준으로
+     * 한다.
+     */
+    @Override
+    public ReportGaugeResponse getGauge(Long userId) {
+        // 1. 마지막 성공한 리포트 조회 → 기준 시점 추출
+        OffsetDateTime after =
+                reportQueryPort
+                        .findLatestSuccessByUserId(userId)
+                        .map(Report::getCreatedAt)
+                        .orElse(null);
+
+        // 2. 기준 시점 이후 완료된 심화기록 수 조회 (10 초과 시에도 계속 누적)
+        int currentCount = starRecordCountQueryPort.countCompletedAfter(userId, after);
+
+        return ReportGaugeResponse.of(currentCount, NEXT_THRESHOLD);
+    }
+
+    /**
+     * RPT-001: 리포트 목록 조회.
+     *
+     * <p>생성일 기준 내림차순 정렬. 이력 없으면 빈 배열 반환.
+     */
+    @Override
+    public ReportListResponse getList(Long userId) {
+        List<Report> reports = reportQueryPort.findAllByUserIdOrderByCreatedAtDesc(userId);
+        return ReportListResponse.from(reports);
+    }
+
+    /**
+     * RPT-001: 리포트 상세 조회.
+     *
+     * <p>소유자 검증 후 MINI/CAREER 타입별 content를 반환한다.
+     */
+    @Override
+    public ReportDetailResponse getDetail(Long reportId, Long userId) {
+        // 1. 리포트 조회
+        Report report =
+                reportQueryPort
+                        .findById(reportId)
+                        .orElseThrow(() -> new BusinessException(ErrorCode.REPORT_NOT_FOUND));
+
+        // 2. 소유자 검증
+        if (!report.getUser().getId().equals(userId)) {
+            throw new BusinessException(ErrorCode.FORBIDDEN);
+        }
+
+        // 3. 생성 완료된 리포트만 조회 가능
+        if (report.getStatus() != ReportStatus.SUCCESS) {
+            throw new BusinessException(ErrorCode.REPORT_NOT_COMPLETED);
+        }
+
+        return ReportDetailResponse.from(report);
+    }
+}

--- a/src/test/java/com/groute/groute_server/report/application/service/ReportQueryServiceTest.java
+++ b/src/test/java/com/groute/groute_server/report/application/service/ReportQueryServiceTest.java
@@ -1,0 +1,288 @@
+package com.groute.groute_server.report.application.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import com.groute.groute_server.common.exception.BusinessException;
+import com.groute.groute_server.common.exception.ErrorCode;
+import com.groute.groute_server.report.adapter.in.web.dto.ReportDetailResponse;
+import com.groute.groute_server.report.adapter.in.web.dto.ReportGaugeResponse;
+import com.groute.groute_server.report.adapter.in.web.dto.ReportListResponse;
+import com.groute.groute_server.report.application.port.out.ReportQueryPort;
+import com.groute.groute_server.report.application.port.out.StarRecordCountQueryPort;
+import com.groute.groute_server.report.domain.Report;
+import com.groute.groute_server.report.domain.enums.ReportStatus;
+import com.groute.groute_server.report.domain.enums.ReportType;
+import com.groute.groute_server.user.entity.User;
+
+@ExtendWith(MockitoExtension.class)
+class ReportQueryServiceTest {
+
+    private static final Long USER_ID = 1L;
+    private static final Long OTHER_USER_ID = 99L;
+    private static final Long REPORT_ID = 10L;
+
+    @Mock ReportQueryPort reportQueryPort;
+    @Mock StarRecordCountQueryPort starRecordCountQueryPort;
+
+    @InjectMocks ReportQueryService service;
+
+    // ============================================================
+    // getGauge
+    // ============================================================
+    @Nested
+    @DisplayName("getGauge")
+    class GetGauge {
+
+        @Test
+        @DisplayName("신규 유저: 리포트 없으면 전체 완료 심화기록 수를 currentCount로 반환한다")
+        void should_returnTotalCount_when_noReport() {
+            // given
+            given(reportQueryPort.findLatestSuccessByUserId(USER_ID)).willReturn(Optional.empty());
+            given(starRecordCountQueryPort.countCompletedAfter(USER_ID, null)).willReturn(7);
+
+            // when
+            ReportGaugeResponse response = service.getGauge(USER_ID);
+
+            // then
+            assertThat(response.currentCount()).isEqualTo(7);
+            assertThat(response.nextThreshold()).isEqualTo(10);
+            assertThat(response.progressRate()).isEqualTo(0.7);
+            assertThat(response.isGeneratable()).isFalse();
+        }
+
+        @Test
+        @DisplayName("리포트 있음: 마지막 리포트 이후 완료 심화기록 수를 currentCount로 반환한다")
+        void should_returnCountAfterLastReport_when_reportExists() {
+            // given
+            OffsetDateTime lastReportAt = OffsetDateTime.now().minusDays(5);
+            Report lastReport =
+                    report(REPORT_ID, USER_ID, ReportType.MINI, ReportStatus.SUCCESS, lastReportAt);
+            given(reportQueryPort.findLatestSuccessByUserId(USER_ID))
+                    .willReturn(Optional.of(lastReport));
+            given(starRecordCountQueryPort.countCompletedAfter(USER_ID, lastReportAt))
+                    .willReturn(4);
+
+            // when
+            ReportGaugeResponse response = service.getGauge(USER_ID);
+
+            // then
+            assertThat(response.currentCount()).isEqualTo(4);
+            assertThat(response.nextThreshold()).isEqualTo(10);
+            assertThat(response.isGeneratable()).isFalse();
+        }
+
+        @Test
+        @DisplayName("currentCount >= 10이면 isGeneratable=true를 반환한다")
+        void should_returnGeneratable_when_currentCountReachesThreshold() {
+            // given
+            OffsetDateTime lastReportAt = OffsetDateTime.now().minusDays(10);
+            Report lastReport =
+                    report(REPORT_ID, USER_ID, ReportType.MINI, ReportStatus.SUCCESS, lastReportAt);
+            given(reportQueryPort.findLatestSuccessByUserId(USER_ID))
+                    .willReturn(Optional.of(lastReport));
+            given(starRecordCountQueryPort.countCompletedAfter(USER_ID, lastReportAt))
+                    .willReturn(10);
+
+            // when
+            ReportGaugeResponse response = service.getGauge(USER_ID);
+
+            // then
+            assertThat(response.isGeneratable()).isTrue();
+            assertThat(response.progressRate()).isEqualTo(1.0);
+        }
+
+        @Test
+        @DisplayName("currentCount > 10이면 progressRate가 1.0을 초과한다")
+        void should_returnProgressRateOverOne_when_currentCountExceedsThreshold() {
+            // given
+            given(reportQueryPort.findLatestSuccessByUserId(USER_ID)).willReturn(Optional.empty());
+            given(starRecordCountQueryPort.countCompletedAfter(USER_ID, null)).willReturn(12);
+
+            // when
+            ReportGaugeResponse response = service.getGauge(USER_ID);
+
+            // then
+            assertThat(response.currentCount()).isEqualTo(12);
+            assertThat(response.progressRate()).isEqualTo(1.2);
+            assertThat(response.isGeneratable()).isTrue();
+        }
+    }
+
+    // ============================================================
+    // getList
+    // ============================================================
+    @Nested
+    @DisplayName("getList")
+    class GetList {
+
+        @Test
+        @DisplayName("리포트 목록을 반환한다")
+        void should_returnReportList() {
+            // given
+            Report mini =
+                    report(
+                            1L,
+                            USER_ID,
+                            ReportType.MINI,
+                            ReportStatus.SUCCESS,
+                            OffsetDateTime.now().minusDays(10));
+            Report career =
+                    report(
+                            2L,
+                            USER_ID,
+                            ReportType.CAREER,
+                            ReportStatus.SUCCESS,
+                            OffsetDateTime.now());
+            given(reportQueryPort.findAllByUserIdOrderByCreatedAtDesc(USER_ID))
+                    .willReturn(List.of(career, mini));
+
+            // when
+            ReportListResponse response = service.getList(USER_ID);
+
+            // then
+            assertThat(response.reports()).hasSize(2);
+            assertThat(response.reports().get(0).reportId()).isEqualTo(2L);
+            assertThat(response.reports().get(1).reportId()).isEqualTo(1L);
+        }
+
+        @Test
+        @DisplayName("리포트 이력 없으면 빈 배열을 반환한다")
+        void should_returnEmptyList_when_noReports() {
+            // given
+            given(reportQueryPort.findAllByUserIdOrderByCreatedAtDesc(USER_ID))
+                    .willReturn(List.of());
+
+            // when
+            ReportListResponse response = service.getList(USER_ID);
+
+            // then
+            assertThat(response.reports()).isEmpty();
+        }
+    }
+
+    // ============================================================
+    // getDetail
+    // ============================================================
+    @Nested
+    @DisplayName("getDetail")
+    class GetDetail {
+
+        @Test
+        @DisplayName("정상 조회: SUCCESS 상태의 본인 리포트를 반환한다")
+        void should_returnDetail_when_validRequest() {
+            // given
+            Report report =
+                    report(
+                            REPORT_ID,
+                            USER_ID,
+                            ReportType.CAREER,
+                            ReportStatus.SUCCESS,
+                            OffsetDateTime.now());
+            given(reportQueryPort.findById(REPORT_ID)).willReturn(Optional.of(report));
+
+            // when
+            ReportDetailResponse response = service.getDetail(REPORT_ID, USER_ID);
+
+            // then
+            assertThat(response.reportId()).isEqualTo(REPORT_ID);
+            assertThat(response.reportType()).isEqualTo(ReportType.CAREER);
+        }
+
+        @Test
+        @DisplayName("리포트 없으면 REPORT_NOT_FOUND를 던진다")
+        void should_throwReportNotFound_when_missing() {
+            // given
+            given(reportQueryPort.findById(REPORT_ID)).willReturn(Optional.empty());
+
+            // when & then
+            assertThatThrownBy(() -> service.getDetail(REPORT_ID, USER_ID))
+                    .isInstanceOf(BusinessException.class)
+                    .extracting("errorCode")
+                    .isEqualTo(ErrorCode.REPORT_NOT_FOUND);
+        }
+
+        @Test
+        @DisplayName("타 유저의 리포트면 FORBIDDEN을 던진다")
+        void should_throwForbidden_when_otherUser() {
+            // given
+            Report report =
+                    report(
+                            REPORT_ID,
+                            OTHER_USER_ID,
+                            ReportType.CAREER,
+                            ReportStatus.SUCCESS,
+                            OffsetDateTime.now());
+            given(reportQueryPort.findById(REPORT_ID)).willReturn(Optional.of(report));
+
+            // when & then
+            assertThatThrownBy(() -> service.getDetail(REPORT_ID, USER_ID))
+                    .isInstanceOf(BusinessException.class)
+                    .extracting("errorCode")
+                    .isEqualTo(ErrorCode.FORBIDDEN);
+        }
+
+        @Test
+        @DisplayName("SUCCESS 상태가 아닌 리포트면 REPORT_NOT_COMPLETED를 던진다")
+        void should_throwReportNotCompleted_when_notSuccess() {
+            // given
+            Report report =
+                    report(
+                            REPORT_ID,
+                            USER_ID,
+                            ReportType.CAREER,
+                            ReportStatus.GENERATING,
+                            OffsetDateTime.now());
+            given(reportQueryPort.findById(REPORT_ID)).willReturn(Optional.of(report));
+
+            // when & then
+            assertThatThrownBy(() -> service.getDetail(REPORT_ID, USER_ID))
+                    .isInstanceOf(BusinessException.class)
+                    .extracting("errorCode")
+                    .isEqualTo(ErrorCode.REPORT_NOT_COMPLETED);
+        }
+    }
+
+    // ============== helpers ==============
+
+    private static Report report(
+            Long id,
+            Long ownerUserId,
+            ReportType type,
+            ReportStatus status,
+            OffsetDateTime createdAt) {
+        Report report = new Report();
+        ReflectionTestUtils.setField(report, "id", id);
+        ReflectionTestUtils.setField(report, "user", user(ownerUserId));
+        ReflectionTestUtils.setField(report, "reportType", type);
+        ReflectionTestUtils.setField(report, "status", status);
+        ReflectionTestUtils.setField(report, "createdAt", createdAt);
+        return report;
+    }
+
+    private static User user(Long id) {
+        try {
+            java.lang.reflect.Constructor<User> ctor = User.class.getDeclaredConstructor();
+            ctor.setAccessible(true);
+            User user = ctor.newInstance();
+            ReflectionTestUtils.setField(user, "id", id);
+            return user;
+        } catch (ReflectiveOperationException e) {
+            throw new IllegalStateException(e);
+        }
+    }
+}

--- a/src/test/java/com/groute/groute_server/report/application/service/ReportQueryServiceTest.java
+++ b/src/test/java/com/groute/groute_server/report/application/service/ReportQueryServiceTest.java
@@ -19,9 +19,9 @@ import org.springframework.test.util.ReflectionTestUtils;
 
 import com.groute.groute_server.common.exception.BusinessException;
 import com.groute.groute_server.common.exception.ErrorCode;
-import com.groute.groute_server.report.adapter.in.web.dto.ReportDetailResponse;
-import com.groute.groute_server.report.adapter.in.web.dto.ReportGaugeResponse;
-import com.groute.groute_server.report.adapter.in.web.dto.ReportListResponse;
+import com.groute.groute_server.report.application.port.in.dto.ReportDetailView;
+import com.groute.groute_server.report.application.port.in.dto.ReportGaugeView;
+import com.groute.groute_server.report.application.port.in.dto.ReportListView;
 import com.groute.groute_server.report.application.port.out.ReportQueryPort;
 import com.groute.groute_server.report.application.port.out.StarRecordCountQueryPort;
 import com.groute.groute_server.report.domain.Report;
@@ -51,24 +51,20 @@ class ReportQueryServiceTest {
         @Test
         @DisplayName("신규 유저: 리포트 없으면 전체 완료 심화기록 수를 currentCount로 반환한다")
         void should_returnTotalCount_when_noReport() {
-            // given
             given(reportQueryPort.findLatestSuccessByUserId(USER_ID)).willReturn(Optional.empty());
             given(starRecordCountQueryPort.countCompletedAfter(USER_ID, null)).willReturn(7);
 
-            // when
-            ReportGaugeResponse response = service.getGauge(USER_ID);
+            ReportGaugeView view = service.getGauge(USER_ID);
 
-            // then
-            assertThat(response.currentCount()).isEqualTo(7);
-            assertThat(response.nextThreshold()).isEqualTo(10);
-            assertThat(response.progressRate()).isEqualTo(0.7);
-            assertThat(response.isGeneratable()).isFalse();
+            assertThat(view.currentCount()).isEqualTo(7);
+            assertThat(view.nextThreshold()).isEqualTo(10);
+            assertThat(view.progressRate()).isEqualTo(0.7);
+            assertThat(view.isGeneratable()).isFalse();
         }
 
         @Test
         @DisplayName("리포트 있음: 마지막 리포트 이후 완료 심화기록 수를 currentCount로 반환한다")
         void should_returnCountAfterLastReport_when_reportExists() {
-            // given
             OffsetDateTime lastReportAt = OffsetDateTime.now().minusDays(5);
             Report lastReport =
                     report(REPORT_ID, USER_ID, ReportType.MINI, ReportStatus.SUCCESS, lastReportAt);
@@ -77,19 +73,16 @@ class ReportQueryServiceTest {
             given(starRecordCountQueryPort.countCompletedAfter(USER_ID, lastReportAt))
                     .willReturn(4);
 
-            // when
-            ReportGaugeResponse response = service.getGauge(USER_ID);
+            ReportGaugeView view = service.getGauge(USER_ID);
 
-            // then
-            assertThat(response.currentCount()).isEqualTo(4);
-            assertThat(response.nextThreshold()).isEqualTo(10);
-            assertThat(response.isGeneratable()).isFalse();
+            assertThat(view.currentCount()).isEqualTo(4);
+            assertThat(view.nextThreshold()).isEqualTo(10);
+            assertThat(view.isGeneratable()).isFalse();
         }
 
         @Test
         @DisplayName("currentCount >= 10이면 isGeneratable=true를 반환한다")
         void should_returnGeneratable_when_currentCountReachesThreshold() {
-            // given
             OffsetDateTime lastReportAt = OffsetDateTime.now().minusDays(10);
             Report lastReport =
                     report(REPORT_ID, USER_ID, ReportType.MINI, ReportStatus.SUCCESS, lastReportAt);
@@ -98,28 +91,23 @@ class ReportQueryServiceTest {
             given(starRecordCountQueryPort.countCompletedAfter(USER_ID, lastReportAt))
                     .willReturn(10);
 
-            // when
-            ReportGaugeResponse response = service.getGauge(USER_ID);
+            ReportGaugeView view = service.getGauge(USER_ID);
 
-            // then
-            assertThat(response.isGeneratable()).isTrue();
-            assertThat(response.progressRate()).isEqualTo(1.0);
+            assertThat(view.isGeneratable()).isTrue();
+            assertThat(view.progressRate()).isEqualTo(1.0);
         }
 
         @Test
         @DisplayName("currentCount > 10이면 progressRate가 1.0을 초과한다")
         void should_returnProgressRateOverOne_when_currentCountExceedsThreshold() {
-            // given
             given(reportQueryPort.findLatestSuccessByUserId(USER_ID)).willReturn(Optional.empty());
             given(starRecordCountQueryPort.countCompletedAfter(USER_ID, null)).willReturn(12);
 
-            // when
-            ReportGaugeResponse response = service.getGauge(USER_ID);
+            ReportGaugeView view = service.getGauge(USER_ID);
 
-            // then
-            assertThat(response.currentCount()).isEqualTo(12);
-            assertThat(response.progressRate()).isEqualTo(1.2);
-            assertThat(response.isGeneratable()).isTrue();
+            assertThat(view.currentCount()).isEqualTo(12);
+            assertThat(view.progressRate()).isEqualTo(1.2);
+            assertThat(view.isGeneratable()).isTrue();
         }
     }
 
@@ -133,7 +121,6 @@ class ReportQueryServiceTest {
         @Test
         @DisplayName("리포트 목록을 반환한다")
         void should_returnReportList() {
-            // given
             Report mini =
                     report(
                             1L,
@@ -151,27 +138,22 @@ class ReportQueryServiceTest {
             given(reportQueryPort.findAllByUserIdOrderByCreatedAtDesc(USER_ID))
                     .willReturn(List.of(career, mini));
 
-            // when
-            ReportListResponse response = service.getList(USER_ID);
+            ReportListView view = service.getList(USER_ID);
 
-            // then
-            assertThat(response.reports()).hasSize(2);
-            assertThat(response.reports().get(0).reportId()).isEqualTo(2L);
-            assertThat(response.reports().get(1).reportId()).isEqualTo(1L);
+            assertThat(view.reports()).hasSize(2);
+            assertThat(view.reports().get(0).reportId()).isEqualTo(2L);
+            assertThat(view.reports().get(1).reportId()).isEqualTo(1L);
         }
 
         @Test
         @DisplayName("리포트 이력 없으면 빈 배열을 반환한다")
         void should_returnEmptyList_when_noReports() {
-            // given
             given(reportQueryPort.findAllByUserIdOrderByCreatedAtDesc(USER_ID))
                     .willReturn(List.of());
 
-            // when
-            ReportListResponse response = service.getList(USER_ID);
+            ReportListView view = service.getList(USER_ID);
 
-            // then
-            assertThat(response.reports()).isEmpty();
+            assertThat(view.reports()).isEmpty();
         }
     }
 
@@ -185,7 +167,6 @@ class ReportQueryServiceTest {
         @Test
         @DisplayName("정상 조회: SUCCESS 상태의 본인 리포트를 반환한다")
         void should_returnDetail_when_validRequest() {
-            // given
             Report report =
                     report(
                             REPORT_ID,
@@ -195,21 +176,17 @@ class ReportQueryServiceTest {
                             OffsetDateTime.now());
             given(reportQueryPort.findById(REPORT_ID)).willReturn(Optional.of(report));
 
-            // when
-            ReportDetailResponse response = service.getDetail(REPORT_ID, USER_ID);
+            ReportDetailView view = service.getDetail(REPORT_ID, USER_ID);
 
-            // then
-            assertThat(response.reportId()).isEqualTo(REPORT_ID);
-            assertThat(response.reportType()).isEqualTo(ReportType.CAREER);
+            assertThat(view.reportId()).isEqualTo(REPORT_ID);
+            assertThat(view.reportType()).isEqualTo(ReportType.CAREER);
         }
 
         @Test
         @DisplayName("리포트 없으면 REPORT_NOT_FOUND를 던진다")
         void should_throwReportNotFound_when_missing() {
-            // given
             given(reportQueryPort.findById(REPORT_ID)).willReturn(Optional.empty());
 
-            // when & then
             assertThatThrownBy(() -> service.getDetail(REPORT_ID, USER_ID))
                     .isInstanceOf(BusinessException.class)
                     .extracting("errorCode")
@@ -219,7 +196,6 @@ class ReportQueryServiceTest {
         @Test
         @DisplayName("타 유저의 리포트면 FORBIDDEN을 던진다")
         void should_throwForbidden_when_otherUser() {
-            // given
             Report report =
                     report(
                             REPORT_ID,
@@ -229,7 +205,6 @@ class ReportQueryServiceTest {
                             OffsetDateTime.now());
             given(reportQueryPort.findById(REPORT_ID)).willReturn(Optional.of(report));
 
-            // when & then
             assertThatThrownBy(() -> service.getDetail(REPORT_ID, USER_ID))
                     .isInstanceOf(BusinessException.class)
                     .extracting("errorCode")
@@ -239,7 +214,6 @@ class ReportQueryServiceTest {
         @Test
         @DisplayName("SUCCESS 상태가 아닌 리포트면 REPORT_NOT_COMPLETED를 던진다")
         void should_throwReportNotCompleted_when_notSuccess() {
-            // given
             Report report =
                     report(
                             REPORT_ID,
@@ -249,7 +223,6 @@ class ReportQueryServiceTest {
                             OffsetDateTime.now());
             given(reportQueryPort.findById(REPORT_ID)).willReturn(Optional.of(report));
 
-            // when & then
             assertThatThrownBy(() -> service.getDetail(REPORT_ID, USER_ID))
                     .isInstanceOf(BusinessException.class)
                     .extracting("errorCode")


### PR DESCRIPTION
## 요약
- 리포트 게이지 조회, 목록 조회, 상세 조회 API 구현

## 변경 사항
- [x] 기능
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 문서
- [ ] 테스트
- [ ] 기타

## 상세 내용

### 1. GET /api/reports/gauge — 리포트 게이지 조회
- 마지막 리포트 생성 이후 완료된 심화기록 수 반환 (N/10 고정)
- 리포트 없는 신규 유저는 전체 완료 심화기록 수 기준
- currentCount >= 10이면 isGeneratable=true

### 2. GET /api/reports — 리포트 목록 조회
- 생성일 기준 내림차순 정렬
- 이력 없으면 빈 배열 반환
- MINI/CAREER 타입별 카드 표시 항목 분기

### 3. GET /api/reports/{reportId} — 리포트 상세 조회
- 소유자 검증
- SUCCESS 상태가 아닌 리포트 조회 시 400 반환
- MINI/CAREER 타입별 content 구조 상이

## 테스트
- [x] 로컬 테스트 완료
- 테스트 방법:
    - ./gradlew test
- `ReportQueryServiceTest`: 게이지/목록/상세 조회 단위 테스트 9개

### 커버리지 (JaCoCo)
- 라인 커버리지: 75%  (기준: 60% 이상)
- [x] `./gradlew test` 실행 후 `build/reports/jacoco/index.html`에서 수치 확인
- (선택) 리포트 스크린샷 또는 60% 미달/특이사항 공유:

## 스크린샷/로그 (선택)
- 필요한 경우 첨부

## 롤백/리스크
- 리스크 포인트:
- 롤백 방법: 해당 커밋 revert

## 관련 이슈
Closes #73 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 보고서 API 3종 추가: 목록 조회, 생성 진행도(게이지) 확인, 상세 조회
  * 목록/게이지/상세 응답 형식 추가로 생성 가능 여부·진행률·요약·상세 콘텐츠 제공

* **Bug Fixes**
  * 조회 불가(404)·미완료(400) 등 보고서 관련 오류 코드 분리 및 명확한 에러 응답 처리

* **Tests**
  * 보고서 조회 서비스 단위 테스트 추가

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/2026-KUSITMS-GLIT/2026-KUSITMS-GLIT-BACK/pull/95)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->