### PR TITLE
fix: 리포트 AI 응답 DTO camelCase 불일치 및 Lazy 로딩 오류 수정 

### DIFF
--- a/src/main/java/com/groute/groute_server/report/adapter/out/ai/AiReportClientAdapter.java
+++ b/src/main/java/com/groute/groute_server/report/adapter/out/ai/AiReportClientAdapter.java
@@ -116,10 +116,10 @@ public class AiReportClientAdapter implements RequestAiReportPort {
                             .body(AiMiniReportResponse.class);
 
             Map<String, Object> contentJson = new HashMap<>();
-            contentJson.put("activity_summary", response.activitySummary());
-            contentJson.put("next_focus_point", response.nextFocusPoint());
-            contentJson.put("competency_frequency", response.competencyFrequency());
-            contentJson.put("top_detail_tags", response.topDetailTags());
+            contentJson.put("activitySummary", response.activitySummary());
+            contentJson.put("nextFocusPoint", response.nextFocusPoint());
+            contentJson.put("competencyFrequency", response.competencyFrequency());
+            contentJson.put("topDetailTags", response.topDetailTags());
 
             return new AiReportResult(null, contentJson);
         } catch (ResourceAccessException e) {
@@ -174,13 +174,13 @@ public class AiReportClientAdapter implements RequestAiReportPort {
                             .body(AiCareerStrengthsAndInterviewResponse.class);
 
             Map<String, Object> contentJson = new HashMap<>();
-            contentJson.put("branding_statement", branding.brandingStatement());
-            contentJson.put("branding_pattern", branding.brandingPattern());
-            contentJson.put("top_detail_tags", branding.topDetailTags());
-            contentJson.put("narrative_summary", narrative.narrativeSummary());
-            contentJson.put("experience_highlights", highlights.experienceHighlights());
+            contentJson.put("brandingStatement", branding.brandingStatement());
+            contentJson.put("brandingPattern", branding.brandingPattern());
+            contentJson.put("topDetailTags", branding.topDetailTags());
+            contentJson.put("narrativeSummary", narrative.narrativeSummary());
+            contentJson.put("experienceHighlights", highlights.experienceHighlights());
             contentJson.put("strengths", strengthsAndInterview.strengths());
-            contentJson.put("interview_questions", strengthsAndInterview.interviewQuestions());
+            contentJson.put("interviewQuestions", strengthsAndInterview.interviewQuestions());
 
             return new AiReportResult(branding.brandingStatement(), contentJson);
         } catch (ResourceAccessException e) {

--- a/src/main/java/com/groute/groute_server/report/adapter/out/ai/dto/AiCareerBrandingResponse.java
+++ b/src/main/java/com/groute/groute_server/report/adapter/out/ai/dto/AiCareerBrandingResponse.java
@@ -6,9 +6,9 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 
 /** FastAPI /api/reports/career/branding 응답. */
 public record AiCareerBrandingResponse(
-        @JsonProperty("branding_statement") String brandingStatement,
-        @JsonProperty("branding_pattern") String brandingPattern,
-        @JsonProperty("top_detail_tags") List<DetailTagStat> topDetailTags) {
+        @JsonProperty("brandingStatement") String brandingStatement,
+        @JsonProperty("brandingPattern") String brandingPattern,
+        @JsonProperty("topDetailTags") List<DetailTagStat> topDetailTags) {
 
     public record DetailTagStat(String tag, int count) {}
 }

--- a/src/main/java/com/groute/groute_server/report/adapter/out/ai/dto/AiCareerHighlightsResponse.java
+++ b/src/main/java/com/groute/groute_server/report/adapter/out/ai/dto/AiCareerHighlightsResponse.java
@@ -6,4 +6,4 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 
 /** FastAPI /api/reports/career/highlights 응답. */
 public record AiCareerHighlightsResponse(
-        @JsonProperty("experience_highlights") List<String> experienceHighlights) {}
+        @JsonProperty("experienceHighlights") List<String> experienceHighlights) {}

--- a/src/main/java/com/groute/groute_server/report/adapter/out/ai/dto/AiCareerNarrativeResponse.java
+++ b/src/main/java/com/groute/groute_server/report/adapter/out/ai/dto/AiCareerNarrativeResponse.java
@@ -4,4 +4,4 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 
 /** FastAPI /api/reports/career/narrative 응답. */
 public record AiCareerNarrativeResponse(
-        @JsonProperty("narrative_summary") String narrativeSummary) {}
+        @JsonProperty("narrativeSummary") String narrativeSummary) {}

--- a/src/main/java/com/groute/groute_server/report/adapter/out/ai/dto/AiCareerStrengthsAndInterviewResponse.java
+++ b/src/main/java/com/groute/groute_server/report/adapter/out/ai/dto/AiCareerStrengthsAndInterviewResponse.java
@@ -7,7 +7,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 /** FastAPI /api/reports/career/strengths-and-interview 응답. */
 public record AiCareerStrengthsAndInterviewResponse(
         List<StrengthItem> strengths,
-        @JsonProperty("interview_questions") List<InterviewQuestion> interviewQuestions) {
+        @JsonProperty("interviewQuestions") List<InterviewQuestion> interviewQuestions) {
 
     public record StrengthItem(String title, String description, List<EvidenceItem> evidences) {}
 
@@ -15,7 +15,7 @@ public record AiCareerStrengthsAndInterviewResponse(
 
     public record EvidenceItem(
             int id,
-            @JsonProperty("project_name") String projectName,
-            @JsonProperty("scrum_title") String scrumTitle,
-            @JsonProperty("created_at") String createdAt) {}
+            @JsonProperty("projectName") String projectName,
+            @JsonProperty("scrumTitle") String scrumTitle,
+            @JsonProperty("createdAt") String createdAt) {}
 }

--- a/src/main/java/com/groute/groute_server/report/adapter/out/ai/dto/AiMiniReportResponse.java
+++ b/src/main/java/com/groute/groute_server/report/adapter/out/ai/dto/AiMiniReportResponse.java
@@ -6,10 +6,10 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 
 /** FastAPI /api/reports/mini 응답. */
 public record AiMiniReportResponse(
-        @JsonProperty("activity_summary") String activitySummary,
-        @JsonProperty("next_focus_point") String nextFocusPoint,
-        @JsonProperty("competency_frequency") List<CompetencyCount> competencyFrequency,
-        @JsonProperty("top_detail_tags") List<String> topDetailTags) {
+        @JsonProperty("activitySummary") String activitySummary,
+        @JsonProperty("nextFocusPoint") String nextFocusPoint,
+        @JsonProperty("competencyFrequency") List<CompetencyCount> competencyFrequency,
+        @JsonProperty("topDetailTags") List<String> topDetailTags) {
 
     public record CompetencyCount(String competency, int count) {}
 }

--- a/src/main/java/com/groute/groute_server/report/adapter/out/ai/dto/AiReportRequest.java
+++ b/src/main/java/com/groute/groute_server/report/adapter/out/ai/dto/AiReportRequest.java
@@ -10,26 +10,26 @@ public record AiReportRequest(
         String job,
         String status,
         List<StarRecordItem> records,
-        @JsonProperty("scrums_by_date") List<ScrumsByDate> scrumsByDate,
-        @JsonProperty("record_period") RecordPeriod recordPeriod,
-        @JsonProperty("total_count") int totalCount) {
+        @JsonProperty("scrumsByDate") List<ScrumsByDate> scrumsByDate,
+        @JsonProperty("recordPeriod") RecordPeriod recordPeriod,
+        @JsonProperty("totalCount") int totalCount) {
 
     public record StarRecordItem(
-            @JsonProperty("star_record_id") Long starRecordId,
-            @JsonProperty("situation_task") String situationTask,
+            @JsonProperty("starRecordId") Long starRecordId,
+            @JsonProperty("situationTask") String situationTask,
             String action,
             String result,
-            @JsonProperty("completed_at") String completedAt,
+            @JsonProperty("completedAt") String completedAt,
             String competency,
-            @JsonProperty("detail_tags") List<String> detailTags) {}
+            @JsonProperty("detailTags") List<String> detailTags) {}
 
     public record ScrumsByDate(String date, List<ScrumItem> scrums) {
 
         public record ScrumItem(
-                @JsonProperty("project_name") String projectName,
-                @JsonProperty("scrum_title") String scrumTitle,
+                @JsonProperty("projectName") String projectName,
+                @JsonProperty("scrumTitle") String scrumTitle,
                 String content,
-                @JsonProperty("star_record_id") Long starRecordId) {}
+                @JsonProperty("starRecordId") Long starRecordId) {}
     }
 
     public record RecordPeriod(@JsonProperty("from") String from, String to) {}

--- a/src/main/java/com/groute/groute_server/report/adapter/out/persistence/ScrumForReportJpaRepository.java
+++ b/src/main/java/com/groute/groute_server/report/adapter/out/persistence/ScrumForReportJpaRepository.java
@@ -22,6 +22,8 @@ public interface ScrumForReportJpaRepository extends JpaRepository<Scrum, Long> 
      */
     @Query(
             "SELECT s FROM Scrum s "
+                    + "JOIN FETCH s.title t "
+                    + "JOIN FETCH t.project "
                     + "WHERE s.user.id = :userId "
                     + "AND s.scrumDate IN ("
                     + "  SELECT sr.scrum.scrumDate FROM StarRecord sr "

--- a/src/main/java/com/groute/groute_server/report/application/port/in/dto/ReportListView.java
+++ b/src/main/java/com/groute/groute_server/report/application/port/in/dto/ReportListView.java
@@ -16,7 +16,11 @@ import com.groute.groute_server.user.entity.User;
 public record ReportListView(List<ReportItemView> reports) {
 
     public static ReportListView from(List<Report> reports, User user) {
-        return new ReportListView(reports.stream().map(r -> ReportItemView.from(r, user)).toList());
+        return new ReportListView(
+                reports.stream()
+                        .filter(r -> r.getStatus() == ReportStatus.SUCCESS)
+                        .map(r -> ReportItemView.from(r, user))
+                        .toList());
     }
 
     public record ReportItemView(


### PR DESCRIPTION
## 요약
- AI 서버가 camelCase로 직렬화하는데 Spring DTO가 snake_case로 매핑돼 파싱 실패로 content_json이 null 저장되던 문제 수정
- Lazy 로딩으로 LazyInitializationException 발생하던 문제 수정
- 리포트 목록에 FAILED 상태도 노출되던 문제 수정

## 상세 내용
AI 응답 DTO 5개 @JsonProperty snake_case → camelCase 수정
AiReportRequest 요청 필드 snake_case → camelCase 수정
AiReportClientAdapter contentJson Map 키 camelCase로 수정
ScrumForReportJpaRepository JOIN FETCH s.title t JOIN FETCH t.project 추가로 Lazy 로딩 해결

리포트 목록 조회 시 FAILED/GENERATING 상태 리포트도 노출되던 문제 수정
ReportListView.from()에서 status == SUCCESS인 것만 필터링하도록 추가

## 변경 사항
- [ ] 기능
- [x] 버그 수정
- [ ] 리팩토링
- [ ] 문서
- [ ] 테스트
- [ ] 기타

## 테스트
- [x] 로컬 테스트 완료
- 테스트 방법:
    - MINI 리포트 생성 → 상세 조회 content 필드 확인
    - CAREER 리포트 생성 → 상세 조회 content 필드 확인

### 커버리지 (JaCoCo)
- 라인 커버리지: __%  (기준: 60% 이상)
- [ ] `./gradlew test` 실행 후 `build/reports/jacoco/index.html`에서 수치 확인
- (선택) 리포트 스크린샷 또는 60% 미달/특이사항 공유:

## 스크린샷/로그 (선택)
- 필요한 경우 첨부

## 롤백/리스크
- 리스크 포인트:
- 롤백 방법:

## 관련 이슈
Closes #140 