### PR TITLE
feat: 온보딩 완료 여부 조회 GET API 추가

### DIFF
--- a/src/main/java/com/groute/groute_server/user/config/UserWebMvcConfig.java
+++ b/src/main/java/com/groute/groute_server/user/config/UserWebMvcConfig.java
@@ -21,6 +21,7 @@ public class UserWebMvcConfig implements WebMvcConfigurer {
                 .addPathPatterns("/api/**")
                 .excludePathPatterns(
                         "/api/onboarding/complete",
+                        "/api/onboarding/status",
                         "/api/auth/**",
                         "/oauth2/**",
                         "/login/oauth2/code/**");

--- a/src/main/java/com/groute/groute_server/user/controller/OnboardingController.java
+++ b/src/main/java/com/groute/groute_server/user/controller/OnboardingController.java
@@ -4,6 +4,7 @@ import java.time.LocalDate;
 
 import jakarta.validation.Valid;
 
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -14,6 +15,7 @@ import com.groute.groute_server.common.response.ApiResponse;
 import com.groute.groute_server.common.util.DateTimeFormatters;
 import com.groute.groute_server.user.config.UserProperties;
 import com.groute.groute_server.user.dto.OnboardCompleteRequest;
+import com.groute.groute_server.user.dto.OnboardingStatusResponse;
 import com.groute.groute_server.user.dto.ProfileResponse;
 import com.groute.groute_server.user.entity.User;
 import com.groute.groute_server.user.service.UserService;
@@ -32,6 +34,17 @@ public class OnboardingController {
 
     private final UserService userService;
     private final UserProperties userProperties;
+
+    @Operation(summary = "온보딩 완료 여부 조회", description = "로그인한 유저의 온보딩 완료 여부를 반환한다.")
+    @io.swagger.v3.oas.annotations.responses.ApiResponse(
+            responseCode = "200",
+            description = "조회 성공")
+    @GetMapping("/status")
+    public ApiResponse<OnboardingStatusResponse> getOnboardingStatus(@CurrentUser Long userId) {
+        return ApiResponse.ok(
+                "온보딩 상태를 조회했습니다.",
+                new OnboardingStatusResponse(userService.isOnboardingCompleted(userId)));
+    }
 
     @Operation(
             summary = "온보딩 완료",

--- a/src/main/java/com/groute/groute_server/user/dto/OnboardingStatusResponse.java
+++ b/src/main/java/com/groute/groute_server/user/dto/OnboardingStatusResponse.java
@@ -4,4 +4,4 @@ import io.swagger.v3.oas.annotations.media.Schema;
 
 /** 온보딩 완료 여부 조회(ONB-STATUS) 응답 DTO. */
 public record OnboardingStatusResponse(
-        @Schema(description = "온보딩 완료 여부", example = "true") boolean isCompleted) {}
+        @Schema(description = "온보딩 완료 여부", example = "true") boolean isOnboardingCompleted) {}

--- a/src/main/java/com/groute/groute_server/user/dto/OnboardingStatusResponse.java
+++ b/src/main/java/com/groute/groute_server/user/dto/OnboardingStatusResponse.java
@@ -1,0 +1,7 @@
+package com.groute.groute_server.user.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+/** 온보딩 완료 여부 조회(ONB-STATUS) 응답 DTO. */
+public record OnboardingStatusResponse(
+        @Schema(description = "온보딩 완료 여부", example = "true") boolean isCompleted) {}

--- a/src/test/java/com/groute/groute_server/user/service/UserServiceTest.java
+++ b/src/test/java/com/groute/groute_server/user/service/UserServiceTest.java
@@ -23,6 +23,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
 
 import com.groute.groute_server.auth.repository.RefreshTokenRepository;
 import com.groute.groute_server.common.exception.BusinessException;
@@ -46,6 +47,38 @@ class UserServiceTest {
     @Mock private Clock clock;
 
     @InjectMocks private UserService userService;
+
+    @Nested
+    @DisplayName("온보딩 완료 여부 조회")
+    class IsOnboardingCompleted {
+
+        @Test
+        @DisplayName("닉네임이 있으면 true")
+        void returnsTrue_whenNicknameSet() {
+            User user = User.createForSocialLogin();
+            ReflectionTestUtils.setField(user, "nickname", "겨레");
+            given(userRepository.findById(USER_ID)).willReturn(Optional.of(user));
+
+            assertThat(userService.isOnboardingCompleted(USER_ID)).isTrue();
+        }
+
+        @Test
+        @DisplayName("닉네임이 null이면 false")
+        void returnsFalse_whenNicknameNull() {
+            given(userRepository.findById(USER_ID))
+                    .willReturn(Optional.of(User.createForSocialLogin()));
+
+            assertThat(userService.isOnboardingCompleted(USER_ID)).isFalse();
+        }
+
+        @Test
+        @DisplayName("유저가 없으면 false")
+        void returnsFalse_whenUserMissing() {
+            given(userRepository.findById(USER_ID)).willReturn(Optional.empty());
+
+            assertThat(userService.isOnboardingCompleted(USER_ID)).isFalse();
+        }
+    }
 
     @Nested
     @DisplayName("내 프로필 조회")


### PR DESCRIPTION
## 요약
- 온보딩 미완료 유저도 자신의 온보딩 상태를 확인할 수 있도록 GET /api/onboarding/status API 추가

## 변경 사항
- [x] 기능
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 문서
- [x] 테스트
- [ ] 기타

## 테스트
- [ㅌ] 로컬 테스트 완료
- 테스트 방법:
    - ./gradlew test
    -  GET /api/onboarding/status — 온보딩 완료 시 isCompleted: true, 미완료 시 false 반환 확인

### 커버리지 (JaCoCo)
- 라인 커버리지: 70%  (기준: 60% 이상)
- [x] `./gradlew test` 실행 후 `build/reports/jacoco/index.html`에서 수치 확인

## 롤백/리스크
- 리스크 포인트: 없음 — 읽기 전용 API, 기존 로직 변경 없음
- 롤백 방법: 엔드포인트 제거 및 인터셉터 exclude 삭제

## 관련 이슈
Closes #109 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새 기능**
  * 사용자가 온보딩을 완료했는지 여부를 확인할 수 있는 새로운 기능이 추가되었습니다. 이제 앱의 온보딩 진행 상황을 실시간으로 추적하고 관리할 수 있으며, 각 사용자의 온보딩 상태에 따른 맞춤형 사용자 경험을 제공할 수 있습니다.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/2026-KUSITMS-GLIT/2026-KUSITMS-GLIT-BACK/pull/110)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->