### PR TITLE
feat: 스크럼 제목 단위 삭제 API

### DIFF
--- a/src/main/java/com/groute/groute_server/record/adapter/in/web/ScrumController.java
+++ b/src/main/java/com/groute/groute_server/record/adapter/in/web/ScrumController.java
@@ -26,6 +26,8 @@ import com.groute.groute_server.record.application.port.in.scrum.DeleteScrumComm
 import com.groute.groute_server.record.application.port.in.scrum.DeleteScrumUseCase;
 import com.groute.groute_server.record.application.port.in.scrum.SyncDailyScrumUseCase;
 import com.groute.groute_server.record.application.port.in.scrum.UpdateScrumCompetencyUseCase;
+import com.groute.groute_server.record.application.port.in.scrumtitle.DeleteScrumTitleCommand;
+import com.groute.groute_server.record.application.port.in.scrumtitle.DeleteScrumTitleUseCase;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
@@ -42,6 +44,7 @@ public class ScrumController {
     private final BulkWriteScrumUseCase bulkWriteScrumUseCase;
     private final UpdateScrumCompetencyUseCase updateScrumCompetencyUseCase;
     private final DeleteScrumUseCase deleteScrumUseCase;
+    private final DeleteScrumTitleUseCase deleteScrumTitleUseCase;
 
     @Operation(
             summary = "스크럼 일괄 저장",
@@ -146,5 +149,29 @@ public class ScrumController {
     public ApiResponse<Void> deleteScrum(@CurrentUser Long userId, @PathVariable Long scrumId) {
         deleteScrumUseCase.deleteScrum(new DeleteScrumCommand(userId, scrumId));
         return ApiResponse.ok("스크럼 삭제 성공");
+    }
+
+    @Operation(
+            summary = "스크럼 제목(freeText) 단위 일괄 삭제",
+            description =
+                    "지정 titleId 산하의 모든 Scrum을 soft-delete 하고 연결된 STAR 기록·첨부 이미지도 함께 cascade 삭제한다."
+                            + " ScrumTitle 자체도 soft-delete 된다. 14일 편집 윈도우와 hasStar 거부 정책은 적용하지 않으며,"
+                            + " 빈 산하(Scrum 0개) ScrumTitle도 정상 처리된다.")
+    @ApiResponses({
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                responseCode = "200",
+                description = "삭제 성공"),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                responseCode = "401",
+                description = "미인증 또는 만료된 액세스 토큰"),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                responseCode = "404",
+                description = "titleId가 본인 소유가 아니거나 존재하지 않음")
+    })
+    @DeleteMapping("/titles/{titleId}")
+    public ApiResponse<Void> deleteScrumTitle(
+            @CurrentUser Long userId, @PathVariable Long titleId) {
+        deleteScrumTitleUseCase.deleteScrumTitle(new DeleteScrumTitleCommand(userId, titleId));
+        return ApiResponse.ok("freeText 삭제 성공");
     }
 }

--- a/src/main/java/com/groute/groute_server/record/adapter/out/persistence/ScrumJpaRepository.java
+++ b/src/main/java/com/groute/groute_server/record/adapter/out/persistence/ScrumJpaRepository.java
@@ -38,6 +38,13 @@ public interface ScrumJpaRepository extends JpaRepository<Scrum, Long> {
     List<Scrum> findAllByIdInAndUserId(
             @Param("ids") Collection<Long> ids, @Param("userId") Long userId);
 
+    /** 특정 ScrumTitle 산하 본인 소유 Scrum 전체. 제목 단위 일괄 삭제 cascade 수집용. */
+    @Query(
+            "SELECT s FROM Scrum s "
+                    + "WHERE s.title.id = :titleId AND s.user.id = :userId AND s.isDeleted = false")
+    List<Scrum> findAllByTitleIdAndUserId(
+            @Param("titleId") Long titleId, @Param("userId") Long userId);
+
     boolean existsByUserIdAndScrumDateAndIsDeletedFalse(Long userId, LocalDate scrumDate);
 
     /** 본문 변경. 호출자가 14일·hasStar 검증 선행. */

--- a/src/main/java/com/groute/groute_server/record/adapter/out/persistence/ScrumPersistenceAdapter.java
+++ b/src/main/java/com/groute/groute_server/record/adapter/out/persistence/ScrumPersistenceAdapter.java
@@ -38,6 +38,11 @@ class ScrumPersistenceAdapter implements ScrumQueryPort, ScrumWritePort {
     }
 
     @Override
+    public List<Scrum> findAllByTitleIdAndUserId(Long titleId, Long userId) {
+        return jpaRepository.findAllByTitleIdAndUserId(titleId, userId);
+    }
+
+    @Override
     public List<Scrum> saveAll(Collection<Scrum> scrums) {
         if (scrums.isEmpty()) {
             return List.of();

--- a/src/main/java/com/groute/groute_server/record/application/port/in/scrumtitle/DeleteScrumTitleCommand.java
+++ b/src/main/java/com/groute/groute_server/record/application/port/in/scrumtitle/DeleteScrumTitleCommand.java
@@ -1,0 +1,4 @@
+package com.groute.groute_server.record.application.port.in.scrumtitle;
+
+/** 스크럼 제목(freeText) 단위 일괄 삭제 입력. */
+public record DeleteScrumTitleCommand(Long userId, Long titleId) {}

--- a/src/main/java/com/groute/groute_server/record/application/port/in/scrumtitle/DeleteScrumTitleUseCase.java
+++ b/src/main/java/com/groute/groute_server/record/application/port/in/scrumtitle/DeleteScrumTitleUseCase.java
@@ -1,0 +1,12 @@
+package com.groute.groute_server.record.application.port.in.scrumtitle;
+
+/**
+ * 스크럼 제목(freeText) 단위 일괄 삭제 유스케이스 (DELETE /api/scrums/titles/{titleId}).
+ *
+ * <p>지정 ScrumTitle 산하의 모든 Scrum을 soft-delete 하고 연결된 STAR·첨부 이미지를 cascade 정리한 뒤 ScrumTitle 자체도
+ * soft-delete 한다. 14일 편집 윈도우와 hasStar 거부 정책은 적용하지 않는다.
+ */
+public interface DeleteScrumTitleUseCase {
+
+    void deleteScrumTitle(DeleteScrumTitleCommand command);
+}

--- a/src/main/java/com/groute/groute_server/record/application/port/out/scrum/ScrumQueryPort.java
+++ b/src/main/java/com/groute/groute_server/record/application/port/out/scrum/ScrumQueryPort.java
@@ -14,4 +14,7 @@ public interface ScrumQueryPort {
 
     /** 요청 scrumId 중 본인 소유인 것만 반환. 결과 크기로 미존재/타인 소유 판별. */
     List<Scrum> findAllByIdInAndUserId(Collection<Long> ids, Long userId);
+
+    /** 특정 ScrumTitle 산하의 본인 소유 Scrum 전체. 제목 단위 일괄 삭제 시 cascade 대상 수집용. */
+    List<Scrum> findAllByTitleIdAndUserId(Long titleId, Long userId);
 }

--- a/src/main/java/com/groute/groute_server/record/application/service/DeleteScrumTitleService.java
+++ b/src/main/java/com/groute/groute_server/record/application/service/DeleteScrumTitleService.java
@@ -1,0 +1,59 @@
+package com.groute.groute_server.record.application.service;
+
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.groute.groute_server.common.exception.BusinessException;
+import com.groute.groute_server.common.exception.ErrorCode;
+import com.groute.groute_server.record.application.port.in.scrumtitle.DeleteScrumTitleCommand;
+import com.groute.groute_server.record.application.port.in.scrumtitle.DeleteScrumTitleUseCase;
+import com.groute.groute_server.record.application.port.out.scrum.ScrumQueryPort;
+import com.groute.groute_server.record.application.port.out.scrum.ScrumWritePort;
+import com.groute.groute_server.record.application.port.out.scrumtitle.ScrumTitleRepositoryPort;
+import com.groute.groute_server.record.application.port.out.star.StarRecordCascadePort;
+import com.groute.groute_server.record.domain.Scrum;
+
+import lombok.RequiredArgsConstructor;
+
+/**
+ * 스크럼 제목(freeText) 단위 일괄 삭제 서비스.
+ *
+ * <p>지정 ScrumTitle 산하의 모든 Scrum을 soft-delete 하고 연결된 STAR·첨부 이미지를 cascade 정리한 뒤 ScrumTitle 자체도
+ * soft-delete 한다. 14일 편집 윈도우와 hasStar 거부 정책은 적용하지 않으며, 빈 산하(Scrum 0개) ScrumTitle도 정상 처리한다.
+ * ScrumTitle.scrumCount는 별도 보정하지 않는다(Title 자체가 soft-delete 되어 어떤 reader도 참조하지 않음).
+ */
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class DeleteScrumTitleService implements DeleteScrumTitleUseCase {
+
+    private final ScrumTitleRepositoryPort scrumTitleRepositoryPort;
+    private final ScrumQueryPort scrumQueryPort;
+    private final ScrumWritePort scrumWritePort;
+    private final StarRecordCascadePort starRecordCascadePort;
+    private final StarImageCascadeCleaner starImageCascadeCleaner;
+
+    @Override
+    public void deleteScrumTitle(DeleteScrumTitleCommand command) {
+        Long titleId = command.titleId();
+        Long userId = command.userId();
+
+        if (scrumTitleRepositoryPort.findAllByIdInAndUserId(Set.of(titleId), userId).isEmpty()) {
+            throw new BusinessException(ErrorCode.TITLE_NOT_FOUND);
+        }
+
+        List<Scrum> scrums = scrumQueryPort.findAllByTitleIdAndUserId(titleId, userId);
+        if (!scrums.isEmpty()) {
+            Set<Long> scrumIds = scrums.stream().map(Scrum::getId).collect(Collectors.toSet());
+            starImageCascadeCleaner.cleanupByScrumIds(scrumIds);
+            scrumWritePort.softDeleteAllByIdIn(scrumIds);
+            starRecordCascadePort.cascadeDeleteByScrumIdIn(scrumIds);
+        }
+
+        scrumTitleRepositoryPort.softDeleteAllByIds(List.of(titleId));
+    }
+}

--- a/src/test/java/com/groute/groute_server/record/application/service/DeleteScrumTitleServiceTest.java
+++ b/src/test/java/com/groute/groute_server/record/application/service/DeleteScrumTitleServiceTest.java
@@ -1,0 +1,196 @@
+package com.groute.groute_server.record.application.service;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.anyCollection;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Set;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import com.groute.groute_server.common.exception.BusinessException;
+import com.groute.groute_server.common.exception.ErrorCode;
+import com.groute.groute_server.record.application.port.in.scrumtitle.DeleteScrumTitleCommand;
+import com.groute.groute_server.record.application.port.out.scrum.ScrumQueryPort;
+import com.groute.groute_server.record.application.port.out.scrum.ScrumWritePort;
+import com.groute.groute_server.record.application.port.out.scrumtitle.ScrumTitleRepositoryPort;
+import com.groute.groute_server.record.application.port.out.star.StarRecordCascadePort;
+import com.groute.groute_server.record.domain.Project;
+import com.groute.groute_server.record.domain.Scrum;
+import com.groute.groute_server.record.domain.ScrumTitle;
+import com.groute.groute_server.user.entity.User;
+
+@ExtendWith(MockitoExtension.class)
+class DeleteScrumTitleServiceTest {
+
+    private static final Long USER_ID = 1L;
+    private static final Long TITLE_ID = 100L;
+    private static final Set<Long> TITLE_IDS = Set.of(TITLE_ID);
+
+    @Mock ScrumTitleRepositoryPort scrumTitleRepositoryPort;
+    @Mock ScrumQueryPort scrumQueryPort;
+    @Mock ScrumWritePort scrumWritePort;
+    @Mock StarRecordCascadePort starRecordCascadePort;
+    @Mock StarImageCascadeCleaner starImageCascadeCleaner;
+
+    @InjectMocks DeleteScrumTitleService service;
+
+    @Nested
+    @DisplayName("정상 삭제")
+    class HappyPath {
+
+        @Test
+        @DisplayName(
+                "산하 Scrum이 있으면 이미지 cleanup·scrum soft-delete·STAR cascade·title soft-delete를 모두 호출한다")
+        void should_softDeleteAllScrums_andTitle_when_titleHasScrums() {
+            // given
+            ScrumTitle title = title(TITLE_ID);
+            Scrum s1 = scrum(10L, title, false);
+            Scrum s2 = scrum(11L, title, false);
+            given(scrumTitleRepositoryPort.findAllByIdInAndUserId(TITLE_IDS, USER_ID))
+                    .willReturn(List.of(title));
+            given(scrumQueryPort.findAllByTitleIdAndUserId(TITLE_ID, USER_ID))
+                    .willReturn(List.of(s1, s2));
+
+            // when
+            assertThatCode(
+                            () ->
+                                    service.deleteScrumTitle(
+                                            new DeleteScrumTitleCommand(USER_ID, TITLE_ID)))
+                    .doesNotThrowAnyException();
+
+            // then
+            Set<Long> expectedScrumIds = Set.of(10L, 11L);
+            verify(starImageCascadeCleaner).cleanupByScrumIds(expectedScrumIds);
+            verify(scrumWritePort).softDeleteAllByIdIn(expectedScrumIds);
+            verify(starRecordCascadePort).cascadeDeleteByScrumIdIn(expectedScrumIds);
+            verify(scrumTitleRepositoryPort).softDeleteAllByIds(List.of(TITLE_ID));
+        }
+
+        @Test
+        @DisplayName("산하 Scrum이 0개면 cleanup·soft-delete·cascade는 호출하지 않고 title만 삭제한다")
+        void should_softDeleteTitleOnly_when_titleHasNoScrums() {
+            // given
+            ScrumTitle title = title(TITLE_ID);
+            given(scrumTitleRepositoryPort.findAllByIdInAndUserId(TITLE_IDS, USER_ID))
+                    .willReturn(List.of(title));
+            given(scrumQueryPort.findAllByTitleIdAndUserId(TITLE_ID, USER_ID))
+                    .willReturn(List.of());
+
+            // when
+            service.deleteScrumTitle(new DeleteScrumTitleCommand(USER_ID, TITLE_ID));
+
+            // then
+            verify(starImageCascadeCleaner, never()).cleanupByScrumIds(anyCollection());
+            verify(scrumWritePort, never()).softDeleteAllByIdIn(anyCollection());
+            verify(starRecordCascadePort, never()).cascadeDeleteByScrumIdIn(anyCollection());
+            verify(scrumTitleRepositoryPort).softDeleteAllByIds(List.of(TITLE_ID));
+        }
+
+        @Test
+        @DisplayName("산하에 hasStar=true 스크럼이 있어도 동일하게 STAR cascade를 호출한다")
+        void should_cascadeStar_when_anyScrumHasStar() {
+            // given
+            ScrumTitle title = title(TITLE_ID);
+            Scrum starred = scrum(10L, title, true);
+            Scrum plain = scrum(11L, title, false);
+            given(scrumTitleRepositoryPort.findAllByIdInAndUserId(TITLE_IDS, USER_ID))
+                    .willReturn(List.of(title));
+            given(scrumQueryPort.findAllByTitleIdAndUserId(TITLE_ID, USER_ID))
+                    .willReturn(List.of(starred, plain));
+
+            // when
+            service.deleteScrumTitle(new DeleteScrumTitleCommand(USER_ID, TITLE_ID));
+
+            // then
+            Set<Long> expectedScrumIds = Set.of(10L, 11L);
+            verify(starImageCascadeCleaner).cleanupByScrumIds(expectedScrumIds);
+            verify(scrumWritePort).softDeleteAllByIdIn(expectedScrumIds);
+            verify(starRecordCascadePort).cascadeDeleteByScrumIdIn(expectedScrumIds);
+            verify(scrumTitleRepositoryPort).softDeleteAllByIds(List.of(TITLE_ID));
+        }
+    }
+
+    @Nested
+    @DisplayName("예외")
+    class Errors {
+
+        @Test
+        @DisplayName("타 유저의 titleId면 TITLE_NOT_FOUND를 던지고 어떤 쓰기도 하지 않는다")
+        void should_throwTitleNotFound_when_titleNotOwnedByUser() {
+            // given
+            given(scrumTitleRepositoryPort.findAllByIdInAndUserId(TITLE_IDS, USER_ID))
+                    .willReturn(List.of());
+
+            // when & then
+            assertThatThrownBy(
+                            () ->
+                                    service.deleteScrumTitle(
+                                            new DeleteScrumTitleCommand(USER_ID, TITLE_ID)))
+                    .isInstanceOf(BusinessException.class)
+                    .extracting("errorCode")
+                    .isEqualTo(ErrorCode.TITLE_NOT_FOUND);
+            verifyNoWrites();
+        }
+
+        @Test
+        @DisplayName("미존재 titleId면 TITLE_NOT_FOUND를 던지고 어떤 쓰기도 하지 않는다")
+        void should_throwTitleNotFound_when_titleDoesNotExist() {
+            // given
+            given(scrumTitleRepositoryPort.findAllByIdInAndUserId(TITLE_IDS, USER_ID))
+                    .willReturn(List.of());
+
+            // when & then
+            assertThatThrownBy(
+                            () ->
+                                    service.deleteScrumTitle(
+                                            new DeleteScrumTitleCommand(USER_ID, TITLE_ID)))
+                    .isInstanceOf(BusinessException.class)
+                    .extracting("errorCode")
+                    .isEqualTo(ErrorCode.TITLE_NOT_FOUND);
+            verifyNoWrites();
+        }
+
+        private void verifyNoWrites() {
+            verify(starImageCascadeCleaner, never()).cleanupByScrumIds(anyCollection());
+            verify(scrumWritePort, never()).softDeleteAllByIdIn(anyCollection());
+            verify(starRecordCascadePort, never()).cascadeDeleteByScrumIdIn(anyCollection());
+            verify(scrumTitleRepositoryPort, never()).softDeleteAllByIds(anyList());
+            verify(scrumQueryPort, never()).findAllByTitleIdAndUserId(anyLong(), anyLong());
+        }
+    }
+
+    // ============== helpers ==============
+
+    private static ScrumTitle title(Long id) {
+        Project project = Project.builder().id(1000L + id).name("P").build();
+        ScrumTitle title = new ScrumTitle();
+        ReflectionTestUtils.setField(title, "id", id);
+        ReflectionTestUtils.setField(title, "project", project);
+        ReflectionTestUtils.setField(title, "freeText", "F");
+        return title;
+    }
+
+    private static Scrum scrum(Long id, ScrumTitle title, boolean hasStar) {
+        Scrum scrum =
+                Scrum.create(
+                        User.createForSocialLogin(), title, "content", LocalDate.of(2026, 5, 23));
+        ReflectionTestUtils.setField(scrum, "id", id);
+        ReflectionTestUtils.setField(scrum, "hasStar", hasStar);
+        return scrum;
+    }
+}


### PR DESCRIPTION
## 요약
- freeText(ScrumTitle) 단위로 산하 스크럼·STAR를 한 번에 정리하는 DELETE /api/scrums/titles/{titleId} 추가

## 변경 사항
- [x] 기능
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 문서
- [x] 테스트

## 세부내용
- DeleteScrumTitleUseCase / DeleteScrumTitleCommand 포트 신설 (port/in/scrumtitle 패키지)
- ScrumQueryPort·Adapter·JpaRepository에 findAllByTitleIdAndUserId 추가
- DeleteScrumTitleService 구현: title 소유 검증 후 산하 Scrum 조회, 이미지 cleanup, Scrum soft-delete, STAR cascade, Title soft-delete
- ScrumController에 sub-resource 엔드포인트 추가 (기존 /api/scrums/{scrumId}와 라우팅 충돌 없음)
- 빈 산하(Scrum 0개) Title 삭제 케이스 정상 처리
- 14일 편집 윈도우, hasStar 거부 정책은 적용하지 않음 (이슈 명세대로)

## 테스트
- [x] 로컬 테스트 완료
- 테스트 방법:
    - ./gradlew test --tests "com.groute.groute_server.record.application.service.DeleteScrumTitleServiceTest"
    - HappyPath 3건 + Errors 2건 모두 통과

### 커버리지 (JaCoCo)
- 라인 커버리지: DeleteScrumTitleService 100% (12/12 lines, 55/55 instructions, 4/4 branches)
- [x] `./gradlew test` 실행 후 `build/reports/jacoco/index.html`에서 수치 확인

## 롤백/리스크
- 리스크 포인트: 없음 (신규 엔드포인트만 추가)
- 롤백 방법: 커밋 5개 revert

## 관련 이슈
Closes #135

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * 스크럼 제목 단위로 해당 제목 아래의 모든 스크럼 및 관련 리소스를 일괄 삭제할 수 있는 기능이 추가되었습니다.

* **Tests**
  * 스크럼 제목 삭제 기능의 정상 작동 및 오류 처리를 검증하는 포괄적인 테스트가 추가되었습니다.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/2026-KUSITMS-GLIT/2026-KUSITMS-GLIT-BACK/pull/139?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->