### PR TITLE
feat: 이미지 업로드·confirm API를 배열 단위 일괄 처리로 변경 (#126)

### DIFF
--- a/src/main/java/com/groute/groute_server/record/adapter/in/web/StarImageController.java
+++ b/src/main/java/com/groute/groute_server/record/adapter/in/web/StarImageController.java
@@ -91,14 +91,15 @@ public class StarImageController {
                 description = "이미 완료된 심화기록")
     })
     @PostMapping("/{starRecordId}/images/presigned-url")
-    public ApiResponse<UploadStarImageResponse> uploadImage(
+    public ApiResponse<List<UploadStarImageResponse>> uploadImage(
             @CurrentUser Long userId,
             @PathVariable Long starRecordId,
             @Valid @RequestBody UploadStarImageRequest request) {
-        return ApiResponse.ok(
-                "이미지 업로드 URL 발급 성공",
-                UploadStarImageResponse.from(
-                        uploadStarImageUseCase.upload(request.toCommand(userId, starRecordId))));
+        List<UploadStarImageResponse> responses =
+                uploadStarImageUseCase.upload(request.toCommand(userId, starRecordId)).stream()
+                        .map(UploadStarImageResponse::from)
+                        .toList();
+        return ApiResponse.ok("이미지 업로드 URL 발급 성공", responses);
     }
 
     @Operation(

--- a/src/main/java/com/groute/groute_server/record/adapter/in/web/dto/ConfirmStarImageRequest.java
+++ b/src/main/java/com/groute/groute_server/record/adapter/in/web/dto/ConfirmStarImageRequest.java
@@ -10,9 +10,7 @@ import com.groute.groute_server.record.application.port.in.star.ConfirmStarImage
 import io.swagger.v3.oas.annotations.media.Schema;
 
 public record ConfirmStarImageRequest(
-        @Schema(description = "Presigned URL 발급 시 반환된 imageKey 목록")
-                @NotEmpty
-                @Size(max = 2)
+        @Schema(description = "Presigned URL 발급 시 반환된 imageKey 목록") @NotEmpty @Size(max = 2)
                 List<String> imageKeys) {
 
     public ConfirmStarImageCommand toCommand(Long userId, Long starRecordId) {

--- a/src/main/java/com/groute/groute_server/record/adapter/in/web/dto/ConfirmStarImageRequest.java
+++ b/src/main/java/com/groute/groute_server/record/adapter/in/web/dto/ConfirmStarImageRequest.java
@@ -2,6 +2,7 @@ package com.groute.groute_server.record.adapter.in.web.dto;
 
 import java.util.List;
 
+import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.Size;
 
@@ -11,7 +12,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 
 public record ConfirmStarImageRequest(
         @Schema(description = "Presigned URL 발급 시 반환된 imageKey 목록") @NotEmpty @Size(max = 2)
-                List<String> imageKeys) {
+                List<@NotBlank String> imageKeys) {
 
     public ConfirmStarImageCommand toCommand(Long userId, Long starRecordId) {
         return new ConfirmStarImageCommand(userId, starRecordId, imageKeys);

--- a/src/main/java/com/groute/groute_server/record/adapter/in/web/dto/ConfirmStarImageRequest.java
+++ b/src/main/java/com/groute/groute_server/record/adapter/in/web/dto/ConfirmStarImageRequest.java
@@ -1,15 +1,21 @@
 package com.groute.groute_server.record.adapter.in.web.dto;
 
-import jakarta.validation.constraints.NotBlank;
+import java.util.List;
+
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.Size;
 
 import com.groute.groute_server.record.application.port.in.star.ConfirmStarImageCommand;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 
 public record ConfirmStarImageRequest(
-        @Schema(description = "Presigned URL 발급 시 반환된 imageKey") @NotBlank String imageKey) {
+        @Schema(description = "Presigned URL 발급 시 반환된 imageKey 목록")
+                @NotEmpty
+                @Size(max = 2)
+                List<String> imageKeys) {
 
     public ConfirmStarImageCommand toCommand(Long userId, Long starRecordId) {
-        return new ConfirmStarImageCommand(userId, starRecordId, imageKey);
+        return new ConfirmStarImageCommand(userId, starRecordId, imageKeys);
     }
 }

--- a/src/main/java/com/groute/groute_server/record/adapter/in/web/dto/UploadStarImageRequest.java
+++ b/src/main/java/com/groute/groute_server/record/adapter/in/web/dto/UploadStarImageRequest.java
@@ -2,6 +2,7 @@ package com.groute.groute_server.record.adapter.in.web.dto;
 
 import java.util.List;
 
+import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
@@ -9,7 +10,7 @@ import jakarta.validation.constraints.Size;
 import com.groute.groute_server.record.application.port.in.star.UploadStarImageCommand;
 
 public record UploadStarImageRequest(
-        @NotEmpty @Size(max = 2) List<@Pattern(regexp = "image/jpeg|image/png") String> mimeTypes) {
+        @NotEmpty @Size(max = 2) List<@NotBlank @Pattern(regexp = "image/jpeg|image/png") String> mimeTypes) {
 
     public UploadStarImageCommand toCommand(Long userId, Long starRecordId) {
         return new UploadStarImageCommand(userId, starRecordId, mimeTypes);

--- a/src/main/java/com/groute/groute_server/record/adapter/in/web/dto/UploadStarImageRequest.java
+++ b/src/main/java/com/groute/groute_server/record/adapter/in/web/dto/UploadStarImageRequest.java
@@ -10,7 +10,8 @@ import jakarta.validation.constraints.Size;
 import com.groute.groute_server.record.application.port.in.star.UploadStarImageCommand;
 
 public record UploadStarImageRequest(
-        @NotEmpty @Size(max = 2) List<@NotBlank @Pattern(regexp = "image/jpeg|image/png") String> mimeTypes) {
+        @NotEmpty @Size(max = 2)
+                List<@NotBlank @Pattern(regexp = "image/jpeg|image/png") String> mimeTypes) {
 
     public UploadStarImageCommand toCommand(Long userId, Long starRecordId) {
         return new UploadStarImageCommand(userId, starRecordId, mimeTypes);

--- a/src/main/java/com/groute/groute_server/record/adapter/in/web/dto/UploadStarImageRequest.java
+++ b/src/main/java/com/groute/groute_server/record/adapter/in/web/dto/UploadStarImageRequest.java
@@ -1,14 +1,19 @@
 package com.groute.groute_server.record.adapter.in.web.dto;
 
-import jakarta.validation.constraints.NotBlank;
+import java.util.List;
+
+import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
 
 import com.groute.groute_server.record.application.port.in.star.UploadStarImageCommand;
 
 public record UploadStarImageRequest(
-        @NotBlank @Pattern(regexp = "image/jpeg|image/png") String mimeType) {
+        @NotEmpty
+                @Size(max = 2)
+                List<@Pattern(regexp = "image/jpeg|image/png") String> mimeTypes) {
 
     public UploadStarImageCommand toCommand(Long userId, Long starRecordId) {
-        return new UploadStarImageCommand(userId, starRecordId, mimeType);
+        return new UploadStarImageCommand(userId, starRecordId, mimeTypes);
     }
 }

--- a/src/main/java/com/groute/groute_server/record/adapter/in/web/dto/UploadStarImageRequest.java
+++ b/src/main/java/com/groute/groute_server/record/adapter/in/web/dto/UploadStarImageRequest.java
@@ -9,9 +9,7 @@ import jakarta.validation.constraints.Size;
 import com.groute.groute_server.record.application.port.in.star.UploadStarImageCommand;
 
 public record UploadStarImageRequest(
-        @NotEmpty
-                @Size(max = 2)
-                List<@Pattern(regexp = "image/jpeg|image/png") String> mimeTypes) {
+        @NotEmpty @Size(max = 2) List<@Pattern(regexp = "image/jpeg|image/png") String> mimeTypes) {
 
     public UploadStarImageCommand toCommand(Long userId, Long starRecordId) {
         return new UploadStarImageCommand(userId, starRecordId, mimeTypes);

--- a/src/main/java/com/groute/groute_server/record/application/port/in/star/ConfirmStarImageCommand.java
+++ b/src/main/java/com/groute/groute_server/record/application/port/in/star/ConfirmStarImageCommand.java
@@ -1,3 +1,5 @@
 package com.groute.groute_server.record.application.port.in.star;
 
-public record ConfirmStarImageCommand(Long userId, Long starRecordId, String imageKey) {}
+import java.util.List;
+
+public record ConfirmStarImageCommand(Long userId, Long starRecordId, List<String> imageKeys) {}

--- a/src/main/java/com/groute/groute_server/record/application/port/in/star/UploadStarImageCommand.java
+++ b/src/main/java/com/groute/groute_server/record/application/port/in/star/UploadStarImageCommand.java
@@ -1,3 +1,5 @@
 package com.groute.groute_server.record.application.port.in.star;
 
-public record UploadStarImageCommand(Long userId, Long starRecordId, String mimeType) {}
+import java.util.List;
+
+public record UploadStarImageCommand(Long userId, Long starRecordId, List<String> mimeTypes) {}

--- a/src/main/java/com/groute/groute_server/record/application/port/in/star/UploadStarImageResult.java
+++ b/src/main/java/com/groute/groute_server/record/application/port/in/star/UploadStarImageResult.java
@@ -1,3 +1,4 @@
 package com.groute.groute_server.record.application.port.in.star;
 
 public record UploadStarImageResult(String imageKey, String presignedUrl, String imageUrl) {}
+

--- a/src/main/java/com/groute/groute_server/record/application/port/in/star/UploadStarImageResult.java
+++ b/src/main/java/com/groute/groute_server/record/application/port/in/star/UploadStarImageResult.java
@@ -1,4 +1,3 @@
 package com.groute.groute_server.record.application.port.in.star;
 
 public record UploadStarImageResult(String imageKey, String presignedUrl, String imageUrl) {}
-

--- a/src/main/java/com/groute/groute_server/record/application/port/in/star/UploadStarImageUseCase.java
+++ b/src/main/java/com/groute/groute_server/record/application/port/in/star/UploadStarImageUseCase.java
@@ -1,6 +1,8 @@
 package com.groute.groute_server.record.application.port.in.star;
 
+import java.util.List;
+
 public interface UploadStarImageUseCase {
 
-    UploadStarImageResult upload(UploadStarImageCommand command);
+    List<UploadStarImageResult> upload(UploadStarImageCommand command);
 }

--- a/src/main/java/com/groute/groute_server/record/application/service/ConfirmStarImageService.java
+++ b/src/main/java/com/groute/groute_server/record/application/service/ConfirmStarImageService.java
@@ -48,18 +48,22 @@ public class ConfirmStarImageService implements ConfirmStarImageUseCase {
 
         List<StarImage> existing =
                 starImageQueryPort.findAllByStarRecordIdOrderBySortOrder(command.starRecordId());
-        if (existing.size() >= MAX_IMAGES_PER_STAR) {
+        if (existing.size() + command.imageKeys().size() > MAX_IMAGES_PER_STAR) {
             throw new BusinessException(ErrorCode.STAR_IMAGE_LIMIT_EXCEEDED);
         }
 
-        short sortOrder = (short) existing.size();
         String expectedPrefix =
                 String.format("star-images/%d/%d/", command.userId(), command.starRecordId());
-        if (!command.imageKey().startsWith(expectedPrefix)) {
-            throw new BusinessException(ErrorCode.STAR_FORBIDDEN);
+        for (String imageKey : command.imageKeys()) {
+            if (!imageKey.startsWith(expectedPrefix)) {
+                throw new BusinessException(ErrorCode.STAR_FORBIDDEN);
+            }
         }
-        String imageUrl = presignedUrlGeneratorPort.toImageUrl(command.imageKey());
 
-        starImageWritePort.save(StarImage.create(record, command.imageKey(), imageUrl, sortOrder));
+        short sortOrder = (short) existing.size();
+        for (String imageKey : command.imageKeys()) {
+            String imageUrl = presignedUrlGeneratorPort.toImageUrl(imageKey);
+            starImageWritePort.save(StarImage.create(record, imageKey, imageUrl, sortOrder++));
+        }
     }
 }

--- a/src/main/java/com/groute/groute_server/record/application/service/ConfirmStarImageService.java
+++ b/src/main/java/com/groute/groute_server/record/application/service/ConfirmStarImageService.java
@@ -1,5 +1,6 @@
 package com.groute.groute_server.record.application.service;
 
+import java.util.HashSet;
 import java.util.List;
 
 import org.springframework.stereotype.Service;
@@ -46,22 +47,27 @@ public class ConfirmStarImageService implements ConfirmStarImageUseCase {
             throw new BusinessException(ErrorCode.STAR_WRITE_LOCKED);
         }
 
+        List<String> imageKeys = command.imageKeys();
+        if (new HashSet<>(imageKeys).size() != imageKeys.size()) {
+            throw new BusinessException(ErrorCode.INVALID_INPUT);
+        }
+
         List<StarImage> existing =
                 starImageQueryPort.findAllByStarRecordIdOrderBySortOrder(command.starRecordId());
-        if (existing.size() + command.imageKeys().size() > MAX_IMAGES_PER_STAR) {
+        if (existing.size() + imageKeys.size() > MAX_IMAGES_PER_STAR) {
             throw new BusinessException(ErrorCode.STAR_IMAGE_LIMIT_EXCEEDED);
         }
 
         String expectedPrefix =
                 String.format("star-images/%d/%d/", command.userId(), command.starRecordId());
-        for (String imageKey : command.imageKeys()) {
+        for (String imageKey : imageKeys) {
             if (!imageKey.startsWith(expectedPrefix)) {
                 throw new BusinessException(ErrorCode.STAR_FORBIDDEN);
             }
         }
 
         short sortOrder = (short) existing.size();
-        for (String imageKey : command.imageKeys()) {
+        for (String imageKey : imageKeys) {
             String imageUrl = presignedUrlGeneratorPort.toImageUrl(imageKey);
             starImageWritePort.save(StarImage.create(record, imageKey, imageUrl, sortOrder++));
         }

--- a/src/main/java/com/groute/groute_server/record/application/service/UploadStarImageService.java
+++ b/src/main/java/com/groute/groute_server/record/application/service/UploadStarImageService.java
@@ -1,5 +1,6 @@
 package com.groute.groute_server.record.application.service;
 
+import java.util.List;
 import java.util.UUID;
 
 import org.springframework.stereotype.Service;
@@ -31,7 +32,7 @@ public class UploadStarImageService implements UploadStarImageUseCase {
     private final PresignedUrlGeneratorPort presignedUrlGeneratorPort;
 
     @Override
-    public UploadStarImageResult upload(UploadStarImageCommand command) {
+    public List<UploadStarImageResult> upload(UploadStarImageCommand command) {
         StarRecord record =
                 starRecordRepositoryPort
                         .findByIdWithLock(command.starRecordId())
@@ -45,26 +46,30 @@ public class UploadStarImageService implements UploadStarImageUseCase {
             throw new BusinessException(ErrorCode.STAR_WRITE_LOCKED);
         }
 
-        int imageCount =
+        int existingCount =
                 starImageQueryPort
                         .findAllByStarRecordIdOrderBySortOrder(command.starRecordId())
                         .size();
-        if (imageCount >= MAX_IMAGES_PER_STAR) {
+        if (existingCount + command.mimeTypes().size() > MAX_IMAGES_PER_STAR) {
             throw new BusinessException(ErrorCode.STAR_IMAGE_LIMIT_EXCEEDED);
         }
 
-        String imageKey =
-                String.format(
-                        "star-images/%d/%d/%s.%s",
-                        command.userId(),
-                        command.starRecordId(),
-                        UUID.randomUUID(),
-                        toExtension(command.mimeType()));
-
-        PresignedUrlResult presigned =
-                presignedUrlGeneratorPort.generate(imageKey, command.mimeType());
-
-        return new UploadStarImageResult(imageKey, presigned.presignedUrl(), presigned.imageUrl());
+        return command.mimeTypes().stream()
+                .map(
+                        mimeType -> {
+                            String imageKey =
+                                    String.format(
+                                            "star-images/%d/%d/%s.%s",
+                                            command.userId(),
+                                            command.starRecordId(),
+                                            UUID.randomUUID(),
+                                            toExtension(mimeType));
+                            PresignedUrlResult presigned =
+                                    presignedUrlGeneratorPort.generate(imageKey, mimeType);
+                            return new UploadStarImageResult(
+                                    imageKey, presigned.presignedUrl(), presigned.imageUrl());
+                        })
+                .toList();
     }
 
     private String toExtension(String mimeType) {

--- a/src/test/java/com/groute/groute_server/record/application/service/ConfirmStarImageServiceTest.java
+++ b/src/test/java/com/groute/groute_server/record/application/service/ConfirmStarImageServiceTest.java
@@ -171,6 +171,25 @@ class ConfirmStarImageServiceTest {
         }
 
         @Test
+        @DisplayName("중복 imageKey가 있으면 INVALID_INPUT을 던진다")
+        void should_throwInvalidInput_when_duplicateImageKeys() {
+            given(starRecordRepositoryPort.findByIdWithLock(STAR_ID))
+                    .willReturn(Optional.of(record));
+
+            assertThatThrownBy(
+                            () ->
+                                    service.confirm(
+                                            new ConfirmStarImageCommand(
+                                                    USER_ID,
+                                                    STAR_ID,
+                                                    List.of(IMAGE_KEY_1, IMAGE_KEY_1))))
+                    .isInstanceOf(BusinessException.class)
+                    .extracting("errorCode")
+                    .isEqualTo(ErrorCode.INVALID_INPUT);
+            verify(starImageWritePort, never()).save(any());
+        }
+
+        @Test
         @DisplayName("이미 2장 존재하면 STAR_IMAGE_LIMIT_EXCEEDED를 던진다")
         void should_throwLimitExceeded_when_alreadyTwoImages() {
             StarImage img1 =

--- a/src/test/java/com/groute/groute_server/record/application/service/ConfirmStarImageServiceTest.java
+++ b/src/test/java/com/groute/groute_server/record/application/service/ConfirmStarImageServiceTest.java
@@ -5,6 +5,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 import java.time.LocalDate;
@@ -41,8 +42,9 @@ class ConfirmStarImageServiceTest {
     private static final Long USER_ID = 1L;
     private static final Long OTHER_USER_ID = 99L;
     private static final Long STAR_ID = 10L;
-    private static final String IMAGE_KEY = "star-images/1/10/uuid.jpg";
-    private static final String IMAGE_URL = "https://cdn.example.com/" + IMAGE_KEY;
+    private static final String IMAGE_KEY_1 = "star-images/1/10/uuid1.jpg";
+    private static final String IMAGE_KEY_2 = "star-images/1/10/uuid2.png";
+    private static final String IMAGE_URL = "https://cdn.example.com/star-images/1/10/uuid1.jpg";
 
     @Mock StarRecordRepositoryPort starRecordRepositoryPort;
     @Mock StarImageQueryPort starImageQueryPort;
@@ -73,37 +75,35 @@ class ConfirmStarImageServiceTest {
     class HappyPath {
 
         @Test
-        @DisplayName("첫 번째 이미지 confirm 시 sortOrder=0으로 DB에 저장된다")
-        void should_saveFirstImage_with_sortOrder0() {
+        @DisplayName("1장 confirm 시 sortOrder=0으로 DB에 저장된다")
+        void should_saveOneImage_with_sortOrder0() {
             given(starRecordRepositoryPort.findByIdWithLock(STAR_ID))
                     .willReturn(Optional.of(record));
             given(starImageQueryPort.findAllByStarRecordIdOrderBySortOrder(STAR_ID))
                     .willReturn(List.of());
-            given(presignedUrlGeneratorPort.toImageUrl(IMAGE_KEY)).willReturn(IMAGE_URL);
+            given(presignedUrlGeneratorPort.toImageUrl(IMAGE_KEY_1)).willReturn(IMAGE_URL);
             given(starImageWritePort.save(any(StarImage.class)))
                     .willAnswer(inv -> inv.getArgument(0));
 
-            service.confirm(command(USER_ID));
+            service.confirm(command(USER_ID, IMAGE_KEY_1));
 
-            verify(starImageWritePort).save(any(StarImage.class));
+            verify(starImageWritePort, times(1)).save(any(StarImage.class));
         }
 
         @Test
-        @DisplayName("두 번째 이미지 confirm 시 sortOrder=1로 DB에 저장된다")
-        void should_saveSecondImage_with_sortOrder1() {
-            StarImage firstImage =
-                    StarImage.create(record, "star-images/1/10/first.jpg", IMAGE_URL, (short) 0);
+        @DisplayName("2장 동시 confirm 시 sortOrder=0,1로 각각 DB에 저장된다")
+        void should_saveTwoImages_with_sortOrder0And1() {
             given(starRecordRepositoryPort.findByIdWithLock(STAR_ID))
                     .willReturn(Optional.of(record));
             given(starImageQueryPort.findAllByStarRecordIdOrderBySortOrder(STAR_ID))
-                    .willReturn(List.of(firstImage));
-            given(presignedUrlGeneratorPort.toImageUrl(IMAGE_KEY)).willReturn(IMAGE_URL);
+                    .willReturn(List.of());
+            given(presignedUrlGeneratorPort.toImageUrl(anyString())).willReturn(IMAGE_URL);
             given(starImageWritePort.save(any(StarImage.class)))
                     .willAnswer(inv -> inv.getArgument(0));
 
-            service.confirm(command(USER_ID));
+            service.confirm(command(USER_ID, IMAGE_KEY_1, IMAGE_KEY_2));
 
-            verify(starImageWritePort).save(any(StarImage.class));
+            verify(starImageWritePort, times(2)).save(any(StarImage.class));
         }
     }
 
@@ -116,7 +116,7 @@ class ConfirmStarImageServiceTest {
         void should_throwStarNotFound_when_notExist() {
             given(starRecordRepositoryPort.findByIdWithLock(STAR_ID)).willReturn(Optional.empty());
 
-            assertThatThrownBy(() -> service.confirm(command(USER_ID)))
+            assertThatThrownBy(() -> service.confirm(command(USER_ID, IMAGE_KEY_1)))
                     .isInstanceOf(BusinessException.class)
                     .extracting("errorCode")
                     .isEqualTo(ErrorCode.STAR_NOT_FOUND);
@@ -129,7 +129,7 @@ class ConfirmStarImageServiceTest {
             given(starRecordRepositoryPort.findByIdWithLock(STAR_ID))
                     .willReturn(Optional.of(record));
 
-            assertThatThrownBy(() -> service.confirm(command(OTHER_USER_ID)))
+            assertThatThrownBy(() -> service.confirm(command(OTHER_USER_ID, IMAGE_KEY_1)))
                     .isInstanceOf(BusinessException.class)
                     .extracting("errorCode")
                     .isEqualTo(ErrorCode.STAR_FORBIDDEN);
@@ -145,7 +145,7 @@ class ConfirmStarImageServiceTest {
             given(starRecordRepositoryPort.findByIdWithLock(STAR_ID))
                     .willReturn(Optional.of(record));
 
-            assertThatThrownBy(() -> service.confirm(command(USER_ID)))
+            assertThatThrownBy(() -> service.confirm(command(USER_ID, IMAGE_KEY_1)))
                     .isInstanceOf(BusinessException.class)
                     .extracting("errorCode")
                     .isEqualTo(ErrorCode.STAR_WRITE_LOCKED);
@@ -160,7 +160,8 @@ class ConfirmStarImageServiceTest {
             given(starImageQueryPort.findAllByStarRecordIdOrderBySortOrder(STAR_ID))
                     .willReturn(List.of());
             ConfirmStarImageCommand tamperedCommand =
-                    new ConfirmStarImageCommand(USER_ID, STAR_ID, "star-images/999/999/hack.jpg");
+                    new ConfirmStarImageCommand(
+                            USER_ID, STAR_ID, List.of("star-images/999/999/hack.jpg"));
 
             assertThatThrownBy(() -> service.confirm(tamperedCommand))
                     .isInstanceOf(BusinessException.class)
@@ -181,7 +182,7 @@ class ConfirmStarImageServiceTest {
             given(starImageQueryPort.findAllByStarRecordIdOrderBySortOrder(STAR_ID))
                     .willReturn(List.of(img1, img2));
 
-            assertThatThrownBy(() -> service.confirm(command(USER_ID)))
+            assertThatThrownBy(() -> service.confirm(command(USER_ID, IMAGE_KEY_1)))
                     .isInstanceOf(BusinessException.class)
                     .extracting("errorCode")
                     .isEqualTo(ErrorCode.STAR_IMAGE_LIMIT_EXCEEDED);
@@ -192,7 +193,7 @@ class ConfirmStarImageServiceTest {
 
     // ============== helpers ==============
 
-    private ConfirmStarImageCommand command(Long userId) {
-        return new ConfirmStarImageCommand(userId, STAR_ID, IMAGE_KEY);
+    private ConfirmStarImageCommand command(Long userId, String... imageKeys) {
+        return new ConfirmStarImageCommand(userId, STAR_ID, List.of(imageKeys));
     }
 }

--- a/src/test/java/com/groute/groute_server/record/application/service/UploadStarImageServiceTest.java
+++ b/src/test/java/com/groute/groute_server/record/application/service/UploadStarImageServiceTest.java
@@ -6,6 +6,7 @@ import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 import java.time.LocalDate;
@@ -43,7 +44,8 @@ class UploadStarImageServiceTest {
     private static final Long USER_ID = 1L;
     private static final Long OTHER_USER_ID = 99L;
     private static final Long STAR_ID = 10L;
-    private static final String MIME_TYPE = "image/jpeg";
+    private static final String MIME_JPEG = "image/jpeg";
+    private static final String MIME_PNG = "image/png";
     private static final String PRESIGNED_URL = "https://s3.example.com/presigned";
     private static final String IMAGE_URL = "https://cdn.example.com/image.jpg";
 
@@ -75,8 +77,8 @@ class UploadStarImageServiceTest {
     class HappyPath {
 
         @Test
-        @DisplayName("첫 번째 이미지 presigned URL 발급 시 imageKey·presignedUrl·imageUrl을 반환한다")
-        void should_returnPresignedUrl_for_firstImage() {
+        @DisplayName("1장 요청 시 presigned URL 1개를 반환한다")
+        void should_returnOnePresignedUrl_when_oneMimeType() {
             given(starRecordRepositoryPort.findByIdWithLock(STAR_ID))
                     .willReturn(Optional.of(record));
             given(starImageQueryPort.findAllByStarRecordIdOrderBySortOrder(STAR_ID))
@@ -84,16 +86,34 @@ class UploadStarImageServiceTest {
             given(presignedUrlGeneratorPort.generate(anyString(), anyString()))
                     .willReturn(new PresignedUrlResult(PRESIGNED_URL, IMAGE_URL));
 
-            UploadStarImageResult result = service.upload(command(USER_ID));
+            List<UploadStarImageResult> results = service.upload(command(USER_ID, MIME_JPEG));
 
-            assertThat(result.imageKey()).isNotBlank();
-            assertThat(result.presignedUrl()).isEqualTo(PRESIGNED_URL);
-            assertThat(result.imageUrl()).isEqualTo(IMAGE_URL);
+            assertThat(results).hasSize(1);
+            assertThat(results.get(0).imageKey()).isNotBlank();
+            assertThat(results.get(0).presignedUrl()).isEqualTo(PRESIGNED_URL);
+            assertThat(results.get(0).imageUrl()).isEqualTo(IMAGE_URL);
         }
 
         @Test
-        @DisplayName("두 번째 이미지도 presigned URL을 정상 반환한다")
-        void should_returnPresignedUrl_for_secondImage() {
+        @DisplayName("2장 동시 요청 시 presigned URL 2개를 반환한다")
+        void should_returnTwoPresignedUrls_when_twoMimeTypes() {
+            given(starRecordRepositoryPort.findByIdWithLock(STAR_ID))
+                    .willReturn(Optional.of(record));
+            given(starImageQueryPort.findAllByStarRecordIdOrderBySortOrder(STAR_ID))
+                    .willReturn(List.of());
+            given(presignedUrlGeneratorPort.generate(anyString(), anyString()))
+                    .willReturn(new PresignedUrlResult(PRESIGNED_URL, IMAGE_URL));
+
+            List<UploadStarImageResult> results =
+                    service.upload(command(USER_ID, MIME_JPEG, MIME_PNG));
+
+            assertThat(results).hasSize(2);
+            verify(presignedUrlGeneratorPort, times(2)).generate(anyString(), anyString());
+        }
+
+        @Test
+        @DisplayName("기존 1장 있을 때 1장 추가 요청은 정상 발급된다")
+        void should_returnPresignedUrl_when_oneExistingAndOneRequested() {
             StarImage firstImage =
                     StarImage.create(record, "star-images/1/10/uuid.jpg", IMAGE_URL, (short) 0);
             given(starRecordRepositoryPort.findByIdWithLock(STAR_ID))
@@ -103,10 +123,9 @@ class UploadStarImageServiceTest {
             given(presignedUrlGeneratorPort.generate(anyString(), anyString()))
                     .willReturn(new PresignedUrlResult(PRESIGNED_URL, IMAGE_URL));
 
-            UploadStarImageResult result = service.upload(command(USER_ID));
+            List<UploadStarImageResult> results = service.upload(command(USER_ID, MIME_JPEG));
 
-            assertThat(result.imageKey()).isNotBlank();
-            assertThat(result.presignedUrl()).isEqualTo(PRESIGNED_URL);
+            assertThat(results).hasSize(1);
         }
 
         @Test
@@ -119,7 +138,7 @@ class UploadStarImageServiceTest {
             given(presignedUrlGeneratorPort.generate(anyString(), anyString()))
                     .willReturn(new PresignedUrlResult(PRESIGNED_URL, IMAGE_URL));
 
-            service.upload(new UploadStarImageCommand(USER_ID, STAR_ID, "image/png"));
+            service.upload(command(USER_ID, MIME_PNG));
 
             verify(presignedUrlGeneratorPort)
                     .generate(argThat(key -> key.endsWith(".png")), anyString());
@@ -135,7 +154,7 @@ class UploadStarImageServiceTest {
         void should_throwStarNotFound_when_notExist() {
             given(starRecordRepositoryPort.findByIdWithLock(STAR_ID)).willReturn(Optional.empty());
 
-            assertThatThrownBy(() -> service.upload(command(USER_ID)))
+            assertThatThrownBy(() -> service.upload(command(USER_ID, MIME_JPEG)))
                     .isInstanceOf(BusinessException.class)
                     .extracting("errorCode")
                     .isEqualTo(ErrorCode.STAR_NOT_FOUND);
@@ -148,7 +167,7 @@ class UploadStarImageServiceTest {
             given(starRecordRepositoryPort.findByIdWithLock(STAR_ID))
                     .willReturn(Optional.of(record));
 
-            assertThatThrownBy(() -> service.upload(command(OTHER_USER_ID)))
+            assertThatThrownBy(() -> service.upload(command(OTHER_USER_ID, MIME_JPEG)))
                     .isInstanceOf(BusinessException.class)
                     .extracting("errorCode")
                     .isEqualTo(ErrorCode.STAR_FORBIDDEN);
@@ -164,7 +183,7 @@ class UploadStarImageServiceTest {
             given(starRecordRepositoryPort.findByIdWithLock(STAR_ID))
                     .willReturn(Optional.of(record));
 
-            assertThatThrownBy(() -> service.upload(command(USER_ID)))
+            assertThatThrownBy(() -> service.upload(command(USER_ID, MIME_JPEG)))
                     .isInstanceOf(BusinessException.class)
                     .extracting("errorCode")
                     .isEqualTo(ErrorCode.STAR_WRITE_LOCKED);
@@ -183,7 +202,24 @@ class UploadStarImageServiceTest {
             given(starImageQueryPort.findAllByStarRecordIdOrderBySortOrder(STAR_ID))
                     .willReturn(List.of(img1, img2));
 
-            assertThatThrownBy(() -> service.upload(command(USER_ID)))
+            assertThatThrownBy(() -> service.upload(command(USER_ID, MIME_JPEG)))
+                    .isInstanceOf(BusinessException.class)
+                    .extracting("errorCode")
+                    .isEqualTo(ErrorCode.STAR_IMAGE_LIMIT_EXCEEDED);
+            verify(presignedUrlGeneratorPort, never()).generate(anyString(), anyString());
+        }
+
+        @Test
+        @DisplayName("기존 1장 + 요청 2장이면 합계 초과로 STAR_IMAGE_LIMIT_EXCEEDED를 던진다")
+        void should_throwLimitExceeded_when_existingPlusRequestedExceedsMax() {
+            StarImage img1 =
+                    StarImage.create(record, "star-images/1/10/a.jpg", IMAGE_URL, (short) 0);
+            given(starRecordRepositoryPort.findByIdWithLock(STAR_ID))
+                    .willReturn(Optional.of(record));
+            given(starImageQueryPort.findAllByStarRecordIdOrderBySortOrder(STAR_ID))
+                    .willReturn(List.of(img1));
+
+            assertThatThrownBy(() -> service.upload(command(USER_ID, MIME_JPEG, MIME_PNG)))
                     .isInstanceOf(BusinessException.class)
                     .extracting("errorCode")
                     .isEqualTo(ErrorCode.STAR_IMAGE_LIMIT_EXCEEDED);
@@ -193,7 +229,7 @@ class UploadStarImageServiceTest {
 
     // ============== helpers ==============
 
-    private UploadStarImageCommand command(Long userId) {
-        return new UploadStarImageCommand(userId, STAR_ID, MIME_TYPE);
+    private UploadStarImageCommand command(Long userId, String... mimeTypes) {
+        return new UploadStarImageCommand(userId, STAR_ID, List.of(mimeTypes));
     }
 }


### PR DESCRIPTION
_##_ 요약
- presigned URL 발급과 confirm API를 배열 단위로 변경하여 최대 2장 이미지를 한 번의 요청으로 처리

## 변경 사항
- [x] 기능
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 문서
- [x] 테스트
- [ ] 기타

**주요 변경 내용**                          
  - `UploadStarImageCommand` / `ConfirmStarImageCommand`: 단건 필드 → `List<String>` 배열로 변경                                            
  - `UploadStarImageService`: mimeTypes 배열 순회 후 `List<UploadStarImageResult>` 반환
  - `ConfirmStarImageService`: imageKeys 배열 순회 후 sortOrder 자동 증가하며 DB 저장                                                       
  - `UploadStarImageRequest` / `ConfirmStarImageRequest`: `@Size(max = 2)` 제약 추가
  - `StarImageController`: presign 응답 타입 `List<UploadStarImageResponse>` 로 변경                                                        
  - 이미지 서비스 테스트: 배열 단위 케이스 추가 (2장 발급, 기존+요청 합계 초과 검증 등)

## 테스트
- [x] 로컬 테스트 완료
- 테스트 방법:
    - ./gradlew test

### 커버리지 (JaCoCo)
- 라인 커버리지: 69%  (기준: 60% 이상)
- [x] `./gradlew test` 실행 후 `build/reports/jacoco/index.html`에서 수치 확인

## 롤백/리스크
- 리스크 포인트: presign·confirm 요청 스펙 변경 — 프론트엔드 노티 필요.
- 롤백 방법: PR revert

## 관련 이슈
Closes #126 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 별 이미지를 한 번에 최대 2개까지 업로드할 수 있도록 개선했습니다.
  * 여러 이미지를 동시에 확인할 수 있는 기능을 추가했습니다.

* **Bug Fixes**
  * 이미지 개수 제한 검증 로직을 강화하여 한 별당 최대 이미지 수를 초과하지 않도록 수정했습니다.

* **Tests**
  * 다중 이미지 처리에 대한 단위 테스트를 추가했습니다.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/2026-KUSITMS-GLIT/2026-KUSITMS-GLIT-BACK/pull/128?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->