### PR TITLE
fix: 캘린더 조회 시 PENDING 스크럼 제외 (#117)

### DIFF
--- a/src/main/java/com/groute/groute_server/calendar/repository/CalendarHomeRepository.java
+++ b/src/main/java/com/groute/groute_server/calendar/repository/CalendarHomeRepository.java
@@ -8,6 +8,7 @@ import jakarta.persistence.EntityManager;
 import org.springframework.stereotype.Repository;
 
 import com.groute.groute_server.record.domain.Scrum;
+import com.groute.groute_server.record.domain.enums.ScrumTitleStatus;
 
 import lombok.RequiredArgsConstructor;
 
@@ -32,21 +33,27 @@ public class CalendarHomeRepository {
 
     private final EntityManager em;
 
-    /** 사용자가 해당 기간에 스크럼을 작성한 날짜 set. soft-delete된 scrum은 제외. */
+    /**
+     * 사용자가 해당 기간에 스크럼을 작성한 날짜 set. soft-delete된 scrum은 제외. ScrumTitle.status=COMMITTED인 스크럼만 포함하여
+     * PENDING(임시저장) 스크럼이 캘린더에 노출되지 않도록 한다.
+     */
     public List<LocalDate> findScrumDatesInRange(Long userId, LocalDate start, LocalDate end) {
         return em.createQuery(
                         """
                         SELECT DISTINCT s.scrumDate
                         FROM Scrum s
+                        JOIN s.title t
                         WHERE s.user.id = :userId
                           AND s.scrumDate BETWEEN :start AND :end
                           AND s.isDeleted = false
+                          AND t.status = :committed
                         ORDER BY s.scrumDate
                         """,
                         LocalDate.class)
                 .setParameter("userId", userId)
                 .setParameter("start", start)
                 .setParameter("end", end)
+                .setParameter("committed", ScrumTitleStatus.COMMITTED)
                 .getResultList();
     }
 
@@ -81,7 +88,7 @@ public class CalendarHomeRepository {
      * 지정 일자의 사용자 스크럼 목록. ScrumTitle·Project를 fetch join 하여 추가 쿼리를 피한다.
      *
      * <p>soft-delete된 scrum은 제외. (title/project는 부모 scrum이 살아있으면 동시 살아있다고 가정하는 record 도메인 컨벤션을 따라
-     * 추가 필터하지 않는다.)
+     * 추가 필터하지 않는다.) ScrumTitle.status=COMMITTED인 스크럼만 반환하여 PENDING(임시저장) 스크럼이 일자 프리뷰에 노출되지 않도록 한다.
      */
     public List<Scrum> findScrumsByUserAndDate(Long userId, LocalDate date) {
         return em.createQuery(
@@ -93,11 +100,13 @@ public class CalendarHomeRepository {
                         WHERE s.user.id = :userId
                           AND s.scrumDate = :date
                           AND s.isDeleted = false
+                          AND t.status = :committed
                         ORDER BY s.id
                         """,
                         Scrum.class)
                 .setParameter("userId", userId)
                 .setParameter("date", date)
+                .setParameter("committed", ScrumTitleStatus.COMMITTED)
                 .getResultList();
     }
 


### PR DESCRIPTION
## 요약
캘린더 월별/일자 프리뷰 조회에서 ScrumTitle.status=PENDING(임시저장) 스크럼이 노출되던 문제를 수정. COMMITTED 상태만 조회하도록 JPQL 필터를 추가.

## 변경 사항
- [ ] 기능
- [x] 버그 수정
- [ ] 리팩토링
- [ ] 문서
- [ ] 테스트
- [ ] 기타

## 테스트
- [x] 로컬 테스트 완료
- 테스트 방법:
    - `./gradlew spotlessApply build` → BUILD SUCCESSFUL
    - 기존 `CalendarHomeServiceTest`는 repository를 mock 처리하므로 그대로 통과 (서비스 로직 변경 없음)

### 커버리지 (JaCoCo)
- 라인 커버리지: 73%  (기준: 60% 이상)
- [x] `./gradlew test` 실행 후 `build/reports/jacoco/index.html`에서 수치 확인
- (선택) 리포트 스크린샷 또는 60% 미달/특이사항 공유: 이번 변경은 JPQL WHERE 조건 추가뿐이라 커버리지 변동 없음

## 스크린샷/로그 (선택)
- 해당 없음

## 롤백/리스크
- 리스크 포인트:
    - X
- 롤백 방법:
    - 해당 커밋 revert. 두 쿼리의 `JOIN s.title t` / `AND t.status = :committed` 와 `committed` 파라미터, `ScrumTitleStatus` import만 되돌리면 됨.

## 관련 이슈
Closes #117 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Bug Fixes**
  * 달력 조회 및 일정 검색 결과에서 확정되지 않은 항목을 제외하도록 개선하여 데이터 정확성을 향상시켰습니다.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/2026-KUSITMS-GLIT/2026-KUSITMS-GLIT-BACK/pull/118?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->