### PR TITLE
feat: 스크럼 단일 삭제 API

### DIFF
--- a/src/main/java/com/groute/groute_server/record/adapter/in/web/ScrumController.java
+++ b/src/main/java/com/groute/groute_server/record/adapter/in/web/ScrumController.java
@@ -5,7 +5,9 @@ import java.util.List;
 
 import jakarta.validation.Valid;
 
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -20,6 +22,8 @@ import com.groute.groute_server.record.adapter.in.web.dto.ScrumBulkWriteResponse
 import com.groute.groute_server.record.adapter.in.web.dto.ScrumCompetencyUpdateRequest;
 import com.groute.groute_server.record.adapter.in.web.dto.SyncDailyScrumRequest;
 import com.groute.groute_server.record.application.port.in.scrum.BulkWriteScrumUseCase;
+import com.groute.groute_server.record.application.port.in.scrum.DeleteScrumCommand;
+import com.groute.groute_server.record.application.port.in.scrum.DeleteScrumUseCase;
 import com.groute.groute_server.record.application.port.in.scrum.SyncDailyScrumUseCase;
 import com.groute.groute_server.record.application.port.in.scrum.UpdateScrumCompetencyUseCase;
 
@@ -37,6 +41,7 @@ public class ScrumController {
     private final SyncDailyScrumUseCase syncDailyScrumUseCase;
     private final BulkWriteScrumUseCase bulkWriteScrumUseCase;
     private final UpdateScrumCompetencyUseCase updateScrumCompetencyUseCase;
+    private final DeleteScrumUseCase deleteScrumUseCase;
 
     @Operation(
             summary = "스크럼 일괄 저장",
@@ -119,5 +124,27 @@ public class ScrumController {
         LocalDate date = DateParam.parseIso(dateRaw);
         syncDailyScrumUseCase.syncDailyScrum(request.toCommand(userId, date));
         return ApiResponse.ok("동기화 성공");
+    }
+
+    @Operation(
+            summary = "스크럼 단일 삭제",
+            description =
+                    "지정한 scrumId 한 건을 soft-delete 한다. 연결된 STAR 기록·첨부 이미지도 함께 cascade 삭제되며,"
+                            + " ScrumTitle.scrumCount 가 1 감소한다. 14일 편집 윈도우와 hasStar 거부 정책은 적용하지 않는다.")
+    @ApiResponses({
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                responseCode = "200",
+                description = "삭제 성공"),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                responseCode = "401",
+                description = "미인증 또는 만료된 액세스 토큰"),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                responseCode = "404",
+                description = "scrumId가 본인 소유가 아니거나 존재하지 않음")
+    })
+    @DeleteMapping("/{scrumId}")
+    public ApiResponse<Void> deleteScrum(@CurrentUser Long userId, @PathVariable Long scrumId) {
+        deleteScrumUseCase.deleteScrum(new DeleteScrumCommand(userId, scrumId));
+        return ApiResponse.ok("스크럼 삭제 성공");
     }
 }

--- a/src/main/java/com/groute/groute_server/record/application/port/in/scrum/DeleteScrumCommand.java
+++ b/src/main/java/com/groute/groute_server/record/application/port/in/scrum/DeleteScrumCommand.java
@@ -1,0 +1,4 @@
+package com.groute.groute_server.record.application.port.in.scrum;
+
+/** 스크럼 단일 삭제 입력. */
+public record DeleteScrumCommand(Long userId, Long scrumId) {}

--- a/src/main/java/com/groute/groute_server/record/application/port/in/scrum/DeleteScrumUseCase.java
+++ b/src/main/java/com/groute/groute_server/record/application/port/in/scrum/DeleteScrumUseCase.java
@@ -1,0 +1,12 @@
+package com.groute.groute_server.record.application.port.in.scrum;
+
+/**
+ * 스크럼 단일 삭제 유스케이스 (DELETE /api/scrums/{scrumId}).
+ *
+ * <p>Scrum soft-delete + 연결된 STAR·첨부 이미지 cascade 정리 + ScrumTitle.scrumCount 1 감소. 14일 편집 윈도우와
+ * hasStar 거부 정책은 적용하지 않는다.
+ */
+public interface DeleteScrumUseCase {
+
+    void deleteScrum(DeleteScrumCommand command);
+}

--- a/src/main/java/com/groute/groute_server/record/application/service/DeleteScrumService.java
+++ b/src/main/java/com/groute/groute_server/record/application/service/DeleteScrumService.java
@@ -1,0 +1,54 @@
+package com.groute.groute_server.record.application.service;
+
+import java.util.List;
+import java.util.Set;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.groute.groute_server.common.exception.BusinessException;
+import com.groute.groute_server.common.exception.ErrorCode;
+import com.groute.groute_server.record.application.port.in.scrum.DeleteScrumCommand;
+import com.groute.groute_server.record.application.port.in.scrum.DeleteScrumUseCase;
+import com.groute.groute_server.record.application.port.out.scrum.ScrumQueryPort;
+import com.groute.groute_server.record.application.port.out.scrum.ScrumWritePort;
+import com.groute.groute_server.record.application.port.out.scrumtitle.ScrumTitleRepositoryPort;
+import com.groute.groute_server.record.application.port.out.star.StarRecordCascadePort;
+import com.groute.groute_server.record.domain.Scrum;
+
+import lombok.RequiredArgsConstructor;
+
+/**
+ * 스크럼 단일 삭제 서비스.
+ *
+ * <p>Scrum soft-delete + 연결된 STAR·첨부 이미지 cascade 정리 + ScrumTitle.scrumCount 1 감소. 14일 편집 윈도우와
+ * hasStar 거부 정책은 적용하지 않으며, STAR가 있는 스크럼이라도 그대로 cascade 삭제한다. 호출 순서는 {@link ScrumSyncService} 의 삭제
+ * 분기와 일치시켜 트랜잭션 불변식을 동일하게 유지한다.
+ */
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class DeleteScrumService implements DeleteScrumUseCase {
+
+    private final ScrumQueryPort scrumQueryPort;
+    private final ScrumWritePort scrumWritePort;
+    private final ScrumTitleRepositoryPort scrumTitleRepositoryPort;
+    private final StarRecordCascadePort starRecordCascadePort;
+    private final StarImageCascadeCleaner starImageCascadeCleaner;
+
+    @Override
+    public void deleteScrum(DeleteScrumCommand command) {
+        Set<Long> scrumIds = Set.of(command.scrumId());
+
+        List<Scrum> owned = scrumQueryPort.findAllByIdInAndUserId(scrumIds, command.userId());
+        if (owned.isEmpty()) {
+            throw new BusinessException(ErrorCode.SCRUM_NOT_FOUND);
+        }
+        Long titleId = owned.get(0).getTitle().getId();
+
+        starImageCascadeCleaner.cleanupByScrumIds(scrumIds);
+        scrumWritePort.softDeleteAllByIdIn(scrumIds);
+        starRecordCascadePort.cascadeDeleteByScrumIdIn(scrumIds);
+        scrumTitleRepositoryPort.applyScrumCountIncrement(titleId, -1);
+    }
+}

--- a/src/test/java/com/groute/groute_server/record/application/service/DeleteScrumServiceTest.java
+++ b/src/test/java/com/groute/groute_server/record/application/service/DeleteScrumServiceTest.java
@@ -1,0 +1,174 @@
+package com.groute.groute_server.record.application.service;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.anyCollection;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+import java.util.List;
+import java.util.Set;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import com.groute.groute_server.common.exception.BusinessException;
+import com.groute.groute_server.common.exception.ErrorCode;
+import com.groute.groute_server.record.application.port.in.scrum.DeleteScrumCommand;
+import com.groute.groute_server.record.application.port.out.scrum.ScrumQueryPort;
+import com.groute.groute_server.record.application.port.out.scrum.ScrumWritePort;
+import com.groute.groute_server.record.application.port.out.scrumtitle.ScrumTitleRepositoryPort;
+import com.groute.groute_server.record.application.port.out.star.StarRecordCascadePort;
+import com.groute.groute_server.record.domain.Project;
+import com.groute.groute_server.record.domain.Scrum;
+import com.groute.groute_server.record.domain.ScrumTitle;
+import com.groute.groute_server.user.entity.User;
+
+@ExtendWith(MockitoExtension.class)
+class DeleteScrumServiceTest {
+
+    private static final Long USER_ID = 1L;
+    private static final Long SCRUM_ID = 10L;
+    private static final Long TITLE_ID = 100L;
+    private static final Set<Long> SCRUM_IDS = Set.of(SCRUM_ID);
+
+    @Mock ScrumQueryPort scrumQueryPort;
+    @Mock ScrumWritePort scrumWritePort;
+    @Mock ScrumTitleRepositoryPort scrumTitleRepositoryPort;
+    @Mock StarRecordCascadePort starRecordCascadePort;
+    @Mock StarImageCascadeCleaner starImageCascadeCleaner;
+
+    @InjectMocks DeleteScrumService service;
+
+    @Nested
+    @DisplayName("정상 삭제")
+    class HappyPath {
+
+        @Test
+        @DisplayName("hasStar=true 스크럼은 이미지 cleanup + soft-delete + STAR cascade + 카운터 -1을 모두 호출한다")
+        void should_softDeleteScrum_andCascadeStar_when_scrumHasStar() {
+            // given
+            ScrumTitle title = title(TITLE_ID);
+            Scrum scrum = scrum(SCRUM_ID, title, true);
+            given(scrumQueryPort.findAllByIdInAndUserId(SCRUM_IDS, USER_ID))
+                    .willReturn(List.of(scrum));
+
+            // when
+            assertThatCode(() -> service.deleteScrum(new DeleteScrumCommand(USER_ID, SCRUM_ID)))
+                    .doesNotThrowAnyException();
+
+            // then
+            verify(starImageCascadeCleaner).cleanupByScrumIds(SCRUM_IDS);
+            verify(scrumWritePort).softDeleteAllByIdIn(SCRUM_IDS);
+            verify(starRecordCascadePort).cascadeDeleteByScrumIdIn(SCRUM_IDS);
+            verify(scrumTitleRepositoryPort).applyScrumCountIncrement(TITLE_ID, -1);
+        }
+
+        @Test
+        @DisplayName("hasStar=false 스크럼도 동일하게 이미지 cleanup·cascade를 호출한다(빈 집합이라도 일관 호출)")
+        void should_softDeleteScrum_when_scrumWithoutStar() {
+            // given
+            ScrumTitle title = title(TITLE_ID);
+            Scrum scrum = scrum(SCRUM_ID, title, false);
+            given(scrumQueryPort.findAllByIdInAndUserId(SCRUM_IDS, USER_ID))
+                    .willReturn(List.of(scrum));
+
+            // when
+            service.deleteScrum(new DeleteScrumCommand(USER_ID, SCRUM_ID));
+
+            // then
+            verify(starImageCascadeCleaner).cleanupByScrumIds(SCRUM_IDS);
+            verify(scrumWritePort).softDeleteAllByIdIn(SCRUM_IDS);
+            verify(starRecordCascadePort).cascadeDeleteByScrumIdIn(SCRUM_IDS);
+            verify(scrumTitleRepositoryPort).applyScrumCountIncrement(TITLE_ID, -1);
+        }
+
+        @Test
+        @DisplayName("ScrumTitle.scrumCount는 정확히 1 감소(-1)만 호출된다")
+        void should_decrementScrumCount_byOne() {
+            // given
+            ScrumTitle title = title(TITLE_ID);
+            Scrum scrum = scrum(SCRUM_ID, title, false);
+            given(scrumQueryPort.findAllByIdInAndUserId(SCRUM_IDS, USER_ID))
+                    .willReturn(List.of(scrum));
+
+            // when
+            service.deleteScrum(new DeleteScrumCommand(USER_ID, SCRUM_ID));
+
+            // then
+            verify(scrumTitleRepositoryPort).applyScrumCountIncrement(TITLE_ID, -1);
+        }
+    }
+
+    @Nested
+    @DisplayName("예외")
+    class Errors {
+
+        @Test
+        @DisplayName("타 유저의 스크럼이면 SCRUM_NOT_FOUND를 던지고 어떤 쓰기도 하지 않는다")
+        void should_throwScrumNotFound_when_scrumNotOwnedByUser() {
+            // given — 본인 소유가 아니므로 쿼리 결과가 비어 있음
+            given(scrumQueryPort.findAllByIdInAndUserId(SCRUM_IDS, USER_ID)).willReturn(List.of());
+
+            // when & then
+            assertThatThrownBy(() -> service.deleteScrum(new DeleteScrumCommand(USER_ID, SCRUM_ID)))
+                    .isInstanceOf(BusinessException.class)
+                    .extracting("errorCode")
+                    .isEqualTo(ErrorCode.SCRUM_NOT_FOUND);
+            verifyNoWrites();
+        }
+
+        @Test
+        @DisplayName("미존재 scrumId면 SCRUM_NOT_FOUND를 던지고 어떤 쓰기도 하지 않는다")
+        void should_throwScrumNotFound_when_scrumDoesNotExist() {
+            // given
+            given(scrumQueryPort.findAllByIdInAndUserId(SCRUM_IDS, USER_ID)).willReturn(List.of());
+
+            // when & then
+            assertThatThrownBy(() -> service.deleteScrum(new DeleteScrumCommand(USER_ID, SCRUM_ID)))
+                    .isInstanceOf(BusinessException.class)
+                    .extracting("errorCode")
+                    .isEqualTo(ErrorCode.SCRUM_NOT_FOUND);
+            verifyNoWrites();
+        }
+
+        private void verifyNoWrites() {
+            verify(starImageCascadeCleaner, never()).cleanupByScrumIds(anyCollection());
+            verify(scrumWritePort, never()).softDeleteAllByIdIn(anyCollection());
+            verify(starRecordCascadePort, never()).cascadeDeleteByScrumIdIn(anyCollection());
+            verify(scrumTitleRepositoryPort, never()).applyScrumCountIncrement(anyLong(), anyInt());
+        }
+    }
+
+    // ============== helpers ==============
+
+    private static ScrumTitle title(Long id) {
+        Project project = Project.builder().id(1000L + id).name("P").build();
+        ScrumTitle title = new ScrumTitle();
+        ReflectionTestUtils.setField(title, "id", id);
+        ReflectionTestUtils.setField(title, "project", project);
+        ReflectionTestUtils.setField(title, "freeText", "F");
+        return title;
+    }
+
+    private static Scrum scrum(Long id, ScrumTitle title, boolean hasStar) {
+        Scrum scrum =
+                Scrum.create(
+                        User.createForSocialLogin(),
+                        title,
+                        "content",
+                        java.time.LocalDate.of(2026, 5, 4));
+        ReflectionTestUtils.setField(scrum, "id", id);
+        ReflectionTestUtils.setField(scrum, "hasStar", hasStar);
+        return scrum;
+    }
+}


### PR DESCRIPTION
## 요약
- 캘린더 상세 화면에서 스크럼 한 건만 자유롭게 삭제할 수 있도록 DELETE /api/scrums/{scrumId} 추가

## 변경 사항
- [x] 기능
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 문서
- [x] 테스트

## 세부내용
- DeleteScrumUseCase / DeleteScrumCommand 포트 추가
- DeleteScrumService 구현 (본인 소유 검증, STAR cascade, 이미지 cleanup, scrumCount -1)
- ScrumController에 DELETE /{scrumId} 엔드포인트 및 Swagger 문서 추가
- 14일 편집 윈도우와 hasStar 거부 정책은 적용하지 않음 (이슈 명세대로 제외)

## 테스트
- [x] 로컬 테스트 완료
- 테스트 방법:
    - ./gradlew test --tests "com.groute.groute_server.record.application.service.DeleteScrumServiceTest"
    - HappyPath 3건 + Errors 2건 모두 통과

### 커버리지 (JaCoCo)
- 라인 커버리지: DeleteScrumService 100% (10/10 lines, 44/44 instructions)
- [x] `./gradlew test` 실행 후 `build/reports/jacoco/index.html`에서 수치 확인

## 롤백/리스크
- 리스크 포인트: 없음 (신규 엔드포인트만 추가, 기존 API 동작 변경 없음)
- 롤백 방법: 커밋 4개 revert

## 관련 이슈
Closes #134

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 스크럼 삭제 기능 추가 - 사용자가 본인의 스크럼을 개별 삭제할 수 있습니다. 삭제 시 연관된 별표와 이미지도 함께 정리됩니다.

* **Tests**
  * 스크럼 삭제 기능에 대한 단위 테스트 추가 - 정상 삭제 및 권한 검증 시나리오를 포함합니다.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/2026-KUSITMS-GLIT/2026-KUSITMS-GLIT-BACK/pull/137?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->