### PR TITLE
fix: 리포트 게이지 조회 시 PostgreSQL 파라미터 타입 추론 오류 수정

### DIFF
--- a/src/main/java/com/groute/groute_server/record/adapter/out/persistence/StarRecordJpaRepository.java
+++ b/src/main/java/com/groute/groute_server/record/adapter/out/persistence/StarRecordJpaRepository.java
@@ -105,7 +105,7 @@ public interface StarRecordJpaRepository extends JpaRepository<StarRecord, Long>
                     + "WHERE sr.user.id = :userId "
                     + "AND sr.isCompleted = true "
                     + "AND sr.isDeleted = false")
-    int countCompleted(@Param("userId") Long userId);
+    long countCompleted(@Param("userId") Long userId);
 
     /** 특정 시점 이후 완료된 심화기록 수를 카운트한다. after는 항상 non-null로 호출해야 한다. */
     @Query(
@@ -114,7 +114,7 @@ public interface StarRecordJpaRepository extends JpaRepository<StarRecord, Long>
                     + "AND sr.isCompleted = true "
                     + "AND sr.isDeleted = false "
                     + "AND sr.completedAt > :after")
-    int countCompletedAfter(@Param("userId") Long userId, @Param("after") OffsetDateTime after);
+    long countCompletedAfter(@Param("userId") Long userId, @Param("after") OffsetDateTime after);
 
     /**
      * 해당 사용자가 소유한 모든 StarRecord 물리 삭제(MYP-005 hard delete 배치).

--- a/src/main/java/com/groute/groute_server/record/adapter/out/persistence/StarRecordJpaRepository.java
+++ b/src/main/java/com/groute/groute_server/record/adapter/out/persistence/StarRecordJpaRepository.java
@@ -99,17 +99,21 @@ public interface StarRecordJpaRepository extends JpaRepository<StarRecord, Long>
             @Param("date") LocalDate date,
             @Param("tagged") StarRecordStatus tagged);
 
-    /**
-     * 특정 시점 이후 완료된 심화기록 수를 카운트한다.
-     *
-     * <p>after가 null이면 전체 완료된 심화기록 수를 반환한다 (신규 유저 케이스).
-     */
+    /** 전체 완료된 심화기록 수를 카운트한다. 리포트가 없는 신규 유저 케이스에 사용한다. */
+    @Query(
+            "SELECT COUNT(sr) FROM StarRecord sr "
+                    + "WHERE sr.user.id = :userId "
+                    + "AND sr.isCompleted = true "
+                    + "AND sr.isDeleted = false")
+    int countCompleted(@Param("userId") Long userId);
+
+    /** 특정 시점 이후 완료된 심화기록 수를 카운트한다. after는 항상 non-null로 호출해야 한다. */
     @Query(
             "SELECT COUNT(sr) FROM StarRecord sr "
                     + "WHERE sr.user.id = :userId "
                     + "AND sr.isCompleted = true "
                     + "AND sr.isDeleted = false "
-                    + "AND (:after IS NULL OR sr.completedAt > :after)")
+                    + "AND sr.completedAt > :after")
     int countCompletedAfter(@Param("userId") Long userId, @Param("after") OffsetDateTime after);
 
     /**

--- a/src/main/java/com/groute/groute_server/report/adapter/in/web/dto/ReportGaugeResponse.java
+++ b/src/main/java/com/groute/groute_server/report/adapter/in/web/dto/ReportGaugeResponse.java
@@ -7,7 +7,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 /** 리포트 게이지 조회 응답 DTO. {@link ReportGaugeView}의 Web 표현. */
 @Schema(description = "리포트 게이지 조회 응답")
 public record ReportGaugeResponse(
-        @Schema(description = "마지막 리포트 생성 이후 완료된 심화기록 수", example = "7") int currentCount,
+        @Schema(description = "마지막 리포트 생성 이후 완료된 심화기록 수", example = "7") long currentCount,
         @Schema(description = "다음 생성 기준 수", example = "10") int nextThreshold,
         @Schema(description = "currentCount / nextThreshold. 1.0 초과 가능", example = "0.7")
                 double progressRate,

--- a/src/main/java/com/groute/groute_server/report/adapter/out/client/StarRecordClientAdapter.java
+++ b/src/main/java/com/groute/groute_server/report/adapter/out/client/StarRecordClientAdapter.java
@@ -23,6 +23,9 @@ public class StarRecordClientAdapter implements StarRecordCountQueryPort {
 
     @Override
     public int countCompletedAfter(Long userId, OffsetDateTime after) {
+        if (after == null) {
+            return starRecordJpaRepository.countCompleted(userId);
+        }
         return starRecordJpaRepository.countCompletedAfter(userId, after);
     }
 }

--- a/src/main/java/com/groute/groute_server/report/adapter/out/client/StarRecordClientAdapter.java
+++ b/src/main/java/com/groute/groute_server/report/adapter/out/client/StarRecordClientAdapter.java
@@ -22,7 +22,7 @@ public class StarRecordClientAdapter implements StarRecordCountQueryPort {
     private final StarRecordJpaRepository starRecordJpaRepository;
 
     @Override
-    public int countCompletedAfter(Long userId, OffsetDateTime after) {
+    public long countCompletedAfter(Long userId, OffsetDateTime after) {
         if (after == null) {
             return starRecordJpaRepository.countCompleted(userId);
         }

--- a/src/main/java/com/groute/groute_server/report/application/port/in/dto/ReportGaugeView.java
+++ b/src/main/java/com/groute/groute_server/report/application/port/in/dto/ReportGaugeView.java
@@ -6,9 +6,9 @@ package com.groute.groute_server.report.application.port.in.dto;
  * <p>마지막 리포트 생성 이후 완료된 심화기록 수와 다음 생성 임계치를 담는다.
  */
 public record ReportGaugeView(
-        int currentCount, int nextThreshold, double progressRate, boolean isGeneratable) {
+        long currentCount, int nextThreshold, double progressRate, boolean isGeneratable) {
 
-    public static ReportGaugeView of(int currentCount, int nextThreshold) {
+    public static ReportGaugeView of(long currentCount, int nextThreshold) {
         double progressRate = (double) currentCount / nextThreshold;
         boolean isGeneratable = currentCount >= nextThreshold;
         return new ReportGaugeView(currentCount, nextThreshold, progressRate, isGeneratable);

--- a/src/main/java/com/groute/groute_server/report/application/port/out/StarRecordCountQueryPort.java
+++ b/src/main/java/com/groute/groute_server/report/application/port/out/StarRecordCountQueryPort.java
@@ -18,5 +18,5 @@ public interface StarRecordCountQueryPort {
      * @param after 이 시점 이후 완료된 것만 카운트. null이면 전체 카운트
      * @return 완료된 심화기록 수
      */
-    int countCompletedAfter(Long userId, OffsetDateTime after);
+    long countCompletedAfter(Long userId, OffsetDateTime after);
 }

--- a/src/main/java/com/groute/groute_server/report/application/service/ReportQueryService.java
+++ b/src/main/java/com/groute/groute_server/report/application/service/ReportQueryService.java
@@ -55,7 +55,7 @@ public class ReportQueryService
                         .map(Report::getCreatedAt)
                         .orElse(null);
 
-        int currentCount = starRecordCountQueryPort.countCompletedAfter(userId, after);
+        long currentCount = starRecordCountQueryPort.countCompletedAfter(userId, after);
 
         return ReportGaugeView.of(currentCount, NEXT_THRESHOLD);
     }


### PR DESCRIPTION
## 요약
- 리포트가 없는 신규 유저 게이지 조회 시 after=null을 JPQL에 넘겨 PostgreSQL 파라미터 타입 추론 실패로 500 에러 발생하던 문제 수정

## 상세내용
- after=null 전달 시 PostgreSQL이 파라미터 타입 추론 실패 → 500
- null/non-null 케이스 쿼리 2개로 분리, StarRecordClientAdapter에서 분기 처리

## 변경 사항
- [ ] 기능
- [x] 버그 수정
- [ ] 리팩토링
- [ ] 문서
- [ ] 테스트
- [ ] 기타

## 테스트
- [x] 로컬 테스트 완료
- 테스트 방법:
    - ./gradlew test
    - swagger test
리포트가 없는 유저로 게이지 조회 API 호출 → 200 확인
리포트가 있는 유저로 게이지 조회 API 호출 → 200 확인

### 커버리지 (JaCoCo)
- 라인 커버리지: __%  (기준: 60% 이상)
- [ ] `./gradlew test` 실행 후 `build/reports/jacoco/index.html`에서 수치 확인
- (선택) 리포트 스크린샷 또는 60% 미달/특이사항 공유:

## 스크린샷/로그 (선택)
- 필요한 경우 첨부

## 롤백/리스크
- 리스크 포인트:
- 롤백 방법:

## 관련 이슈
Closes #이슈번호

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **리팩토링**
  * 심화기록 조회 로직의 구조를 개선했습니다.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/2026-KUSITMS-GLIT/2026-KUSITMS-GLIT-BACK/pull/131?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->