### PR TITLE
fix: AI 태깅 트리거 시 requestTagging() 비동기 호출 누락 수정

### DIFF
--- a/src/main/java/com/groute/groute_server/common/config/AsyncConfig.java
+++ b/src/main/java/com/groute/groute_server/common/config/AsyncConfig.java
@@ -1,11 +1,16 @@
 package com.groute.groute_server.common.config;
 
 import java.time.Clock;
+import java.util.Arrays;
 
+import org.springframework.aop.interceptor.AsyncUncaughtExceptionHandler;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.AsyncConfigurer;
 import org.springframework.scheduling.annotation.EnableAsync;
 import org.springframework.scheduling.annotation.EnableScheduling;
+
+import lombok.extern.slf4j.Slf4j;
 
 /**
  * 비동기·스케줄링 인프라 활성화 설정.
@@ -17,10 +22,11 @@ import org.springframework.scheduling.annotation.EnableScheduling;
  * <p>{@link Clock} 빈은 시간 의존 로직(스케줄러의 KST 매칭 등)이 단위 테스트에서 시각을 주입할 수 있도록 노출한다. 운영에서는 UTC 시스템 시계를
  * 사용한다.
  */
+@Slf4j
 @Configuration
 @EnableAsync
 @EnableScheduling
-public class AsyncConfig {
+public class AsyncConfig implements AsyncConfigurer {
 
     /**
      * 시간 의존 로직 단위 테스트 용이성을 위한 {@link Clock} 빈.
@@ -32,5 +38,22 @@ public class AsyncConfig {
     @Bean
     public Clock clock() {
         return Clock.systemUTC();
+    }
+
+    /**
+     * 비동기 메서드({@code @Async void})에서 발생한 예외를 로깅한다.
+     *
+     * <p>{@code void} 반환 비동기 메서드는 예외가 caller에게 전파되지 않으므로, 핸들러 없이는 예외가 무음으로 사라진다. 최소한 에러 로그를 남겨 운영 중
+     * 원인 추적이 가능하도록 한다.
+     */
+    @Override
+    public AsyncUncaughtExceptionHandler getAsyncUncaughtExceptionHandler() {
+        return (ex, method, params) ->
+                log.error(
+                        "[Async] 비동기 메서드 예외 — method={}, params={}, message={}",
+                        method.getName(),
+                        Arrays.toString(params),
+                        ex.getMessage(),
+                        ex);
     }
 }

--- a/src/main/java/com/groute/groute_server/record/adapter/out/ai/AiTaggingClientAdapter.java
+++ b/src/main/java/com/groute/groute_server/record/adapter/out/ai/AiTaggingClientAdapter.java
@@ -5,6 +5,7 @@ import java.util.Map;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Lazy;
 import org.springframework.http.MediaType;
 import org.springframework.http.client.SimpleClientHttpRequestFactory;
 import org.springframework.stereotype.Component;
@@ -47,7 +48,7 @@ public class AiTaggingClientAdapter implements AiTaggingClient {
             @Value("${ai.timeout.connect:5000}") int connectTimeoutMs,
             @Value("${ai.timeout.read:30000}") int readTimeoutMs,
             AiTaggingJobPort aiTaggingJobPort,
-            CompleteAiTaggingUseCase completeAiTaggingUseCase) {
+            @Lazy CompleteAiTaggingUseCase completeAiTaggingUseCase) {
         SimpleClientHttpRequestFactory factory = new SimpleClientHttpRequestFactory();
         factory.setConnectTimeout(java.time.Duration.ofMillis(connectTimeoutMs));
         factory.setReadTimeout(java.time.Duration.ofMillis(readTimeoutMs));

--- a/src/main/java/com/groute/groute_server/record/adapter/out/persistence/AiTaggingJobPersistenceAdapter.java
+++ b/src/main/java/com/groute/groute_server/record/adapter/out/persistence/AiTaggingJobPersistenceAdapter.java
@@ -27,6 +27,11 @@ public class AiTaggingJobPersistenceAdapter implements AiTaggingJobPort {
     }
 
     @Override
+    public Optional<AiTaggingJob> findById(Long jobId) {
+        return aiTaggingJobRepository.findById(jobId);
+    }
+
+    @Override
     public AiTaggingJob save(StarRecord starRecord) {
         return aiTaggingJobRepository.save(new AiTaggingJob(starRecord));
     }

--- a/src/main/java/com/groute/groute_server/record/adapter/out/persistence/AiTaggingJobRepository.java
+++ b/src/main/java/com/groute/groute_server/record/adapter/out/persistence/AiTaggingJobRepository.java
@@ -19,10 +19,7 @@ public interface AiTaggingJobRepository extends JpaRepository<AiTaggingJob, Long
      * @param starRecordId 조회할 STAR 기록 ID
      * @return 가장 최근 잡 (없으면 empty)
      */
-    @Query(
-            "SELECT j FROM AiTaggingJob j WHERE j.starRecord.id = :starRecordId ORDER BY j.createdAt DESC LIMIT 1")
-    Optional<AiTaggingJob> findTopByStarRecordIdOrderByCreatedAtDesc(
-            @Param("starRecordId") Long starRecordId);
+    Optional<AiTaggingJob> findTopByStarRecordIdOrderByCreatedAtDesc(Long starRecordId);
 
     /**
      * 해당 사용자가 소유한 모든 AiTaggingJob 물리 삭제(MYP-005 hard delete 배치).

--- a/src/main/java/com/groute/groute_server/record/adapter/out/persistence/AiTaggingJobRepository.java
+++ b/src/main/java/com/groute/groute_server/record/adapter/out/persistence/AiTaggingJobRepository.java
@@ -19,7 +19,10 @@ public interface AiTaggingJobRepository extends JpaRepository<AiTaggingJob, Long
      * @param starRecordId 조회할 STAR 기록 ID
      * @return 가장 최근 잡 (없으면 empty)
      */
-    Optional<AiTaggingJob> findTopByStarRecordIdOrderByCreatedAtDesc(Long starRecordId);
+    @Query(
+            "SELECT j FROM AiTaggingJob j WHERE j.starRecord.id = :starRecordId ORDER BY j.createdAt DESC LIMIT 1")
+    Optional<AiTaggingJob> findTopByStarRecordIdOrderByCreatedAtDesc(
+            @Param("starRecordId") Long starRecordId);
 
     /**
      * 해당 사용자가 소유한 모든 AiTaggingJob 물리 삭제(MYP-005 hard delete 배치).

--- a/src/main/java/com/groute/groute_server/record/application/port/out/AiTaggingJobPort.java
+++ b/src/main/java/com/groute/groute_server/record/application/port/out/AiTaggingJobPort.java
@@ -23,6 +23,14 @@ public interface AiTaggingJobPort {
     Optional<AiTaggingJob> findLatestByStarRecordId(Long starRecordId);
 
     /**
+     * 잡 ID로 단건 조회한다.
+     *
+     * @param jobId 조회할 잡 ID
+     * @return 잡 (없으면 empty)
+     */
+    Optional<AiTaggingJob> findById(Long jobId);
+
+    /**
      * 새 잡을 저장한다.
      *
      * @param starRecord 잡을 생성할 STAR 기록

--- a/src/main/java/com/groute/groute_server/record/application/service/AiTaggingAsyncExecutor.java
+++ b/src/main/java/com/groute/groute_server/record/application/service/AiTaggingAsyncExecutor.java
@@ -1,0 +1,51 @@
+package com.groute.groute_server.record.application.service;
+
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.groute.groute_server.record.application.port.out.AiTaggingClient;
+import com.groute.groute_server.record.application.port.out.AiTaggingJobPort;
+import com.groute.groute_server.record.domain.AiTaggingJob;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * AI 태깅 비동기 실행기.
+ *
+ * <p>{@link AiTaggingService#trigger}에서 잡 생성 후 호출된다. {@code @Async}를 별도 빈으로 분리해 Spring 프록시를 통한 비동기
+ * 실행을 보장한다.
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class AiTaggingAsyncExecutor {
+
+    private final AiTaggingClient aiTaggingClient;
+    private final AiTaggingJobPort aiTaggingJobPort;
+
+    /**
+     * FastAPI 태깅 요청을 비동기로 실행한다.
+     *
+     * <p>트리거 API 응답을 블로킹하지 않고 백그라운드에서 실행된다. jobId로 새 트랜잭션에서 잡을 재조회해 Lazy 로딩 세션 문제를 방지한다.
+     *
+     * @param jobId 처리할 AI 태깅 잡 ID
+     */
+    @Async
+    @Transactional
+    public void execute(Long jobId) {
+        AiTaggingJob job =
+                aiTaggingJobPort
+                        .findById(jobId)
+                        .orElseThrow(
+                                () ->
+                                        new IllegalStateException(
+                                                "AI 태깅 잡을 찾을 수 없습니다: jobId=" + jobId));
+        log.debug(
+                "[AI Tagging] 비동기 실행 시작 — jobId={}, starRecordId={}",
+                job.getId(),
+                job.getStarRecord().getId());
+        aiTaggingClient.requestTagging(job);
+    }
+}

--- a/src/main/java/com/groute/groute_server/record/application/service/AiTaggingService.java
+++ b/src/main/java/com/groute/groute_server/record/application/service/AiTaggingService.java
@@ -5,6 +5,8 @@ import java.util.List;
 
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
 
 import com.groute.groute_server.common.exception.BusinessException;
 import com.groute.groute_server.common.exception.ErrorCode;
@@ -101,8 +103,15 @@ public class AiTaggingService
         AiTaggingJob job = aiTaggingJobPort.save(starRecord);
         log.debug("AI 태깅 잡 생성: starRecordId={}, userId={}", starRecordId, userId);
 
-        // 6. 비동기 FastAPI 호출
-        aiTaggingAsyncExecutor.execute(job.getId());
+        // 6. 트랜잭션 커밋 후 비동기 FastAPI 호출 (커밋 전 조회 실패 방지)
+        Long jobId = job.getId();
+        TransactionSynchronizationManager.registerSynchronization(
+                new TransactionSynchronization() {
+                    @Override
+                    public void afterCommit() {
+                        aiTaggingAsyncExecutor.execute(jobId);
+                    }
+                });
     }
 
     /**

--- a/src/main/java/com/groute/groute_server/record/application/service/AiTaggingService.java
+++ b/src/main/java/com/groute/groute_server/record/application/service/AiTaggingService.java
@@ -51,6 +51,7 @@ public class AiTaggingService
     private final ScrumQueryPort scrumQueryPort;
     private final ScrumTitleRepositoryPort scrumTitleRepositoryPort;
     private final UserPort userPort;
+    private final AiTaggingAsyncExecutor aiTaggingAsyncExecutor;
 
     /**
      * REC-005: AI 태깅 트리거.
@@ -97,8 +98,11 @@ public class AiTaggingService
                         });
 
         // 5. 새 잡 생성 (QUEUED)
-        aiTaggingJobPort.save(starRecord);
+        AiTaggingJob job = aiTaggingJobPort.save(starRecord);
         log.debug("AI 태깅 잡 생성: starRecordId={}, userId={}", starRecordId, userId);
+
+        // 6. 비동기 FastAPI 호출
+        aiTaggingAsyncExecutor.execute(job.getId());
     }
 
     /**

--- a/src/test/java/com/groute/groute_server/record/application/service/AiTaggingAsyncExecutorTest.java
+++ b/src/test/java/com/groute/groute_server/record/application/service/AiTaggingAsyncExecutorTest.java
@@ -1,0 +1,56 @@
+package com.groute.groute_server.record.application.service;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import com.groute.groute_server.record.application.port.out.AiTaggingClient;
+import com.groute.groute_server.record.application.port.out.AiTaggingJobPort;
+import com.groute.groute_server.record.domain.AiTaggingJob;
+import com.groute.groute_server.record.domain.StarRecord;
+
+@ExtendWith(MockitoExtension.class)
+class AiTaggingAsyncExecutorTest {
+
+    private static final long JOB_ID = 1L;
+
+    @Mock private AiTaggingClient aiTaggingClient;
+    @Mock private AiTaggingJobPort aiTaggingJobPort;
+
+    @InjectMocks private AiTaggingAsyncExecutor aiTaggingAsyncExecutor;
+
+    @Test
+    @DisplayName("성공 — 잡 조회 후 requestTagging 호출됨")
+    void callsRequestTagging_whenJobFound() {
+        StarRecord starRecord = new StarRecord();
+        ReflectionTestUtils.setField(starRecord, "id", 10L);
+        AiTaggingJob job = new AiTaggingJob();
+        ReflectionTestUtils.setField(job, "id", JOB_ID);
+        ReflectionTestUtils.setField(job, "starRecord", starRecord);
+        given(aiTaggingJobPort.findById(JOB_ID)).willReturn(Optional.of(job));
+
+        aiTaggingAsyncExecutor.execute(JOB_ID);
+
+        verify(aiTaggingClient).requestTagging(job);
+    }
+
+    @Test
+    @DisplayName("실패 — 잡 없으면 IllegalStateException")
+    void throwsIllegalState_whenJobNotFound() {
+        given(aiTaggingJobPort.findById(JOB_ID)).willReturn(Optional.empty());
+
+        assertThatThrownBy(() -> aiTaggingAsyncExecutor.execute(JOB_ID))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("jobId=" + JOB_ID);
+    }
+}

--- a/src/test/java/com/groute/groute_server/record/service/AiTaggingServiceTest.java
+++ b/src/test/java/com/groute/groute_server/record/service/AiTaggingServiceTest.java
@@ -30,11 +30,11 @@ import com.groute.groute_server.record.adapter.in.web.dto.AiTaggingResultRespons
 import com.groute.groute_server.record.adapter.in.web.dto.AiTaggingStatusResponse;
 import com.groute.groute_server.record.application.port.out.AiTaggingJobPort;
 import com.groute.groute_server.record.application.port.out.UserPort;
-import com.groute.groute_server.record.application.service.AiTaggingAsyncExecutor;
 import com.groute.groute_server.record.application.port.out.scrum.ScrumQueryPort;
 import com.groute.groute_server.record.application.port.out.scrumtitle.ScrumTitleRepositoryPort;
 import com.groute.groute_server.record.application.port.out.star.StarRecordRepositoryPort;
 import com.groute.groute_server.record.application.port.out.star.StarTagQueryPort;
+import com.groute.groute_server.record.application.service.AiTaggingAsyncExecutor;
 import com.groute.groute_server.record.application.service.AiTaggingService;
 import com.groute.groute_server.record.domain.AiTaggingJob;
 import com.groute.groute_server.record.domain.Scrum;

--- a/src/test/java/com/groute/groute_server/record/service/AiTaggingServiceTest.java
+++ b/src/test/java/com/groute/groute_server/record/service/AiTaggingServiceTest.java
@@ -12,6 +12,8 @@ import java.util.List;
 import java.util.Optional;
 
 import org.assertj.core.api.InstanceOfAssertFactories;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -20,6 +22,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
 
 import com.groute.groute_server.common.exception.BusinessException;
 import com.groute.groute_server.common.exception.ErrorCode;
@@ -27,6 +30,7 @@ import com.groute.groute_server.record.adapter.in.web.dto.AiTaggingResultRespons
 import com.groute.groute_server.record.adapter.in.web.dto.AiTaggingStatusResponse;
 import com.groute.groute_server.record.application.port.out.AiTaggingJobPort;
 import com.groute.groute_server.record.application.port.out.UserPort;
+import com.groute.groute_server.record.application.service.AiTaggingAsyncExecutor;
 import com.groute.groute_server.record.application.port.out.scrum.ScrumQueryPort;
 import com.groute.groute_server.record.application.port.out.scrumtitle.ScrumTitleRepositoryPort;
 import com.groute.groute_server.record.application.port.out.star.StarRecordRepositoryPort;
@@ -58,8 +62,23 @@ class AiTaggingServiceTest {
     @Mock private ScrumQueryPort scrumQueryPort;
     @Mock private ScrumTitleRepositoryPort scrumTitleRepositoryPort;
     @Mock private UserPort userPort;
+    @Mock private AiTaggingAsyncExecutor aiTaggingAsyncExecutor;
 
     @InjectMocks private AiTaggingService aiTaggingService;
+
+    // =========================================================
+    // 트랜잭션 동기화 설정 (TransactionSynchronizationManager 사용하는 trigger() 테스트용)
+    // =========================================================
+
+    @BeforeEach
+    void initTransactionSync() {
+        TransactionSynchronizationManager.initSynchronization();
+    }
+
+    @AfterEach
+    void clearTransactionSync() {
+        TransactionSynchronizationManager.clearSynchronization();
+    }
 
     // =========================================================
     // 테스트 픽스처 헬퍼
@@ -124,9 +143,12 @@ class AiTaggingServiceTest {
         @DisplayName("성공 — 잡 없을 때 새 잡 생성")
         void createsNewJob_whenNoJobExists() {
             StarRecord record = makeStarRecord(USER_ID, StarStep.DONE);
+            AiTaggingJob savedJob = makeJob(JobStatus.QUEUED, 0);
+            ReflectionTestUtils.setField(savedJob, "id", 99L);
             given(starRecordPort.findById(STAR_RECORD_ID)).willReturn(Optional.of(record));
             given(aiTaggingJobPort.findLatestByStarRecordId(STAR_RECORD_ID))
                     .willReturn(Optional.empty());
+            given(aiTaggingJobPort.save(record)).willReturn(savedJob);
 
             aiTaggingService.trigger(STAR_RECORD_ID, USER_ID);
 
@@ -138,9 +160,12 @@ class AiTaggingServiceTest {
         void createsNewJob_whenPreviousJobFailedWithRetryCount0() {
             StarRecord record = makeStarRecord(USER_ID, StarStep.DONE);
             AiTaggingJob failedJob = makeJob(JobStatus.FAILED, 0);
+            AiTaggingJob savedJob = makeJob(JobStatus.QUEUED, 0);
+            ReflectionTestUtils.setField(savedJob, "id", 99L);
             given(starRecordPort.findById(STAR_RECORD_ID)).willReturn(Optional.of(record));
             given(aiTaggingJobPort.findLatestByStarRecordId(STAR_RECORD_ID))
                     .willReturn(Optional.of(failedJob));
+            given(aiTaggingJobPort.save(record)).willReturn(savedJob);
 
             aiTaggingService.trigger(STAR_RECORD_ID, USER_ID);
 


### PR DESCRIPTION
## 요약
- 트리거 API 호출 시 잡 생성만 되고 FastAPI 실제 호출이 누락돼 AI 태깅이 진행되지 않던 문제 수정

## 세부내용
- 트리거 API 호출 시 잡 생성 후 FastAPI 호출 누락으로 태깅 미진행 문제 수정
- AiTaggingAsyncExecutor 추가해 requestTagging() 비동기 연결
- 순환 참조 @Lazy로 해결


- AI 응답 결과의 star_tags DB 저장은 미구현 상태 (추후 별도 이슈로 처리)

## 변경 사항
- [ ] 기능
- [x] 버그 수정
- [ ] 리팩토링
- [ ] 문서
- [ ] 테스트
- [ ] 기타

## 테스트
- [x] 로컬 테스트 완료
- 테스트 방법:
    - swagger 테스트
트리거 API 호출 → ai_tagging_jobs QUEUED → RUNNING → SUCCESS 전환 확인
AI 태깅 상태 폴링 API로 SUCCESS 확인


### 커버리지 (JaCoCo)
- 라인 커버리지: __%  (기준: 60% 이상)
- [ ] `./gradlew test` 실행 후 `build/reports/jacoco/index.html`에서 수치 확인
- (선택) 리포트 스크린샷 또는 60% 미달/특이사항 공유:

## 스크린샷/로그 (선택)
- 필요한 경우 첨부

## 롤백/리스크
- 리스크 포인트:
- 롤백 방법:

## 관련 이슈
Closes #131 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * AI 태깅 요청을 커밋 이후 백그라운드 비동기로 실행하도록 추가되었습니다.

* **개선 사항**
  * 특정 작업 ID로 AI 태깅 작업을 단건 조회할 수 있게 되었습니다.
  * 트랜잭션 경계와 동기화로 처리 안정성이 향상되었습니다.
  * 의존성 초기화 지연을 통한 메모리/성능 개선이 적용되었습니다.

* **테스트**
  * 비동기 실행 및 예외 흐름을 검증하는 단위 테스트가 추가되었습니다.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/2026-KUSITMS-GLIT/2026-KUSITMS-GLIT-BACK/pull/133?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->