### PR TITLE
feat: RPT-001/003 응답 필드 보완 및 날짜 구분자 수정

### DIFF
--- a/src/main/java/com/groute/groute_server/report/adapter/in/web/dto/ReportDetailResponse.java
+++ b/src/main/java/com/groute/groute_server/report/adapter/in/web/dto/ReportDetailResponse.java
@@ -12,11 +12,17 @@ import io.swagger.v3.oas.annotations.media.Schema;
 public record ReportDetailResponse(
         @Schema(description = "리포트 식별자", example = "1") Long reportId,
         @Schema(description = "리포트 종류", example = "CAREER") ReportType reportType,
-        @Schema(description = "리포트 생성일 (yyyy-MM-dd)", example = "2026-04-10") String createdAt,
+        @Schema(description = "리포트 생성일 (yyyy.MM.dd)", example = "2026.04.10") String createdAt,
+        @Schema(description = "선택한 심화기록 수. CAREER 타입 상세 서브텍스트용", example = "20")
+                Integer selectedStarCount,
         @Schema(description = "리포트 본문. MINI/CAREER 타입별 구조 상이") Map<String, Object> content) {
 
     public static ReportDetailResponse from(ReportDetailView view) {
         return new ReportDetailResponse(
-                view.reportId(), view.reportType(), view.createdAt(), view.content());
+                view.reportId(),
+                view.reportType(),
+                view.createdAt(),
+                view.selectedStarCount(),
+                view.content());
     }
 }

--- a/src/main/java/com/groute/groute_server/report/adapter/in/web/dto/ReportListResponse.java
+++ b/src/main/java/com/groute/groute_server/report/adapter/in/web/dto/ReportListResponse.java
@@ -24,10 +24,12 @@ public record ReportListResponse(
             @Schema(description = "리포트 식별자", example = "1") Long reportId,
             @Schema(description = "리포트 종류", example = "CAREER") ReportType reportType,
             @Schema(description = "리포트 상태", example = "SUCCESS") ReportStatus status,
-            @Schema(description = "리포트 생성일 (yyyy-MM-dd)", example = "2026-04-10") String createdAt,
+            @Schema(description = "리포트 생성일 (yyyy.MM.dd)", example = "2026.04.10") String createdAt,
             @Schema(
-                            description = "커리어 브랜딩 문장. CAREER 타입만 존재",
-                            example = "OOO님은 복잡한 문제를 구조로 풀어내는 '설계형 기획자'입니다.")
+                            description =
+                                    "리포트 제목. MINI: '{닉네임}님은 어떤 {직군명}으로 성장하고 있을까요?' 고정 문구."
+                                            + " CAREER: AI 생성 브랜딩 문장 (reports.title)",
+                            example = "박도현님은 어떤 개발자로 성장하고 있을까요?")
                     String title,
             @Schema(description = "목록 카드 텍스트 프리뷰") String previewText,
             @Schema(

--- a/src/main/java/com/groute/groute_server/report/application/port/in/dto/ReportDetailView.java
+++ b/src/main/java/com/groute/groute_server/report/application/port/in/dto/ReportDetailView.java
@@ -13,18 +13,28 @@ import com.groute.groute_server.report.domain.enums.ReportType;
  * <p>MINI/CAREER 타입에 따라 content 구조가 다르다.
  */
 public record ReportDetailView(
-        Long reportId, ReportType reportType, String createdAt, Map<String, Object> content) {
+        Long reportId,
+        ReportType reportType,
+        String createdAt,
+        Integer selectedStarCount,
+        Map<String, Object> content) {
 
     public static ReportDetailView from(Report report) {
         String createdAt =
                 report.getCreatedAt()
                         .atZoneSameInstant(ZoneId.of("Asia/Seoul"))
                         .toLocalDate()
-                        .toString();
+                        .toString()
+                        .replace('-', '.');
         Map<String, Object> content =
                 report.getContentJson() != null
                         ? Collections.unmodifiableMap(report.getContentJson())
                         : Collections.emptyMap();
-        return new ReportDetailView(report.getId(), report.getReportType(), createdAt, content);
+        return new ReportDetailView(
+                report.getId(),
+                report.getReportType(),
+                createdAt,
+                report.getSelectedStarCount(),
+                content);
     }
 }

--- a/src/main/java/com/groute/groute_server/report/application/port/in/dto/ReportListView.java
+++ b/src/main/java/com/groute/groute_server/report/application/port/in/dto/ReportListView.java
@@ -19,10 +19,6 @@ public record ReportListView(List<ReportItemView> reports) {
         return new ReportListView(reports.stream().map(r -> ReportItemView.from(r, user)).toList());
     }
 
-    public static ReportListView from(List<Report> reports) {
-        throw new UnsupportedOperationException("use from(reports, user) instead");
-    }
-
     public record ReportItemView(
             Long reportId,
             ReportType reportType,

--- a/src/main/java/com/groute/groute_server/report/application/port/in/dto/ReportListView.java
+++ b/src/main/java/com/groute/groute_server/report/application/port/in/dto/ReportListView.java
@@ -6,6 +6,7 @@ import java.util.List;
 import com.groute.groute_server.report.domain.Report;
 import com.groute.groute_server.report.domain.enums.ReportStatus;
 import com.groute.groute_server.report.domain.enums.ReportType;
+import com.groute.groute_server.user.entity.User;
 
 /**
  * RPT-001: 리포트 목록 조회 뷰.
@@ -14,8 +15,12 @@ import com.groute.groute_server.report.domain.enums.ReportType;
  */
 public record ReportListView(List<ReportItemView> reports) {
 
+    public static ReportListView from(List<Report> reports, User user) {
+        return new ReportListView(reports.stream().map(r -> ReportItemView.from(r, user)).toList());
+    }
+
     public static ReportListView from(List<Report> reports) {
-        return new ReportListView(reports.stream().map(ReportItemView::from).toList());
+        throw new UnsupportedOperationException("use from(reports, user) instead");
     }
 
     public record ReportItemView(
@@ -27,12 +32,21 @@ public record ReportListView(List<ReportItemView> reports) {
             String previewText,
             String competencyStatSummary) {
 
-        public static ReportItemView from(Report report) {
+        public static ReportItemView from(Report report, User user) {
             String createdAt =
                     report.getCreatedAt()
                             .atZoneSameInstant(ZoneId.of("Asia/Seoul"))
                             .toLocalDate()
-                            .toString();
+                            .toString()
+                            .replace('-', '.');
+
+            String title =
+                    report.getReportType() == ReportType.MINI
+                            ? user.getNickname()
+                                    + "님은 어떤 "
+                                    + user.getJobRole().getLabel()
+                                    + "으로 성장하고 있을까요?"
+                            : report.getTitle();
 
             String previewText = null;
             String competencyStatSummary = null;
@@ -55,7 +69,7 @@ public record ReportListView(List<ReportItemView> reports) {
                     report.getReportType(),
                     report.getStatus(),
                     createdAt,
-                    report.getTitle(),
+                    title,
                     previewText,
                     competencyStatSummary);
         }

--- a/src/main/java/com/groute/groute_server/report/application/service/ReportQueryService.java
+++ b/src/main/java/com/groute/groute_server/report/application/service/ReportQueryService.java
@@ -15,10 +15,12 @@ import com.groute.groute_server.report.application.port.in.GetReportListUseCase;
 import com.groute.groute_server.report.application.port.in.dto.ReportDetailView;
 import com.groute.groute_server.report.application.port.in.dto.ReportGaugeView;
 import com.groute.groute_server.report.application.port.in.dto.ReportListView;
+import com.groute.groute_server.report.application.port.out.LoadUserPort;
 import com.groute.groute_server.report.application.port.out.ReportQueryPort;
 import com.groute.groute_server.report.application.port.out.StarRecordCountQueryPort;
 import com.groute.groute_server.report.domain.Report;
 import com.groute.groute_server.report.domain.enums.ReportStatus;
+import com.groute.groute_server.user.entity.User;
 
 import lombok.RequiredArgsConstructor;
 
@@ -37,6 +39,7 @@ public class ReportQueryService
 
     private final ReportQueryPort reportQueryPort;
     private final StarRecordCountQueryPort starRecordCountQueryPort;
+    private final LoadUserPort loadUserPort;
 
     /**
      * RPT-001: 리포트 게이지 조회.
@@ -65,7 +68,8 @@ public class ReportQueryService
     @Override
     public ReportListView getList(Long userId) {
         List<Report> reports = reportQueryPort.findAllByUserIdOrderByCreatedAtDesc(userId);
-        return ReportListView.from(reports);
+        User user = loadUserPort.findUserById(userId);
+        return ReportListView.from(reports, user);
     }
 
     /**

--- a/src/main/java/com/groute/groute_server/report/application/service/ReportTransactionalService.java
+++ b/src/main/java/com/groute/groute_server/report/application/service/ReportTransactionalService.java
@@ -62,7 +62,9 @@ public class ReportTransactionalService {
         int totalStarCount = loadStarRecordPort.countCompletedByUserId(command.userId());
 
         // 5. reports row INSERT
-        Report report = Report.create(user, command.reportType(), totalStarCount);
+        Report report =
+                Report.create(
+                        user, command.reportType(), totalStarCount, command.starRecordIds().size());
         Report savedReport = saveReportPort.save(report);
 
         // 6. 선택된 심화기록 로드 (userId로 소유권 검증)

--- a/src/main/java/com/groute/groute_server/report/domain/Report.java
+++ b/src/main/java/com/groute/groute_server/report/domain/Report.java
@@ -50,8 +50,8 @@ public class Report extends BaseTimeEntity {
     @Column(name = "star_count_at", nullable = false)
     private Integer starCountAt;
 
-    /** 리포트 생성 시 유저가 선택한 심화기록 수. 커리어 리포트 상세 서브텍스트용(RPT003). */
-    @Column(name = "selected_star_count", nullable = false)
+    /** 리포트 생성 시 유저가 선택한 심화기록 수. 커리어 리포트 상세 서브텍스트용(RPT003). 기존 리포트는 NULL. */
+    @Column(name = "selected_star_count")
     private Integer selectedStarCount;
 
     /** 커리어 브랜딩 문장. 리포트 목록 카드에 노출(RPT001). */

--- a/src/main/java/com/groute/groute_server/report/domain/Report.java
+++ b/src/main/java/com/groute/groute_server/report/domain/Report.java
@@ -50,6 +50,10 @@ public class Report extends BaseTimeEntity {
     @Column(name = "star_count_at", nullable = false)
     private Integer starCountAt;
 
+    /** 리포트 생성 시 유저가 선택한 심화기록 수. 커리어 리포트 상세 서브텍스트용(RPT003). */
+    @Column(name = "selected_star_count", nullable = false)
+    private Integer selectedStarCount;
+
     /** 커리어 브랜딩 문장. 리포트 목록 카드에 노출(RPT001). */
     @Column(name = "title", length = 200)
     private String title;
@@ -74,12 +78,14 @@ public class Report extends BaseTimeEntity {
      * @param reportType MINI / CAREER
      * @param starCountAt 발행 시점 누적 STAR 수
      */
-    public static Report create(User user, ReportType reportType, int starCountAt) {
+    public static Report create(
+            User user, ReportType reportType, int starCountAt, int selectedStarCount) {
         Report report = new Report();
         report.user = user;
         report.reportType = reportType;
         report.status = ReportStatus.GENERATING;
         report.starCountAt = starCountAt;
+        report.selectedStarCount = selectedStarCount;
         report.retryCount = 0;
         return report;
     }

--- a/src/main/resources/db/migration/V20260518130000__add_reports_selected_star_count.sql
+++ b/src/main/resources/db/migration/V20260518130000__add_reports_selected_star_count.sql
@@ -1,2 +1,5 @@
 -- RPT: 리포트 생성 시 선택한 심화기록 개수 저장 (커리어 리포트 상세 서브텍스트용)
-ALTER TABLE reports ADD COLUMN selected_star_count int NOT NULL DEFAULT 0;
+ALTER TABLE reports ADD COLUMN selected_star_count int;
+-- 신규 생성분부터 애플리케이션에서 값 저장
+-- 레거시 데이터 백필 정책 확정 후
+-- ALTER TABLE reports ALTER COLUMN selected_star_count SET NOT NULL;

--- a/src/main/resources/db/migration/V20260518130000__add_reports_selected_star_count.sql
+++ b/src/main/resources/db/migration/V20260518130000__add_reports_selected_star_count.sql
@@ -1,0 +1,2 @@
+-- RPT: 리포트 생성 시 선택한 심화기록 개수 저장 (커리어 리포트 상세 서브텍스트용)
+ALTER TABLE reports ADD COLUMN selected_star_count int NOT NULL DEFAULT 0;

--- a/src/test/java/com/groute/groute_server/report/application/service/ReportQueryServiceTest.java
+++ b/src/test/java/com/groute/groute_server/report/application/service/ReportQueryServiceTest.java
@@ -22,6 +22,7 @@ import com.groute.groute_server.common.exception.ErrorCode;
 import com.groute.groute_server.report.application.port.in.dto.ReportDetailView;
 import com.groute.groute_server.report.application.port.in.dto.ReportGaugeView;
 import com.groute.groute_server.report.application.port.in.dto.ReportListView;
+import com.groute.groute_server.report.application.port.out.LoadUserPort;
 import com.groute.groute_server.report.application.port.out.ReportQueryPort;
 import com.groute.groute_server.report.application.port.out.StarRecordCountQueryPort;
 import com.groute.groute_server.report.domain.Report;
@@ -38,6 +39,7 @@ class ReportQueryServiceTest {
 
     @Mock ReportQueryPort reportQueryPort;
     @Mock StarRecordCountQueryPort starRecordCountQueryPort;
+    @Mock LoadUserPort loadUserPort;
 
     @InjectMocks ReportQueryService service;
 
@@ -137,6 +139,7 @@ class ReportQueryServiceTest {
                             OffsetDateTime.now());
             given(reportQueryPort.findAllByUserIdOrderByCreatedAtDesc(USER_ID))
                     .willReturn(List.of(career, mini));
+            given(loadUserPort.findUserById(USER_ID)).willReturn(user(USER_ID));
 
             ReportListView view = service.getList(USER_ID);
 
@@ -150,6 +153,7 @@ class ReportQueryServiceTest {
         void should_returnEmptyList_when_noReports() {
             given(reportQueryPort.findAllByUserIdOrderByCreatedAtDesc(USER_ID))
                     .willReturn(List.of());
+            given(loadUserPort.findUserById(USER_ID)).willReturn(user(USER_ID));
 
             ReportListView view = service.getList(USER_ID);
 
@@ -253,6 +257,9 @@ class ReportQueryServiceTest {
             ctor.setAccessible(true);
             User user = ctor.newInstance();
             ReflectionTestUtils.setField(user, "id", id);
+            ReflectionTestUtils.setField(user, "nickname", "테스트유저");
+            ReflectionTestUtils.setField(
+                    user, "jobRole", com.groute.groute_server.user.enums.JobRole.DEVELOPER);
             return user;
         } catch (ReflectiveOperationException e) {
             throw new IllegalStateException(e);


### PR DESCRIPTION
## 요약
- 프론트 요청 반영 — 리포트 응답에 selectedStarCount 추가, 미니 리포트 title 고정 문구 분기, 날짜 포맷 변경

## 상세 내용

- reports 테이블에 selected_star_count 컬럼 추가 — 리포트 생성 시 선택한 심화기록 수 저장
- 리포트 상세 응답(GET /api/reports/{reportId})에 selectedStarCount 필드 추가 — 커리어 리포트 서브텍스트("벌써 N개의 심화기록이 쌓였어요!") 렌더링용
- 리포트 목록 응답(GET /api/reports)의 title 분기 처리 — MINI는 {닉네임}님은 어떤 {직군명}으로 성장하고 있을까요? 고정 문구, CAREER는 AI 생성 브랜딩 문장
- 날짜 포맷 변경 — yyyy-MM-dd → yyyy.MM.dd

## 변경 사항
- [x] 기능
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 문서
- [ ] 테스트
- [ ] 기타

## 테스트
- [x] 로컬 테스트 완료
- 테스트 방법:
    - ./gradlew test
    - ReportQueryServiceTest: 목록 조회 시 유저 mock 추가, MINI title 고정 문구 검증

### 커버리지 (JaCoCo)
- 라인 커버리지: __%  (기준: 60% 이상)
- [ ] `./gradlew test` 실행 후 `build/reports/jacoco/index.html`에서 수치 확인
- 해당 pr 내용이 아닌 ScrumSyncServiceTest에서 테스트 실패로 확인어려움

## 스크린샷/로그 (선택)
- 필요한 경우 첨부

## 롤백/리스크
- 리스크 포인트:
- 롤백 방법:  해당 커밋 revert

## 관련 이슈
Closes #113 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 리포트에서 선택된 심화기록 개수 정보 표시 추가

* **개선 사항**
  * 날짜 형식을 국내 기준에 맞춰 `yyyy.MM.dd`로 통일
  * MINI 유형 리포트 제목에 사용자 닉네임 및 직무 정보 포함
  * 리포트 목록 조회 시 사용자 기반 맥락 정보 강화

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/2026-KUSITMS-GLIT/2026-KUSITMS-GLIT-BACK/pull/114?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->