### PR TITLE
fix: 심화기록 상세 응답에 scrumContent 추가 (#123)

### DIFF
--- a/src/main/java/com/groute/groute_server/record/adapter/in/web/dto/StarDetailResponse.java
+++ b/src/main/java/com/groute/groute_server/record/adapter/in/web/dto/StarDetailResponse.java
@@ -12,6 +12,7 @@ public record StarDetailResponse(
         @Schema(description = "심화기록 식별자", example = "1") Long starRecordId,
         @Schema(description = "프로젝트 태그명 (최대 15자)", example = "밋업 프로젝트") String projectTag,
         @Schema(description = "제목 자유작성 (최대 20자)", example = "기획 작업") String freeText,
+        @Schema(description = "스크럼 본문 (최대 50자)", example = "어드민 페이지 기능명세서 작성") String scrumContent,
         @Schema(description = "대표 역량 (5대 역량 enum)", example = "PLANNING_EXECUTION")
                 String primaryCategory,
         @Schema(description = "세부 역량 태그 목록 (최대 3개, 빈 배열 가능)", example = "[\"UX 설계\", \"품질 관리\"]")
@@ -27,6 +28,7 @@ public record StarDetailResponse(
                 view.starRecordId(),
                 view.projectTag(),
                 view.freeText(),
+                view.scrumContent(),
                 view.primaryCategory(),
                 view.detailTags(),
                 view.situationTask(),

--- a/src/main/java/com/groute/groute_server/record/application/port/in/star/StarDetailView.java
+++ b/src/main/java/com/groute/groute_server/record/application/port/in/star/StarDetailView.java
@@ -11,6 +11,7 @@ public record StarDetailView(
         Long starRecordId,
         String projectTag,
         String freeText,
+        String scrumContent,
         String primaryCategory,
         List<String> detailTags,
         String situationTask,

--- a/src/main/java/com/groute/groute_server/record/application/service/StarRecordQueryService.java
+++ b/src/main/java/com/groute/groute_server/record/application/service/StarRecordQueryService.java
@@ -73,6 +73,7 @@ public class StarRecordQueryService implements GetStarDetailUseCase {
                 starRecord.getId(),
                 title.getProject().getName(),
                 title.getFreeText(),
+                starRecord.getScrum().getContent(),
                 primaryCategory,
                 detailTags,
                 starRecord.getSituationTask(),

--- a/src/test/resources/application.yaml
+++ b/src/test/resources/application.yaml
@@ -107,6 +107,7 @@ app:
     server-description: Test
   user:
     default-profile-image-url: ""
+    hard-delete-grace-days: 30
 
 discord:
   webhook:


### PR DESCRIPTION
## 요약
GET /api/star-records/{starRecordId} 응답에 Scrum.content가 빠져 있어 scrumContent 필드로 노출.

## 변경 사항
- [ ] 기능
- [x] 버그 수정
- [ ] 리팩토링
- [ ] 문서
- [ ] 테스트
- [ ] 기타

## 테스트
- [x] 로컬 테스트 완료
- 테스트 방법:
    - `./gradlew spotlessApply test --tests "*StarRecordQueryServiceTest*"` → BUILD SUCCESSFUL
    - 기존 StarRecordQueryServiceTest happy path가 변경된 시그니처로도 통과 확인

### 커버리지 (JaCoCo)
- 라인 커버리지: 73%  (기준: 60% 이상)
- [x] `./gradlew test` 실행 후 `build/reports/jacoco/index.html`에서 수치 확인
- (선택) 리포트 스크린샷 또는 60% 미달/특이사항 공유: 필드 1개 추가라 변동 없음

## 스크린샷/로그 (선택)
- 해당 없음

## 롤백/리스크
- 리스크 포인트: X
- 롤백 방법:
    - 해당 커밋 revert. StarDetailView/StarDetailResponse/StarRecordQueryService 세 곳의 scrumContent 라인만 되돌리면 됨.

## 관련 이슈
Closes #123 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * 스타 상세 조회 API 응답에 스크럼 본문 정보가 추가되어, 사용자가 보다 완전한 정보를 한 번에 받을 수 있게 개선되었습니다.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/2026-KUSITMS-GLIT/2026-KUSITMS-GLIT-BACK/pull/124?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->