### PR TITLE
fix: 로그아웃 응답 바디 누락 수정

### DIFF
--- a/src/main/java/com/groute/groute_server/auth/controller/AuthController.java
+++ b/src/main/java/com/groute/groute_server/auth/controller/AuthController.java
@@ -93,6 +93,6 @@ public class AuthController {
     public ApiResponse<Void> logout(@CurrentUser Long userId, HttpServletResponse response) {
         authService.logout(userId);
         tokenDeliveryService.clear(response);
-        return null;
+        return ApiResponse.ok("로그아웃 성공");
     }
 }


### PR DESCRIPTION
## 요약
- POST /api/auth/logout 응답이 빈 바디로 반환되어 Swagger UI에서 응답이 안 오는 것처럼 보이던 문제 수정

## 상세 내용
AuthController.logout()이 `return null;` 로 반환되어 ApiResponse 래퍼 없이 빈 바디가 직렬화되던 문제
다른 엔드포인트와 동일하게 `ApiResponse.ok("로그아웃 성공")` 로 래핑해 반환하도록 수정

## 변경 사항
- [ ] 기능
- [x] 버그 수정
- [ ] 리팩토링
- [ ] 문서
- [ ] 테스트
- [ ] 기타

## 테스트
- [ ] 로컬 테스트 완료
- 테스트 방법:
    - Swagger에서 Authorize 후 POST /api/auth/logout Execute
    - 응답 바디에 `{"success": true, "code": "200", "message": "로그아웃 성공"}` 반환 확인

### 커버리지 (JaCoCo)
- 라인 커버리지: __%  (기준: 60% 이상)
- [ ] `./gradlew test` 실행 후 `build/reports/jacoco/index.html`에서 수치 확인

## 스크린샷/로그 (선택)
- 필요한 경우 첨부

## 롤백/리스크
- 리스크 포인트: 응답 바디 형태만 변경, 동작 로직 변화 없음
- 롤백 방법: 해당 커밋 revert

## 관련 이슈
Closes #143

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 로그아웃 요청 시 명확한 성공 응답을 반환하도록 개선되었습니다.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/2026-KUSITMS-GLIT/2026-KUSITMS-GLIT-BACK/pull/144?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->