### PR TITLE
fix: 일자 프리뷰를 title 단위로 그룹핑 (#127)

### DIFF
--- a/src/main/java/com/groute/groute_server/calendar/controller/CalendarHomeController.java
+++ b/src/main/java/com/groute/groute_server/calendar/controller/CalendarHomeController.java
@@ -25,7 +25,7 @@ import lombok.RequiredArgsConstructor;
  *
  * <p>월별 잔디(스크럼/STAR 작성 + 대표 역량) 데이터와 날짜 클릭 시 노출되는 프리뷰 목록을 반환한다. 인증된 사용자(JWT) 본인 데이터만 조회.
  */
-@Tag(name = "Calendar", description = "캘린더 조회 (메인 홈 월/일 프리뷰 + 일자별 스크럼)")
+@Tag(name = "Calendar", description = "캘린더 조회 (메인 홈 월별 + 일자별 작업(title) 단위 프리뷰)")
 @RestController
 @RequestMapping("/api/calendar")
 @RequiredArgsConstructor
@@ -59,7 +59,8 @@ public class CalendarHomeController {
     @Operation(
             summary = "날짜 프리뷰 조회",
             description =
-                    "지정한 일자(yyyy-MM-dd)의 스크럼 목록을 반환한다. STAR 완료 시에만 대표 역량/세부 태그가 채워지며 그 외 null.")
+                    "지정한 일자(yyyy-MM-dd)의 작업(ScrumTitle) 단위 프리뷰 목록을 반환한다. 같은 freeText에 속한 스크럼들을 하나의 카드로 묶고, "
+                            + "카드 내 STAR 완료된 스크럼들의 대표 역량을 distinct 배열로 노출한다. STAR 완료가 없으면 primaryCategories는 빈 배열, hasStarAny는 false.")
     @ApiResponses({
         @io.swagger.v3.oas.annotations.responses.ApiResponse(
                 responseCode = "200",

--- a/src/main/java/com/groute/groute_server/calendar/dto/CalendarDailyPreviewResponse.java
+++ b/src/main/java/com/groute/groute_server/calendar/dto/CalendarDailyPreviewResponse.java
@@ -10,46 +10,41 @@ import io.swagger.v3.oas.annotations.media.Schema;
 /**
  * 캘린더 메인 홈 날짜 프리뷰 조회 응답 DTO.
  *
- * <p>지정 일자의 스크럼 목록을 반환한다. 각 스크럼은 STAR 완료 시에만 {@code primaryCategory}/{@code detailTags}가 채워지며,
- * 미완료/미작성이면 두 필드 모두 {@code null}.
+ * <p>지정 일자의 작업(ScrumTitle) 단위 프리뷰 목록을 반환한다. 같은 freeText에 속한 스크럼들이 하나의 카드로 묶이고, 카드 단위로 STAR 완료된
+ * 스크럼들의 {@code primaryCategory}가 distinct 배열로 노출된다.
  */
 @Schema(description = "날짜 프리뷰 조회 응답")
 public record CalendarDailyPreviewResponse(
-        @Schema(description = "조회한 날짜 (yyyy-MM-dd)", example = "2026-04-02") String date,
-        @Schema(description = "스크럼 목록 (없으면 빈 배열)") List<ScrumPreview> scrums) {
+        @Schema(description = "조회한 날짜 (yyyy-MM-dd)", example = "2026-05-20") String date,
+        @Schema(description = "작업(title) 단위 프리뷰 목록 (없으면 빈 배열)") List<TitlePreview> titles) {
 
     public static CalendarDailyPreviewResponse from(CalendarDailyPreviewView view) {
-        List<ScrumPreview> previews =
-                view.scrums().stream()
+        List<TitlePreview> titles =
+                view.titles().stream()
                         .map(
-                                s ->
-                                        new ScrumPreview(
-                                                s.scrumId(),
-                                                s.projectName(),
-                                                s.freeText(),
-                                                s.content(),
-                                                s.primaryCategory(),
-                                                s.detailTags(),
-                                                s.hasStar()))
+                                t ->
+                                        new TitlePreview(
+                                                t.titleId(),
+                                                t.projectName(),
+                                                t.freeText(),
+                                                t.primaryCategories(),
+                                                t.scrumCount(),
+                                                t.hasStarAny()))
                         .toList();
-        return new CalendarDailyPreviewResponse(view.date().toString(), previews);
+        return new CalendarDailyPreviewResponse(view.date().toString(), titles);
     }
 
-    @Schema(description = "스크럼 프리뷰 항목")
-    public record ScrumPreview(
-            @Schema(description = "스크럼 식별자", example = "1") Long scrumId,
+    @Schema(description = "작업(title) 단위 프리뷰 항목")
+    public record TitlePreview(
+            @Schema(description = "스크럼 제목 식별자", example = "50") Long titleId,
             @Schema(description = "프로젝트 태그명 (최대 15자)", example = "밋업프로젝트") String projectName,
             @Schema(description = "제목 자유작성 영역 (최대 20자)", example = "기획 작업") String freeText,
-            @Schema(description = "스크럼 본문 (최대 50자)", example = "어드민 페이지 기능명세서 작성") String content,
             @Schema(
-                            description = "대표 역량. STAR 완료 기록이 없으면 null",
-                            example = "PLANNING_EXECUTION",
-                            nullable = true)
-                    CompetencyCategory primaryCategory,
-            @Schema(
-                            description = "세부 역량 태그 (최대 3개). STAR 완료 기록이 없으면 null",
-                            example = "[\"UX 설계\", \"품질 관리\"]",
-                            nullable = true)
-                    List<String> detailTags,
-            @Schema(description = "STAR 완료 여부", example = "true") boolean hasStar) {}
+                            description =
+                                    "카드 내 STAR 완료된 스크럼들의 distinct primaryCategory 집합. STAR 완료가 없으면 빈 배열.",
+                            example = "[\"PLANNING_EXECUTION\", \"COLLABORATION\"]")
+                    List<CompetencyCategory> primaryCategories,
+            @Schema(description = "카드에 속한 스크럼 개수", example = "2") int scrumCount,
+            @Schema(description = "카드 내 STAR 완료된 스크럼이 1건 이상 존재하는지 여부", example = "true")
+                    boolean hasStarAny) {}
 }

--- a/src/main/java/com/groute/groute_server/calendar/service/CalendarDailyPreviewView.java
+++ b/src/main/java/com/groute/groute_server/calendar/service/CalendarDailyPreviewView.java
@@ -8,17 +8,22 @@ import com.groute.groute_server.record.domain.enums.CompetencyCategory;
 /**
  * 날짜 프리뷰 도메인 뷰.
  *
- * <p>지정 일자의 스크럼 목록을 service ↔ controller 사이에 전달한다. STAR 완료 기록이 있는 스크럼만 {@code
- * primaryCategory}/{@code detailTags}가 채워지며, 미완료/미작성이면 두 필드 모두 {@code null}.
+ * <p>지정 일자의 작업(ScrumTitle) 단위 프리뷰 목록을 service ↔ controller 사이에 전달한다. 같은 freeText에 속한 스크럼들을 하나의 카드로
+ * 묶고, 카드 단위로 STAR 완료된 스크럼들의 {@code primaryCategory}를 distinct 집합으로 노출한다.
  */
-public record CalendarDailyPreviewView(LocalDate date, List<ScrumItem> scrums) {
+public record CalendarDailyPreviewView(LocalDate date, List<TitlePreview> titles) {
 
-    public record ScrumItem(
-            Long scrumId,
+    /**
+     * 작업(ScrumTitle) 단위 프리뷰 항목.
+     *
+     * <p>{@code primaryCategories}는 카드 내 STAR 완료된 스크럼들의 distinct primaryCategory 집합으로, scrum.id 오름차순
+     * 첫 발견 순서를 따른다. STAR 완료된 스크럼이 한 건도 없으면 빈 배열이고 {@code hasStarAny}는 false다.
+     */
+    public record TitlePreview(
+            Long titleId,
             String projectName,
             String freeText,
-            String content,
-            CompetencyCategory primaryCategory,
-            List<String> detailTags,
-            boolean hasStar) {}
+            List<CompetencyCategory> primaryCategories,
+            int scrumCount,
+            boolean hasStarAny) {}
 }

--- a/src/main/java/com/groute/groute_server/calendar/service/CalendarDailyPreviewView.java
+++ b/src/main/java/com/groute/groute_server/calendar/service/CalendarDailyPreviewView.java
@@ -16,8 +16,8 @@ public record CalendarDailyPreviewView(LocalDate date, List<TitlePreview> titles
     /**
      * 작업(ScrumTitle) 단위 프리뷰 항목.
      *
-     * <p>{@code primaryCategories}는 카드 내 STAR 완료된 스크럼들의 distinct primaryCategory 집합으로, scrum.id 오름차순
-     * 첫 발견 순서를 따른다. STAR 완료된 스크럼이 한 건도 없으면 빈 배열이고 {@code hasStarAny}는 false다.
+     * <p>{@code primaryCategories}는 카드 내 STAR 완료된 스크럼들의 distinct primaryCategory 집합으로, scrum.id
+     * 오름차순 첫 발견 순서를 따른다. STAR 완료된 스크럼이 한 건도 없으면 빈 배열이고 {@code hasStarAny}는 false다.
      */
     public record TitlePreview(
             Long titleId,

--- a/src/main/java/com/groute/groute_server/calendar/service/CalendarHomeService.java
+++ b/src/main/java/com/groute/groute_server/calendar/service/CalendarHomeService.java
@@ -5,8 +5,10 @@ import java.time.YearMonth;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -14,9 +16,9 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.groute.groute_server.calendar.repository.CalendarHomeRepository;
-import com.groute.groute_server.calendar.repository.ScrumStarTagRow;
 import com.groute.groute_server.calendar.repository.StarDailyRow;
 import com.groute.groute_server.record.domain.Scrum;
+import com.groute.groute_server.record.domain.ScrumTitle;
 import com.groute.groute_server.record.domain.enums.CompetencyCategory;
 
 import lombok.RequiredArgsConstructor;
@@ -67,11 +69,11 @@ public class CalendarHomeService {
     }
 
     /**
-     * 지정 일자의 스크럼 프리뷰 목록을 반환한다. 본인 데이터만 포함되며 빈 결과는 {@code scrums=[]}.
+     * 지정 일자의 작업(ScrumTitle) 단위 프리뷰 목록을 반환한다. 본인 데이터만 포함되며 빈 결과는 {@code titles=[]}.
      *
-     * <p>각 스크럼의 {@code primaryCategory}/{@code detailTags}는 STAR가 완료된 경우에만
-     * 채워진다(`isCompleted=true`). 미완료/미작성이면 두 필드 모두 {@code null}이며, {@code detailTags}는 안전 차원에서 최대
-     * 3개로 제한.
+     * <p>같은 freeText에 속한 스크럼들을 하나의 카드로 묶고, 카드 단위로 STAR 완료된 스크럼들의 {@code primaryCategory}를 distinct 집합으로
+     * 노출한다. STAR 완료된 스크럼이 한 건도 없으면 {@code primaryCategories=[]}이고 {@code hasStarAny=false}다. 정렬은 그룹
+     * 첫 발견 순서(scrum.id ASC) 를 따른다.
      */
     public CalendarDailyPreviewView getDailyPreview(Long userId, LocalDate date) {
         List<Scrum> scrums = calendarHomeRepository.findScrumsByUserAndDate(userId, date);
@@ -80,30 +82,43 @@ public class CalendarHomeService {
         }
 
         List<Long> scrumIds = scrums.stream().map(Scrum::getId).toList();
-        Map<Long, List<ScrumStarTagRow>> tagsByScrumId =
+        Map<Long, CompetencyCategory> primaryByScrumId =
                 calendarHomeRepository.findCompletedStarTagsByScrumIds(userId, scrumIds).stream()
-                        .collect(Collectors.groupingBy(ScrumStarTagRow::scrumId));
+                        .collect(
+                                Collectors.toMap(
+                                        row -> row.scrumId(),
+                                        row -> row.primaryCategory(),
+                                        (a, b) -> a));
 
-        List<CalendarDailyPreviewView.ScrumItem> items = new ArrayList<>();
-        for (Scrum scrum : scrums) {
-            List<ScrumStarTagRow> tagRows = tagsByScrumId.get(scrum.getId());
-            CompetencyCategory primary = null;
-            List<String> detailTags = null;
-            if (tagRows != null && !tagRows.isEmpty()) {
-                primary = tagRows.get(0).primaryCategory();
-                detailTags = tagRows.stream().map(ScrumStarTagRow::detailTag).limit(3).toList();
-            }
-            items.add(
-                    new CalendarDailyPreviewView.ScrumItem(
-                            scrum.getId(),
-                            scrum.getTitle().getProject().getName(),
-                            scrum.getTitle().getFreeText(),
-                            scrum.getContent(),
-                            primary,
-                            detailTags,
-                            scrum.isHasStar()));
+        // scrums 는 repository에서 s.id ASC 정렬되어 들어오므로 LinkedHashMap이 그룹 첫 발견 순서를 보존한다.
+        Map<Long, List<Scrum>> scrumsByTitleId =
+                scrums.stream()
+                        .collect(
+                                Collectors.groupingBy(
+                                        s -> s.getTitle().getId(),
+                                        LinkedHashMap::new,
+                                        Collectors.toList()));
+
+        List<CalendarDailyPreviewView.TitlePreview> titles = new ArrayList<>();
+        for (List<Scrum> group : scrumsByTitleId.values()) {
+            ScrumTitle title = group.get(0).getTitle();
+            List<CompetencyCategory> primaryCategories =
+                    group.stream()
+                            .map(Scrum::getId)
+                            .map(primaryByScrumId::get)
+                            .filter(Objects::nonNull)
+                            .distinct()
+                            .toList();
+            titles.add(
+                    new CalendarDailyPreviewView.TitlePreview(
+                            title.getId(),
+                            title.getProject().getName(),
+                            title.getFreeText(),
+                            primaryCategories,
+                            group.size(),
+                            !primaryCategories.isEmpty()));
         }
-        return new CalendarDailyPreviewView(date, items);
+        return new CalendarDailyPreviewView(date, titles);
     }
 
     /** 그날 STAR 행 중 가장 최근 완료된 row의 primaryCategory. 비어 있으면 {@code null}. */

--- a/src/main/java/com/groute/groute_server/calendar/service/CalendarHomeService.java
+++ b/src/main/java/com/groute/groute_server/calendar/service/CalendarHomeService.java
@@ -71,9 +71,9 @@ public class CalendarHomeService {
     /**
      * 지정 일자의 작업(ScrumTitle) 단위 프리뷰 목록을 반환한다. 본인 데이터만 포함되며 빈 결과는 {@code titles=[]}.
      *
-     * <p>같은 freeText에 속한 스크럼들을 하나의 카드로 묶고, 카드 단위로 STAR 완료된 스크럼들의 {@code primaryCategory}를 distinct 집합으로
-     * 노출한다. STAR 완료된 스크럼이 한 건도 없으면 {@code primaryCategories=[]}이고 {@code hasStarAny=false}다. 정렬은 그룹
-     * 첫 발견 순서(scrum.id ASC) 를 따른다.
+     * <p>같은 freeText에 속한 스크럼들을 하나의 카드로 묶고, 카드 단위로 STAR 완료된 스크럼들의 {@code primaryCategory}를 distinct
+     * 집합으로 노출한다. STAR 완료된 스크럼이 한 건도 없으면 {@code primaryCategories=[]}이고 {@code hasStarAny=false}다.
+     * 정렬은 그룹 첫 발견 순서(scrum.id ASC) 를 따른다.
      */
     public CalendarDailyPreviewView getDailyPreview(Long userId, LocalDate date) {
         List<Scrum> scrums = calendarHomeRepository.findScrumsByUserAndDate(userId, date);

--- a/src/main/java/com/groute/groute_server/calendar/service/CalendarHomeService.java
+++ b/src/main/java/com/groute/groute_server/calendar/service/CalendarHomeService.java
@@ -90,9 +90,10 @@ public class CalendarHomeService {
                                         row -> row.primaryCategory(),
                                         (a, b) -> a));
 
-        // scrums 는 repository에서 s.id ASC 정렬되어 들어오므로 LinkedHashMap이 그룹 첫 발견 순서를 보존한다.
+        // 카드 정렬 규칙(scrum.id ASC 첫 발견 순서)을 repository 쿼리 변경에 의존하지 않도록 서비스에서 명시적으로 정렬한다.
         Map<Long, List<Scrum>> scrumsByTitleId =
                 scrums.stream()
+                        .sorted(Comparator.comparing(Scrum::getId))
                         .collect(
                                 Collectors.groupingBy(
                                         s -> s.getTitle().getId(),

--- a/src/test/java/com/groute/groute_server/calendar/service/CalendarHomeServiceTest.java
+++ b/src/test/java/com/groute/groute_server/calendar/service/CalendarHomeServiceTest.java
@@ -159,59 +159,113 @@ class CalendarHomeServiceTest {
     class DailyPreviewHappyPath {
 
         @Test
-        @DisplayName("STAR가 완료된 스크럼은 primaryCategory와 detailTags가 채워진다")
-        void should_fillStarFields_when_starCompleted() {
+        @DisplayName("같은 title의 스크럼들은 하나의 카드로 묶이고 primaryCategory는 distinct로 모인다")
+        void should_groupScrumsByTitle_when_multipleScrumsSameTitle() {
             // given
-            Scrum scrum = scrum(7L, "어드민 페이지 기능명세서 작성", true, 50L, "밋업프로젝트", "기획 작업");
+            Scrum scrum1 = scrum(7L, "본문 A", true, 50L, "밋업프로젝트", "기획 작업");
+            Scrum scrum2 = scrum(8L, "본문 B", true, 50L, "밋업프로젝트", "기획 작업");
             given(calendarHomeRepository.findScrumsByUserAndDate(USER_ID, DATE))
-                    .willReturn(List.of(scrum));
-            given(calendarHomeRepository.findCompletedStarTagsByScrumIds(USER_ID, List.of(7L)))
+                    .willReturn(List.of(scrum1, scrum2));
+            given(calendarHomeRepository.findCompletedStarTagsByScrumIds(USER_ID, List.of(7L, 8L)))
                     .willReturn(
                             List.of(
                                     new ScrumStarTagRow(
                                             7L, CompetencyCategory.PLANNING_EXECUTION, "UX 설계"),
                                     new ScrumStarTagRow(
-                                            7L, CompetencyCategory.PLANNING_EXECUTION, "품질 관리")));
+                                            8L, CompetencyCategory.COLLABORATION, "협업")));
 
             // when
             CalendarDailyPreviewView view = service.getDailyPreview(USER_ID, DATE);
 
             // then
             assertThat(view.date()).isEqualTo(DATE);
-            assertThat(view.scrums()).hasSize(1);
-            CalendarDailyPreviewView.ScrumItem item = view.scrums().get(0);
-            assertThat(item.scrumId()).isEqualTo(7L);
-            assertThat(item.projectName()).isEqualTo("밋업프로젝트");
-            assertThat(item.freeText()).isEqualTo("기획 작업");
-            assertThat(item.content()).isEqualTo("어드민 페이지 기능명세서 작성");
-            assertThat(item.primaryCategory()).isEqualTo(CompetencyCategory.PLANNING_EXECUTION);
-            assertThat(item.detailTags()).containsExactly("UX 설계", "품질 관리");
-            assertThat(item.hasStar()).isTrue();
+            assertThat(view.titles()).hasSize(1);
+            CalendarDailyPreviewView.TitlePreview preview = view.titles().get(0);
+            assertThat(preview.titleId()).isEqualTo(50L);
+            assertThat(preview.projectName()).isEqualTo("밋업프로젝트");
+            assertThat(preview.freeText()).isEqualTo("기획 작업");
+            assertThat(preview.primaryCategories())
+                    .containsExactly(
+                            CompetencyCategory.PLANNING_EXECUTION,
+                            CompetencyCategory.COLLABORATION);
+            assertThat(preview.scrumCount()).isEqualTo(2);
+            assertThat(preview.hasStarAny()).isTrue();
         }
 
         @Test
-        @DisplayName("STAR가 미완료/미작성인 스크럼은 primaryCategory와 detailTags가 null")
-        void should_returnNullStarFields_when_noCompletedStar() {
-            // given — 스크럼은 있으나 완료된 STAR row 없음
-            Scrum scrum = scrum(7L, "본문", false, 50L, "밋업프로젝트", "기획 작업");
+        @DisplayName("그룹 내 일부 스크럼만 STAR 완료 시 완료된 것만 primaryCategories에 모인다")
+        void should_includeOnlyCompletedPrimaryCategories_when_partialStarCompleted() {
+            // given — scrum1만 STAR 완료, scrum2는 미완료
+            Scrum scrum1 = scrum(7L, "본문 A", true, 50L, "밋업프로젝트", "기획 작업");
+            Scrum scrum2 = scrum(8L, "본문 B", false, 50L, "밋업프로젝트", "기획 작업");
             given(calendarHomeRepository.findScrumsByUserAndDate(USER_ID, DATE))
-                    .willReturn(List.of(scrum));
-            given(calendarHomeRepository.findCompletedStarTagsByScrumIds(USER_ID, List.of(7L)))
+                    .willReturn(List.of(scrum1, scrum2));
+            given(calendarHomeRepository.findCompletedStarTagsByScrumIds(USER_ID, List.of(7L, 8L)))
+                    .willReturn(
+                            List.of(
+                                    new ScrumStarTagRow(
+                                            7L, CompetencyCategory.PLANNING_EXECUTION, "UX 설계")));
+
+            // when
+            CalendarDailyPreviewView view = service.getDailyPreview(USER_ID, DATE);
+
+            // then
+            CalendarDailyPreviewView.TitlePreview preview = view.titles().get(0);
+            assertThat(preview.primaryCategories())
+                    .containsExactly(CompetencyCategory.PLANNING_EXECUTION);
+            assertThat(preview.scrumCount()).isEqualTo(2);
+            assertThat(preview.hasStarAny()).isTrue();
+        }
+
+        @Test
+        @DisplayName("그룹 전체 STAR 미완료 시 primaryCategories는 빈 배열, hasStarAny는 false")
+        void should_returnEmptyPrimaryCategories_when_noStarCompleted() {
+            // given
+            Scrum scrum1 = scrum(7L, "본문 A", false, 50L, "밋업프로젝트", "기획 작업");
+            Scrum scrum2 = scrum(8L, "본문 B", false, 50L, "밋업프로젝트", "기획 작업");
+            given(calendarHomeRepository.findScrumsByUserAndDate(USER_ID, DATE))
+                    .willReturn(List.of(scrum1, scrum2));
+            given(calendarHomeRepository.findCompletedStarTagsByScrumIds(USER_ID, List.of(7L, 8L)))
                     .willReturn(List.of());
 
             // when
             CalendarDailyPreviewView view = service.getDailyPreview(USER_ID, DATE);
 
             // then
-            CalendarDailyPreviewView.ScrumItem item = view.scrums().get(0);
-            assertThat(item.primaryCategory()).isNull();
-            assertThat(item.detailTags()).isNull();
-            assertThat(item.hasStar()).isFalse();
+            CalendarDailyPreviewView.TitlePreview preview = view.titles().get(0);
+            assertThat(preview.primaryCategories()).isEmpty();
+            assertThat(preview.scrumCount()).isEqualTo(2);
+            assertThat(preview.hasStarAny()).isFalse();
+        }
+
+        @Test
+        @DisplayName("서로 다른 title은 별도 카드로 분리되며 첫 발견(scrum.id ASC) 순서를 따른다")
+        void should_separateCardsByTitle_when_differentTitles() {
+            // given — titleId 50의 scrum이 먼저(id=7), titleId 60의 scrum이 나중(id=8)
+            Scrum scrum1 = scrum(7L, "본문 A", true, 50L, "밋업프로젝트", "기획 작업");
+            Scrum scrum2 = scrum(8L, "본문 B", true, 60L, "디자인프로젝트", "디자인 작업");
+            given(calendarHomeRepository.findScrumsByUserAndDate(USER_ID, DATE))
+                    .willReturn(List.of(scrum1, scrum2));
+            given(calendarHomeRepository.findCompletedStarTagsByScrumIds(USER_ID, List.of(7L, 8L)))
+                    .willReturn(
+                            List.of(
+                                    new ScrumStarTagRow(
+                                            7L, CompetencyCategory.PLANNING_EXECUTION, "UX 설계"),
+                                    new ScrumStarTagRow(
+                                            8L, CompetencyCategory.COLLABORATION, "협업")));
+
+            // when
+            CalendarDailyPreviewView view = service.getDailyPreview(USER_ID, DATE);
+
+            // then
+            assertThat(view.titles()).hasSize(2);
+            assertThat(view.titles().get(0).titleId()).isEqualTo(50L);
+            assertThat(view.titles().get(1).titleId()).isEqualTo(60L);
         }
 
         @Test
         @DisplayName("스크럼이 없으면 빈 배열을 반환한다")
-        void should_returnEmptyScrums_when_noScrums() {
+        void should_returnEmptyTitles_when_noScrums() {
             // given
             given(calendarHomeRepository.findScrumsByUserAndDate(USER_ID, DATE))
                     .willReturn(List.of());
@@ -220,7 +274,7 @@ class CalendarHomeServiceTest {
             CalendarDailyPreviewView view = service.getDailyPreview(USER_ID, DATE);
 
             // then
-            assertThat(view.scrums()).isEmpty();
+            assertThat(view.titles()).isEmpty();
         }
     }
 


### PR DESCRIPTION
## 요약
캘린더 일자 프리뷰 응답을 ScrumTitle(작업) 단위로 그룹핑하고 카드 내 STAR 완료된 스크럼들의 primaryCategory를 distinct 배열로 노출.

## 변경 사항
- [ ] 기능
- [x] 버그 수정
- [ ] 리팩토링
- [ ] 문서
- [x] 테스트
- [ ] 기타

## 테스트
- [x] 로컬 테스트 완료
- 테스트 방법:
    - `./gradlew spotlessApply test --tests "*CalendarHomeServiceTest*"` → BUILD SUCCESSFUL
    - DailyPreview 5 케이스(같은 title 그룹핑, 일부 STAR 완료, 전체 미완료, title 분리, 빈 결과) 통과 확인

### 커버리지 (JaCoCo)
- 라인 커버리지: 73%  (기준: 60% 이상)
- [x] `./gradlew test` 실행 후 `build/reports/jacoco/index.html`에서 수치 확인
- (선택) 리포트 스크린샷 또는 60% 미달/특이사항 공유: 응답 스키마 변경이 주라 커버리지 변동 없음

## 스크린샷/로그 (선택)
- 해당 없음

## 롤백/리스크
- 리스크 포인트:
    - GET /api/calendar/daily-preview **응답 스키마 변경** (breaking change). 필드 `scrums` → `titles`, `ScrumPreview` → `TitlePreview`. 본문(content)/detailTags 제거. [이 스레드](https://discord.com/channels/1484514575167520870/1506537752425136138)에서 논의했습니다.
- 롤백 방법:
    - 해당 커밋 revert. View/Service/DTO/Controller/Test 5개 파일이 함께 되돌아감.

## 관련 이슈
Closes #127

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Improvements**
  * 캘린더 일일 프리뷰가 작업 단위로 표시되도록 개선되었습니다. 같은 작업에 속한 여러 스크럼들이 하나의 카드로 그룹화되어 표시됩니다.
  * 완료된 스크럼들의 역량이 구별되어 배열 형태로 노출됩니다.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/2026-KUSITMS-GLIT/2026-KUSITMS-GLIT-BACK/pull/129?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->