### PR TITLE
fix: Swagger self-origin 차단 해소 위해 api 도메인 CORS 허용 (#106)

### DIFF
--- a/src/main/java/com/groute/groute_server/common/config/SecurityConfig.java
+++ b/src/main/java/com/groute/groute_server/common/config/SecurityConfig.java
@@ -77,9 +77,18 @@ public class SecurityConfig {
      *
      * <p>로컬 개발은 Vite(5173)/Next·CRA(3000), 운영은 {@code https://glit.today}에서 호출. {@code
      * allowCredentials(true)}는 refresh 쿠키 동작에 필수.
+     *
+     * <p>{@code stg-api.glit.today} / {@code api.glit.today}는 Swagger UI가 같은 호스트에서 API를 호출할 때 브라우저가
+     * Origin 헤더를 함께 보내 Spring CORS 필터가 cross-origin으로 판정하기 때문에 self-origin도 화이트리스트에 포함한다. (정식
+     * refactor는 별도 이슈에서 yaml/SSM 기반으로 분리 예정)
      */
     private static final List<String> ALLOWED_ORIGINS =
-            List.of("http://localhost:3000", "http://localhost:5173", "https://glit.today");
+            List.of(
+                    "http://localhost:3000",
+                    "http://localhost:5173",
+                    "https://glit.today",
+                    "https://stg-api.glit.today",
+                    "https://api.glit.today");
 
     @Bean
     public CorsConfigurationSource corsConfigurationSource() {


### PR DESCRIPTION
## 요약
- Swagger UI에서 API 호출 시 발생하던 `403 Invalid CORS request`를 해소하기 위해 `stg-api.glit.today` / `api.glit.today`를 CORS 화이트리스트에 추가.

## 변경 사항
- [ ] 기능
- [x] 버그 수정
- [ ] 리팩토링
- [ ] 문서
- [ ] 테스트
- [ ] 기타

## 테스트
- 테스트 방법:
    - 스테이징 배포 후 `https://stg-api.glit.today/swagger-ui.html` 진입 → Authorize에 access token 등록 → 보호 API `Try it out` 200 응답 확인
    - 프론트 로컬(`http://localhost:3000`)에서 stg API 호출 정상 응답 확인

### 커버리지 (JaCoCo)
- 라인 커버리지: __%  (기준: 60% 이상)
- [ ] `./gradlew test` 실행 후 `build/reports/jacoco/index.html`에서 수치 확인
- (선택) 리포트 스크린샷 또는 60% 미달/특이사항 공유:
    - SecurityConfig는 `**/config/**` 패턴으로 JaCoCo 커버리지 제외 대상이라 본 PR로 인한 수치 변화 없음.

## 스크린샷/로그 (선택)
변경 전 응답:
```
HTTP/1.1 403
vary: Origin,Access-Control-Request-Method,Access-Control-Request-Headers

Invalid CORS request
```

## 롤백/리스크
- 리스크 포인트:
    - CORS 허용 origin 확장은 보안적으로 외부 도메인 노출과 무관 (자사 API 도메인 self-origin 추가).
    - `allowCredentials=true` 유지 — 와일드카드 미사용으로 자격증명 노출 위험 없음.
- 롤백 방법:
    - `SecurityConfig#ALLOWED_ORIGINS`에서 `https://stg-api.glit.today`, `https://api.glit.today` 두 줄 제거 후 재배포.

## 후속 작업
- 정식 refactor: 하드코딩된 `ALLOWED_ORIGINS`를 `@ConfigurationProperties` + yaml/SSM 기반으로 분리 (별도 이슈로 등록 예정).

## 관련 이슈
Closes #106 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **기타 작업**
  * 애플리케이션의 보안 설정을 업데이트하여 스테이징 및 프로덕션 환경의 추가 도메인과의 안전한 통신을 지원하도록 했습니다. 이를 통해 멀티 환경 배포 시에도 애플리케이션이 안정적으로 작동하며, API 통신이 원활하게 이루어질 수 있게 개선되었습니다.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/2026-KUSITMS-GLIT/2026-KUSITMS-GLIT-BACK/pull/107)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->