### PR TITLE
feat: AI 태깅 stub 어댑터 → FastAPI 실 구현체 교체

### DIFF
--- a/src/main/java/com/groute/groute_server/record/adapter/out/ai/AiTaggingClientAdapter.java
+++ b/src/main/java/com/groute/groute_server/record/adapter/out/ai/AiTaggingClientAdapter.java
@@ -20,17 +20,17 @@ import com.groute.groute_server.record.application.port.in.CompleteAiTaggingUseC
 import com.groute.groute_server.record.application.port.out.AiTaggingClient;
 import com.groute.groute_server.record.application.port.out.AiTaggingJobPort;
 import com.groute.groute_server.record.domain.AiTaggingJob;
-import com.groute.groute_server.record.domain.StarRecord;
 import com.groute.groute_server.record.domain.Scrum;
+import com.groute.groute_server.record.domain.StarRecord;
 
 import lombok.extern.slf4j.Slf4j;
 
 /**
  * {@link AiTaggingClient}의 FastAPI 실 구현체.
  *
- * <p>STAR 기록의 ST/A/R 텍스트와 직군, 선택 역량을 FastAPI {@code POST /api/tagging}에 전송하고,
- * 응답으로 받은 primaryCategory + detailTags를 {@link CompleteAiTaggingUseCase}에 전달한다.
- * 실패 시 최대 1회 재시도하며, 재시도 후에도 실패 시 FAILED로 확정한다.
+ * <p>STAR 기록의 ST/A/R 텍스트와 직군, 선택 역량을 FastAPI {@code POST /api/tagging}에 전송하고, 응답으로 받은
+ * primaryCategory + detailTags를 {@link CompleteAiTaggingUseCase}에 전달한다. 실패 시 최대 1회 재시도하며, 재시도 후에도
+ * 실패 시 FAILED로 확정한다.
  */
 @Slf4j
 @Component
@@ -162,10 +162,7 @@ public class AiTaggingClientAdapter implements AiTaggingClient {
                 aiTaggingJobPort.saveJob(job);
             }
         } else {
-            log.error(
-                    "[AI Tagging] 최종 실패 — jobId={}, error={}",
-                    job.getId(),
-                    errorMessage);
+            log.error("[AI Tagging] 최종 실패 — jobId={}, error={}", job.getId(), errorMessage);
             job.fail(errorMessage);
             aiTaggingJobPort.saveJob(job);
         }

--- a/src/main/java/com/groute/groute_server/record/adapter/out/ai/AiTaggingClientAdapter.java
+++ b/src/main/java/com/groute/groute_server/record/adapter/out/ai/AiTaggingClientAdapter.java
@@ -100,19 +100,24 @@ public class AiTaggingClientAdapter implements AiTaggingClient {
 
         try {
             AiTaggingResponse response = callFastApi(request);
-
-            Map<String, Object> responsePayload =
-                    Map.of(
-                            "primaryCategory", response.primaryCategory(),
-                            "detailTags", response.detailTags());
-            job.succeed(responsePayload);
+            job.succeed(toResponsePayload(response));
             aiTaggingJobPort.saveJob(job);
-
-            completeAiTaggingUseCase.completeTagging(starRecord.getId());
-
         } catch (BusinessException e) {
             handleFailure(job, e.getMessage(), request);
+            return;
         }
+        completeAiTaggingUseCase.completeTagging(starRecord.getId());
+    }
+
+    private Map<String, Object> toResponsePayload(AiTaggingResponse response) {
+        String primaryCategory =
+                response.primaryCategory() != null ? response.primaryCategory() : "";
+        java.util.List<String> detailTags =
+                response.detailTags() != null ? response.detailTags() : java.util.List.of();
+        Map<String, Object> payload = new java.util.HashMap<>();
+        payload.put("primaryCategory", primaryCategory);
+        payload.put("detailTags", detailTags);
+        return payload;
     }
 
     private AiTaggingResponse callFastApi(AiTaggingRequest request) {
@@ -146,13 +151,8 @@ public class AiTaggingClientAdapter implements AiTaggingClient {
             aiTaggingJobPort.saveJob(job);
             try {
                 AiTaggingResponse response = callFastApi(request);
-                Map<String, Object> responsePayload =
-                        Map.of(
-                                "primaryCategory", response.primaryCategory(),
-                                "detailTags", response.detailTags());
-                job.succeed(responsePayload);
+                job.succeed(toResponsePayload(response));
                 aiTaggingJobPort.saveJob(job);
-                completeAiTaggingUseCase.completeTagging(job.getStarRecord().getId());
             } catch (BusinessException retryEx) {
                 log.error(
                         "[AI Tagging] 재시도 실패 확정 — jobId={}, error={}",
@@ -160,7 +160,9 @@ public class AiTaggingClientAdapter implements AiTaggingClient {
                         retryEx.getMessage());
                 job.fail(retryEx.getMessage());
                 aiTaggingJobPort.saveJob(job);
+                return;
             }
+            completeAiTaggingUseCase.completeTagging(job.getStarRecord().getId());
         } else {
             log.error("[AI Tagging] 최종 실패 — jobId={}, error={}", job.getId(), errorMessage);
             job.fail(errorMessage);

--- a/src/main/java/com/groute/groute_server/record/adapter/out/ai/AiTaggingClientAdapter.java
+++ b/src/main/java/com/groute/groute_server/record/adapter/out/ai/AiTaggingClientAdapter.java
@@ -1,30 +1,173 @@
 package com.groute.groute_server.record.adapter.out.ai;
 
-import org.springframework.stereotype.Component;
+import java.net.SocketTimeoutException;
+import java.util.Map;
 
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.MediaType;
+import org.springframework.http.client.SimpleClientHttpRequestFactory;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.ResourceAccessException;
+import org.springframework.web.client.RestClient;
+import org.springframework.web.client.RestClientException;
+
+import com.groute.groute_server.common.exception.BusinessException;
+import com.groute.groute_server.common.exception.ErrorCode;
+import com.groute.groute_server.record.adapter.out.ai.dto.AiTaggingRequest;
+import com.groute.groute_server.record.adapter.out.ai.dto.AiTaggingResponse;
+import com.groute.groute_server.record.application.port.in.CompleteAiTaggingUseCase;
 import com.groute.groute_server.record.application.port.out.AiTaggingClient;
+import com.groute.groute_server.record.application.port.out.AiTaggingJobPort;
 import com.groute.groute_server.record.domain.AiTaggingJob;
+import com.groute.groute_server.record.domain.StarRecord;
+import com.groute.groute_server.record.domain.Scrum;
 
 import lombok.extern.slf4j.Slf4j;
 
 /**
- * {@link AiTaggingClient}의 FastAPI stub 구현체.
+ * {@link AiTaggingClient}의 FastAPI 실 구현체.
  *
- * <p>AI 서버 로직이 미구현 상태이므로 현재는 로그만 출력한다. FastAPI 구현 완료 후 이 클래스에 실제 HTTP 호출 코드를 추가한다.
- *
- * <p>교체 시 서비스 코드는 변경하지 않아도 된다. {@link AiTaggingClient} 인터페이스의 새 구현체로 교체하거나 이 클래스를 수정하면 된다.
+ * <p>STAR 기록의 ST/A/R 텍스트와 직군, 선택 역량을 FastAPI {@code POST /api/tagging}에 전송하고,
+ * 응답으로 받은 primaryCategory + detailTags를 {@link CompleteAiTaggingUseCase}에 전달한다.
+ * 실패 시 최대 1회 재시도하며, 재시도 후에도 실패 시 FAILED로 확정한다.
  */
 @Slf4j
 @Component
 public class AiTaggingClientAdapter implements AiTaggingClient {
 
+    private final RestClient restClient;
+    private final AiTaggingJobPort aiTaggingJobPort;
+    private final CompleteAiTaggingUseCase completeAiTaggingUseCase;
+
+    @Autowired
+    public AiTaggingClientAdapter(
+            @Value("${ai.base-url:http://localhost:8000}") String baseUrl,
+            @Value("${ai.internal-token:}") String internalToken,
+            @Value("${ai.timeout.connect:5000}") int connectTimeoutMs,
+            @Value("${ai.timeout.read:30000}") int readTimeoutMs,
+            AiTaggingJobPort aiTaggingJobPort,
+            CompleteAiTaggingUseCase completeAiTaggingUseCase) {
+        SimpleClientHttpRequestFactory factory = new SimpleClientHttpRequestFactory();
+        factory.setConnectTimeout(java.time.Duration.ofMillis(connectTimeoutMs));
+        factory.setReadTimeout(java.time.Duration.ofMillis(readTimeoutMs));
+        this.restClient =
+                RestClient.builder()
+                        .baseUrl(baseUrl)
+                        .requestFactory(factory)
+                        .defaultHeader("X-Internal-Token", internalToken)
+                        .defaultHeader("Content-Type", MediaType.APPLICATION_JSON_VALUE)
+                        .build();
+        this.aiTaggingJobPort = aiTaggingJobPort;
+        this.completeAiTaggingUseCase = completeAiTaggingUseCase;
+    }
+
+    /** 테스트용 생성자. RestClient를 직접 주입받는다. */
+    AiTaggingClientAdapter(
+            RestClient restClient,
+            AiTaggingJobPort aiTaggingJobPort,
+            CompleteAiTaggingUseCase completeAiTaggingUseCase) {
+        this.restClient = restClient;
+        this.aiTaggingJobPort = aiTaggingJobPort;
+        this.completeAiTaggingUseCase = completeAiTaggingUseCase;
+    }
+
     @Override
     public void requestTagging(AiTaggingJob job) {
-        // TODO: FastAPI 구현 완료 후 HTTP 호출 추가. 완료 콜백 수신 시 CompleteAiTaggingUseCase.completeTagging()
-        // 호출.
-        log.info(
-                "[AI Tagging Stub] jobId={}, starRecordId={} 태깅 요청 (미구현)",
-                job.getId(),
-                job.getStarRecord().getId());
+        StarRecord starRecord = job.getStarRecord();
+        Scrum scrum = starRecord.getScrum();
+
+        AiTaggingRequest request =
+                new AiTaggingRequest(
+                        starRecord.getUser().getJobRole().name(),
+                        scrum.getSelectedCompetency() != null
+                                ? scrum.getSelectedCompetency().name()
+                                : "",
+                        starRecord.getSituationTask(),
+                        starRecord.getAction(),
+                        starRecord.getResult());
+
+        // request payload 저장 및 RUNNING 전환
+        Map<String, Object> requestPayload =
+                Map.of(
+                        "jobRole", request.jobRole(),
+                        "selectedCompetency", request.selectedCompetency(),
+                        "situationTask", request.situationTask(),
+                        "action", request.action(),
+                        "result", request.result());
+        job.start(requestPayload);
+        aiTaggingJobPort.saveJob(job);
+
+        try {
+            AiTaggingResponse response = callFastApi(request);
+
+            Map<String, Object> responsePayload =
+                    Map.of(
+                            "primaryCategory", response.primaryCategory(),
+                            "detailTags", response.detailTags());
+            job.succeed(responsePayload);
+            aiTaggingJobPort.saveJob(job);
+
+            completeAiTaggingUseCase.completeTagging(starRecord.getId());
+
+        } catch (BusinessException e) {
+            handleFailure(job, e.getMessage(), request);
+        }
+    }
+
+    private AiTaggingResponse callFastApi(AiTaggingRequest request) {
+        try {
+            return restClient
+                    .post()
+                    .uri("/api/tagging")
+                    .body(request)
+                    .retrieve()
+                    .body(AiTaggingResponse.class);
+        } catch (ResourceAccessException e) {
+            if (e.getCause() instanceof SocketTimeoutException) {
+                log.error("[AI Tagging] 타임아웃 발생", e);
+                throw new BusinessException(ErrorCode.AI_SERVER_TIMEOUT);
+            }
+            log.error("[AI Tagging] 네트워크 오류", e);
+            throw new BusinessException(ErrorCode.AI_SERVER_ERROR);
+        } catch (RestClientException e) {
+            log.error("[AI Tagging] 호출 실패 — {}", e.getMessage(), e);
+            throw new BusinessException(ErrorCode.AI_SERVER_ERROR);
+        }
+    }
+
+    private void handleFailure(AiTaggingJob job, String errorMessage, AiTaggingRequest request) {
+        if (job.isRetryable()) {
+            log.warn(
+                    "[AI Tagging] 1차 실패, 재시도 — jobId={}, starRecordId={}",
+                    job.getId(),
+                    job.getStarRecord().getId());
+            job.fail(errorMessage);
+            aiTaggingJobPort.saveJob(job);
+            try {
+                AiTaggingResponse response = callFastApi(request);
+                Map<String, Object> responsePayload =
+                        Map.of(
+                                "primaryCategory", response.primaryCategory(),
+                                "detailTags", response.detailTags());
+                job.succeed(responsePayload);
+                aiTaggingJobPort.saveJob(job);
+                completeAiTaggingUseCase.completeTagging(job.getStarRecord().getId());
+            } catch (BusinessException retryEx) {
+                log.error(
+                        "[AI Tagging] 재시도 실패 확정 — jobId={}, error={}",
+                        job.getId(),
+                        retryEx.getMessage());
+                job.fail(retryEx.getMessage());
+                aiTaggingJobPort.saveJob(job);
+            }
+        } else {
+            log.error(
+                    "[AI Tagging] 최종 실패 — jobId={}, error={}",
+                    job.getId(),
+                    errorMessage);
+            job.fail(errorMessage);
+            aiTaggingJobPort.saveJob(job);
+        }
     }
 }

--- a/src/main/java/com/groute/groute_server/record/adapter/out/ai/dto/AiTaggingRequest.java
+++ b/src/main/java/com/groute/groute_server/record/adapter/out/ai/dto/AiTaggingRequest.java
@@ -1,0 +1,11 @@
+package com.groute.groute_server.record.adapter.out.ai.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/** FastAPI POST /api/tagging 요청 body. */
+public record AiTaggingRequest(
+        @JsonProperty("jobRole") String jobRole,
+        @JsonProperty("selectedCompetency") String selectedCompetency,
+        @JsonProperty("situationTask") String situationTask,
+        String action,
+        String result) {}

--- a/src/main/java/com/groute/groute_server/record/adapter/out/ai/dto/AiTaggingResponse.java
+++ b/src/main/java/com/groute/groute_server/record/adapter/out/ai/dto/AiTaggingResponse.java
@@ -1,0 +1,10 @@
+package com.groute.groute_server.record.adapter.out.ai.dto;
+
+import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/** FastAPI POST /api/tagging 응답 body. */
+public record AiTaggingResponse(
+        @JsonProperty("primaryCategory") String primaryCategory,
+        @JsonProperty("detailTags") List<String> detailTags) {}

--- a/src/main/java/com/groute/groute_server/record/adapter/out/persistence/AiTaggingJobPersistenceAdapter.java
+++ b/src/main/java/com/groute/groute_server/record/adapter/out/persistence/AiTaggingJobPersistenceAdapter.java
@@ -30,4 +30,9 @@ public class AiTaggingJobPersistenceAdapter implements AiTaggingJobPort {
     public AiTaggingJob save(StarRecord starRecord) {
         return aiTaggingJobRepository.save(new AiTaggingJob(starRecord));
     }
+
+    @Override
+    public AiTaggingJob saveJob(AiTaggingJob job) {
+        return aiTaggingJobRepository.save(job);
+    }
 }

--- a/src/main/java/com/groute/groute_server/record/application/port/out/AiTaggingJobPort.java
+++ b/src/main/java/com/groute/groute_server/record/application/port/out/AiTaggingJobPort.java
@@ -29,4 +29,14 @@ public interface AiTaggingJobPort {
      * @return 저장된 잡
      */
     AiTaggingJob save(StarRecord starRecord);
+
+    /**
+     * 직접 존재하는 잡을 저장(update)한다.
+     *
+     * <p>상태 전환 이후 변경된 잡을 DB에 반영할 때 사용한다.
+     *
+     * @param job 저장할 잡
+     * @return 저장된 잡
+     */
+    AiTaggingJob saveJob(AiTaggingJob job);
 }

--- a/src/main/java/com/groute/groute_server/record/domain/AiTaggingJob.java
+++ b/src/main/java/com/groute/groute_server/record/domain/AiTaggingJob.java
@@ -76,4 +76,31 @@ public class AiTaggingJob extends BaseTimeEntity {
         this.status = JobStatus.QUEUED;
         this.retryCount = 0;
     }
+
+    /** 워커가 잡을 집어가 처리 시작. RUNNING으로 전환하고 요청 페이로드를 저장한다. */
+    public void start(Map<String, Object> requestPayload) {
+        this.status = JobStatus.RUNNING;
+        this.requestPayload = requestPayload;
+        this.startedAt = OffsetDateTime.now();
+    }
+
+    /** AI 태깅 성공. SUCCESS로 전환하고 응답 페이로드를 저장한다. */
+    public void succeed(Map<String, Object> responsePayload) {
+        this.status = JobStatus.SUCCESS;
+        this.responsePayload = responsePayload;
+        this.finishedAt = OffsetDateTime.now();
+    }
+
+    /** AI 태깅 실패. FAILED로 전환하고 retryCount를 증가시킨다. */
+    public void fail(String errorMessage) {
+        this.status = JobStatus.FAILED;
+        this.errorMessage = errorMessage;
+        this.finishedAt = OffsetDateTime.now();
+        this.retryCount++;
+    }
+
+    /** 재시도 가능 여부. 최대 1회 재시도 허용(REC006). */
+    public boolean isRetryable() {
+        return this.retryCount < 1;
+    }
 }

--- a/src/test/java/com/groute/groute_server/record/adapter/out/ai/AiTaggingClientAdapterTest.java
+++ b/src/test/java/com/groute/groute_server/record/adapter/out/ai/AiTaggingClientAdapterTest.java
@@ -1,0 +1,157 @@
+package com.groute.groute_server.record.adapter.out.ai;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentMatchers;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.web.client.RestClient;
+
+import com.groute.groute_server.common.exception.BusinessException;
+import com.groute.groute_server.common.exception.ErrorCode;
+import com.groute.groute_server.record.adapter.out.ai.dto.AiTaggingRequest;
+import com.groute.groute_server.record.adapter.out.ai.dto.AiTaggingResponse;
+import com.groute.groute_server.record.application.port.in.CompleteAiTaggingUseCase;
+import com.groute.groute_server.record.application.port.out.AiTaggingJobPort;
+import com.groute.groute_server.record.domain.AiTaggingJob;
+import com.groute.groute_server.record.domain.Scrum;
+import com.groute.groute_server.record.domain.StarRecord;
+import com.groute.groute_server.record.domain.enums.CompetencyCategory;
+import com.groute.groute_server.record.domain.enums.JobStatus;
+import com.groute.groute_server.user.entity.User;
+import com.groute.groute_server.user.enums.JobRole;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class AiTaggingClientAdapterTest {
+
+    @Mock private AiTaggingJobPort aiTaggingJobPort;
+    @Mock private CompleteAiTaggingUseCase completeAiTaggingUseCase;
+
+    private RestClient mockRestClient;
+    private RestClient.RequestBodyUriSpec uriSpec;
+    private RestClient.RequestBodySpec bodySpec;
+    private RestClient.ResponseSpec responseSpec;
+
+    private AiTaggingClientAdapter adapter;
+
+    private static final Long STAR_RECORD_ID = 1L;
+
+    @BeforeEach
+    void setUp() {
+        mockRestClient = mock(RestClient.class);
+        uriSpec = mock(RestClient.RequestBodyUriSpec.class);
+        bodySpec = mock(RestClient.RequestBodySpec.class);
+        responseSpec = mock(RestClient.ResponseSpec.class);
+
+        given(mockRestClient.post()).willReturn(uriSpec);
+        given(uriSpec.uri("/api/tagging")).willReturn(bodySpec);
+        given(bodySpec.body(ArgumentMatchers.any(AiTaggingRequest.class))).willReturn(bodySpec);
+        given(bodySpec.retrieve()).willReturn(responseSpec);
+
+        adapter =
+                new AiTaggingClientAdapter(
+                        mockRestClient, aiTaggingJobPort, completeAiTaggingUseCase);
+    }
+
+    private AiTaggingJob makeJob() {
+        User user = User.createForSocialLogin();
+        ReflectionTestUtils.setField(user, "jobRole", JobRole.DEVELOPER);
+
+        Scrum scrum = new Scrum();
+        ReflectionTestUtils.setField(
+                scrum, "selectedCompetency", CompetencyCategory.PROBLEM_SOLVING);
+
+        StarRecord starRecord = new StarRecord();
+        ReflectionTestUtils.setField(starRecord, "id", STAR_RECORD_ID);
+        ReflectionTestUtils.setField(starRecord, "user", user);
+        ReflectionTestUtils.setField(starRecord, "scrum", scrum);
+        ReflectionTestUtils.setField(starRecord, "situationTask", "상황");
+        ReflectionTestUtils.setField(starRecord, "action", "행동");
+        ReflectionTestUtils.setField(starRecord, "result", "결과");
+
+        AiTaggingJob job = new AiTaggingJob(starRecord);
+        ReflectionTestUtils.setField(job, "id", 10L);
+        return job;
+    }
+
+    @Nested
+    @DisplayName("AI 태깅 성공")
+    class Success {
+
+        @Test
+        @DisplayName("FastAPI 정상 응답 시 job SUCCESS 전환 및 completeTagging 호출")
+        void should_succeedAndCompleteTagging_when_fastApiRespondsNormally() {
+            // given
+            AiTaggingJob job = makeJob();
+            given(responseSpec.body(AiTaggingResponse.class))
+                    .willReturn(new AiTaggingResponse("PROBLEM_SOLVING", List.of("문제해결", "개선")));
+            given(aiTaggingJobPort.saveJob(any())).willAnswer(inv -> inv.getArgument(0));
+
+            // when
+            adapter.requestTagging(job);
+
+            // then
+            assertThat(job.getStatus()).isEqualTo(JobStatus.SUCCESS);
+            then(completeAiTaggingUseCase).should().completeTagging(STAR_RECORD_ID);
+            then(aiTaggingJobPort).should(times(2)).saveJob(job);
+        }
+    }
+
+    @Nested
+    @DisplayName("AI 태깅 실패")
+    class Failure {
+
+        @Test
+        @DisplayName("1차 실패 후 재시도 성공 시 job SUCCESS 전환")
+        void should_succeedOnRetry_when_firstCallFails() {
+            // given
+            AiTaggingJob job = makeJob();
+            given(responseSpec.body(AiTaggingResponse.class))
+                    .willThrow(new BusinessException(ErrorCode.AI_SERVER_ERROR))
+                    .willReturn(new AiTaggingResponse("PROBLEM_SOLVING", List.of("문제해결")));
+            given(aiTaggingJobPort.saveJob(any())).willAnswer(inv -> inv.getArgument(0));
+
+            // when
+            adapter.requestTagging(job);
+
+            // then
+            assertThat(job.getStatus()).isEqualTo(JobStatus.SUCCESS);
+            then(completeAiTaggingUseCase).should().completeTagging(STAR_RECORD_ID);
+        }
+
+        @Test
+        @DisplayName("1차 실패 후 재시도도 실패 시 job FAILED 확정")
+        void should_failPermanently_when_retryAlsoFails() {
+            // given
+            AiTaggingJob job = makeJob();
+            given(responseSpec.body(AiTaggingResponse.class))
+                    .willThrow(new BusinessException(ErrorCode.AI_SERVER_ERROR))
+                    .willThrow(new BusinessException(ErrorCode.AI_SERVER_ERROR));
+            given(aiTaggingJobPort.saveJob(any())).willAnswer(inv -> inv.getArgument(0));
+
+            // when
+            adapter.requestTagging(job);
+
+            // then
+            assertThat(job.getStatus()).isEqualTo(JobStatus.FAILED);
+            assertThat(job.getRetryCount()).isEqualTo((short) 2);
+            then(completeAiTaggingUseCase).shouldHaveNoInteractions();
+        }
+    }
+}


### PR DESCRIPTION
## 요약
- AiTaggingClientAdapter stub을 FastAPI 실 구현체로 교체하여 STAR 태깅 플로우 완성

## 상세 내용
- AiTaggingClientAdapter → FastAPI POST /api/tagging 실 HTTP 호출로 교체
- AiTaggingJob에 start() / succeed() / fail() / isRetryable() 상태 전환 메서드 추가
- 호출 성공 시 job.succeed() + completeTagging(starRecordId) 호출
- 호출 실패 시 job.fail() 후 최대 1회 재시도, 재시도 실패 시 FAILED 확정
- AiTaggingJobPort에 saveJob() 메서드 추가 — 상태 전환 후 job DB 저장
- FastAPI 요청/응답 DTO 추가 (AiTaggingRequest, AiTaggingResponse)
- AiTaggingClientAdapter 단위 테스트 추가 (성공/1차 실패 후 재시도 성공/최종 실패)

## 변경 사항
- [x] 기능
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 문서
- [ ] 테스트
- [ ] 기타

## 테스트
- [x] 로컬 테스트 완료
- 테스트 방법:
    - ./gradlew test — 단위 테스트 통과
    - FastAPI 연동 테스트는 stg 배포 후 확인 예정

### 커버리지 (JaCoCo)
- 라인 커버리지: __%  (기준: 60% 이상)
- [ ] `./gradlew test` 실행 후 `build/reports/jacoco/index.html`에서 수치 확인
- (선택) 리포트 스크린샷 또는 60% 미달/특이사항 공유:

## 스크린샷/로그 (선택)
- 필요한 경우 첨부

## 롤백/리스크
- 리스크 포인트:
- 롤백 방법:

## 관련 이슈
Closes #119 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * AI 자동 태깅 기능의 실제 구현 완료. 직무, 역량, 상황 정보를 기반으로 자동 분류 및 태그 생성 가능.

* **개선 사항**
  * 태깅 요청 실패 시 1회 자동 재시도 로직 추가.
  * 네트워크 타임아웃 및 서버 오류에 대한 상세한 에러 처리 구현.
  * 태깅 작업 상태 추적 및 로깅 개선.

* **테스트**
  * AI 태깅 기능의 성공/실패/재시도 시나리오 테스트 추가.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/2026-KUSITMS-GLIT/2026-KUSITMS-GLIT-BACK/pull/121?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->