### PR TITLE
feat: AI 태깅 결과 star_tags 저장 누락 수정

### DIFF
--- a/src/main/java/com/groute/groute_server/record/adapter/out/ai/AiTaggingClientAdapter.java
+++ b/src/main/java/com/groute/groute_server/record/adapter/out/ai/AiTaggingClientAdapter.java
@@ -99,15 +99,17 @@ public class AiTaggingClientAdapter implements AiTaggingClient {
         job.start(requestPayload);
         aiTaggingJobPort.saveJob(job);
 
+        AiTaggingResponse response;
         try {
-            AiTaggingResponse response = callFastApi(request);
+            response = callFastApi(request);
             job.succeed(toResponsePayload(response));
             aiTaggingJobPort.saveJob(job);
         } catch (BusinessException e) {
             handleFailure(job, e.getMessage(), request);
             return;
         }
-        completeAiTaggingUseCase.completeTagging(starRecord.getId());
+        completeAiTaggingUseCase.completeTagging(
+                starRecord.getId(), response.primaryCategory(), response.detailTags());
     }
 
     private Map<String, Object> toResponsePayload(AiTaggingResponse response) {
@@ -150,8 +152,9 @@ public class AiTaggingClientAdapter implements AiTaggingClient {
                     job.getStarRecord().getId());
             job.fail(errorMessage);
             aiTaggingJobPort.saveJob(job);
+            AiTaggingResponse response;
             try {
-                AiTaggingResponse response = callFastApi(request);
+                response = callFastApi(request);
                 job.succeed(toResponsePayload(response));
                 aiTaggingJobPort.saveJob(job);
             } catch (BusinessException retryEx) {
@@ -163,7 +166,8 @@ public class AiTaggingClientAdapter implements AiTaggingClient {
                 aiTaggingJobPort.saveJob(job);
                 return;
             }
-            completeAiTaggingUseCase.completeTagging(job.getStarRecord().getId());
+            completeAiTaggingUseCase.completeTagging(
+                    job.getStarRecord().getId(), response.primaryCategory(), response.detailTags());
         } else {
             log.error("[AI Tagging] 최종 실패 — jobId={}, error={}", job.getId(), errorMessage);
             job.fail(errorMessage);

--- a/src/main/java/com/groute/groute_server/record/adapter/out/ai/AiTaggingClientAdapter.java
+++ b/src/main/java/com/groute/groute_server/record/adapter/out/ai/AiTaggingClientAdapter.java
@@ -102,14 +102,14 @@ public class AiTaggingClientAdapter implements AiTaggingClient {
         AiTaggingResponse response;
         try {
             response = callFastApi(request);
-            job.succeed(toResponsePayload(response));
-            aiTaggingJobPort.saveJob(job);
         } catch (BusinessException e) {
             handleFailure(job, e.getMessage(), request);
             return;
         }
         completeAiTaggingUseCase.completeTagging(
                 starRecord.getId(), response.primaryCategory(), response.detailTags());
+        job.succeed(toResponsePayload(response));
+        aiTaggingJobPort.saveJob(job);
     }
 
     private Map<String, Object> toResponsePayload(AiTaggingResponse response) {
@@ -155,8 +155,6 @@ public class AiTaggingClientAdapter implements AiTaggingClient {
             AiTaggingResponse response;
             try {
                 response = callFastApi(request);
-                job.succeed(toResponsePayload(response));
-                aiTaggingJobPort.saveJob(job);
             } catch (BusinessException retryEx) {
                 log.error(
                         "[AI Tagging] 재시도 실패 확정 — jobId={}, error={}",
@@ -168,6 +166,8 @@ public class AiTaggingClientAdapter implements AiTaggingClient {
             }
             completeAiTaggingUseCase.completeTagging(
                     job.getStarRecord().getId(), response.primaryCategory(), response.detailTags());
+            job.succeed(toResponsePayload(response));
+            aiTaggingJobPort.saveJob(job);
         } else {
             log.error("[AI Tagging] 최종 실패 — jobId={}, error={}", job.getId(), errorMessage);
             job.fail(errorMessage);

--- a/src/main/java/com/groute/groute_server/record/adapter/out/persistence/StarTagPersistenceAdapter.java
+++ b/src/main/java/com/groute/groute_server/record/adapter/out/persistence/StarTagPersistenceAdapter.java
@@ -5,6 +5,7 @@ import java.util.List;
 import org.springframework.stereotype.Component;
 
 import com.groute.groute_server.record.application.port.out.star.StarTagQueryPort;
+import com.groute.groute_server.record.application.port.out.star.StarTagSavePort;
 import com.groute.groute_server.record.domain.StarTag;
 
 import lombok.RequiredArgsConstructor;
@@ -16,12 +17,17 @@ import lombok.RequiredArgsConstructor;
  */
 @Component
 @RequiredArgsConstructor
-class StarTagPersistenceAdapter implements StarTagQueryPort {
+class StarTagPersistenceAdapter implements StarTagQueryPort, StarTagSavePort {
 
     private final StarTagJpaRepository jpaRepository;
 
     @Override
     public List<StarTag> findAllByStarRecordId(Long starRecordId) {
         return jpaRepository.findAllByStarRecordId(starRecordId);
+    }
+
+    @Override
+    public void saveAll(List<StarTag> tags) {
+        jpaRepository.saveAll(tags);
     }
 }

--- a/src/main/java/com/groute/groute_server/record/application/port/in/CompleteAiTaggingUseCase.java
+++ b/src/main/java/com/groute/groute_server/record/application/port/in/CompleteAiTaggingUseCase.java
@@ -1,5 +1,7 @@
 package com.groute.groute_server.record.application.port.in;
 
+import java.util.List;
+
 /**
  * AI 태깅 완료 처리 유스케이스.
  *
@@ -8,5 +10,10 @@ package com.groute.groute_server.record.application.port.in;
  */
 public interface CompleteAiTaggingUseCase {
 
-    void completeTagging(Long starRecordId);
+    /**
+     * @param starRecordId 완료된 STAR 기록 ID
+     * @param primaryCategory AI가 추출한 대표 역량 (e.g. "PLANNING_EXECUTION")
+     * @param detailTags AI가 추출한 세부 태그 목록 (1~3개)
+     */
+    void completeTagging(Long starRecordId, String primaryCategory, List<String> detailTags);
 }

--- a/src/main/java/com/groute/groute_server/record/application/port/out/star/StarTagSavePort.java
+++ b/src/main/java/com/groute/groute_server/record/application/port/out/star/StarTagSavePort.java
@@ -1,0 +1,16 @@
+package com.groute.groute_server.record.application.port.out.star;
+
+import java.util.List;
+
+import com.groute.groute_server.record.domain.StarTag;
+
+/** StarTag 저장 포트. AI 태깅 완료 시 결과를 star_tags 테이블에 저장한다. */
+public interface StarTagSavePort {
+
+    /**
+     * StarTag 목록을 저장한다.
+     *
+     * @param tags 저장할 StarTag 목록
+     */
+    void saveAll(List<StarTag> tags);
+}

--- a/src/main/java/com/groute/groute_server/record/application/service/AiTaggingService.java
+++ b/src/main/java/com/groute/groute_server/record/application/service/AiTaggingService.java
@@ -22,10 +22,12 @@ import com.groute.groute_server.record.application.port.out.scrum.ScrumQueryPort
 import com.groute.groute_server.record.application.port.out.scrumtitle.ScrumTitleRepositoryPort;
 import com.groute.groute_server.record.application.port.out.star.StarRecordRepositoryPort;
 import com.groute.groute_server.record.application.port.out.star.StarTagQueryPort;
+import com.groute.groute_server.record.application.port.out.star.StarTagSavePort;
 import com.groute.groute_server.record.domain.AiTaggingJob;
 import com.groute.groute_server.record.domain.Scrum;
 import com.groute.groute_server.record.domain.StarRecord;
 import com.groute.groute_server.record.domain.StarTag;
+import com.groute.groute_server.record.domain.enums.CompetencyCategory;
 import com.groute.groute_server.record.domain.enums.JobStatus;
 import com.groute.groute_server.user.entity.User;
 
@@ -50,6 +52,7 @@ public class AiTaggingService
     private final StarRecordRepositoryPort starRecordPort;
     private final AiTaggingJobPort aiTaggingJobPort;
     private final StarTagQueryPort starTagPort;
+    private final StarTagSavePort starTagSavePort;
     private final ScrumQueryPort scrumQueryPort;
     private final ScrumTitleRepositoryPort scrumTitleRepositoryPort;
     private final UserPort userPort;
@@ -184,13 +187,22 @@ public class AiTaggingService
      */
     @Override
     @Transactional
-    public void completeTagging(Long starRecordId) {
+    public void completeTagging(
+            Long starRecordId, String primaryCategory, List<String> detailTags) {
         StarRecord record =
                 starRecordPort
                         .findByIdWithScrum(starRecordId)
                         .orElseThrow(() -> new BusinessException(ErrorCode.STAR_RECORD_NOT_FOUND));
 
         record.tag();
+
+        // star_tags 저장
+        CompetencyCategory category = CompetencyCategory.valueOf(primaryCategory);
+        List<StarTag> tags =
+                detailTags.stream()
+                        .map(detailTag -> StarTag.of(record, category, detailTag))
+                        .toList();
+        starTagSavePort.saveAll(tags);
 
         Long userId = record.getUser().getId();
         LocalDate date = record.getScrum().getScrumDate();

--- a/src/main/java/com/groute/groute_server/record/application/service/AiTaggingService.java
+++ b/src/main/java/com/groute/groute_server/record/application/service/AiTaggingService.java
@@ -197,12 +197,30 @@ public class AiTaggingService
         record.tag();
 
         // star_tags 저장
-        CompetencyCategory category = CompetencyCategory.valueOf(primaryCategory);
-        List<StarTag> tags =
-                detailTags.stream()
-                        .map(detailTag -> StarTag.of(record, category, detailTag))
-                        .toList();
-        starTagSavePort.saveAll(tags);
+        if (primaryCategory == null || primaryCategory.isBlank()) {
+            log.warn(
+                    "[AI Tagging] primaryCategory가 비어있어 star_tags 저장 생략 — starRecordId={}",
+                    starRecordId);
+        } else {
+            CompetencyCategory category;
+            try {
+                category = CompetencyCategory.valueOf(primaryCategory);
+            } catch (IllegalArgumentException e) {
+                log.warn(
+                        "[AI Tagging] primaryCategory 값 불일치 — value={}, starRecordId={}",
+                        primaryCategory,
+                        starRecordId);
+                category = null;
+            }
+            if (category != null && detailTags != null && !detailTags.isEmpty()) {
+                final CompetencyCategory finalCategory = category;
+                List<StarTag> tags =
+                        detailTags.stream()
+                                .map(detailTag -> StarTag.of(record, finalCategory, detailTag))
+                                .toList();
+                starTagSavePort.saveAll(tags);
+            }
+        }
 
         Long userId = record.getUser().getId();
         LocalDate date = record.getScrum().getScrumDate();

--- a/src/main/java/com/groute/groute_server/record/domain/StarTag.java
+++ b/src/main/java/com/groute/groute_server/record/domain/StarTag.java
@@ -35,4 +35,20 @@ public class StarTag extends BaseTimeEntity {
     /** 세부 태그. AI가 자유롭게 생성(예: "이해관계자 조율"). REC007 완료 화면에 최대 3개 노출. */
     @Column(name = "detail_tag", nullable = false, length = 50)
     private String detailTag;
+
+    /**
+     * StarTag 생성 팩토리 메서드.
+     *
+     * @param starRecord 연결된 STAR 기록
+     * @param primaryCategory 대표 역량
+     * @param detailTag 세부 태그
+     */
+    public static StarTag of(
+            StarRecord starRecord, CompetencyCategory primaryCategory, String detailTag) {
+        StarTag tag = new StarTag();
+        tag.starRecord = starRecord;
+        tag.primaryCategory = primaryCategory;
+        tag.detailTag = detailTag;
+        return tag;
+    }
 }


### PR DESCRIPTION
## 요약
- AI 태깅 완료 후 star_tags 테이블에 결과가 저장되지 않아 태깅 결과 조회 API(REC-007)가 항상 404를 반환하던 문제 수정

## 상세내용
CompleteAiTaggingUseCase.completeTagging() 시그니처에 primaryCategory, detailTags 파라미터 추가
StarTagSavePort 인터페이스 및 StarTagPersistenceAdapter 구현체 추가
StarTag.of() 팩토리 메서드 추가
AiTaggingService.completeTagging()에서 AI 응답 파싱 후 star_tags 저장
AiTaggingClientAdapter에서 AI 응답을 completeTagging()에 전달하도록 수정 

⚠️ 이 PR은 #133 을 base로 작성되었습니다

## 변경 사항
- [x] 기능
- [x] 버그 수정
- [ ] 리팩토링
- [ ] 문서
- [ ] 테스트
- [ ] 기타

## 테스트
- [x] 로컬 테스트 완료
- 테스트 방법:
    - swagger 테스트
    - 트리거 API 호출 후 star_tags 테이블에 태그 저장 확인
    - 태깅 결과 조회 API(REC-007) 정상 응답 확인

### 커버리지 (JaCoCo)
- 라인 커버리지: __%  (기준: 60% 이상)
- [ ] `./gradlew test` 실행 후 `build/reports/jacoco/index.html`에서 수치 확인
- (선택) 리포트 스크린샷 또는 60% 미달/특이사항 공유:

## 스크린샷/로그 (선택)
- 필요한 경우 첨부

## 롤백/리스크
- 리스크 포인트:
- 롤백 방법:

## 관련 이슈
Closes #136 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **개선사항**
  * AI 태깅 결과에 카테고리 및 상세 태그 정보가 함께 저장되도록 개선했습니다.
  * 태그 저장 처리 흐름 및 배치 저장 기능을 최적화했습니다.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/2026-KUSITMS-GLIT/2026-KUSITMS-GLIT-BACK/pull/138?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->