### PR TITLE
test: dev 브랜치 테스트 컴파일·실행 실패 수정

### DIFF
--- a/src/test/java/com/groute/groute_server/record/adapter/out/ai/AiTaggingClientAdapterTest.java
+++ b/src/test/java/com/groute/groute_server/record/adapter/out/ai/AiTaggingClientAdapterTest.java
@@ -108,7 +108,9 @@ class AiTaggingClientAdapterTest {
 
             // then
             assertThat(job.getStatus()).isEqualTo(JobStatus.SUCCESS);
-            then(completeAiTaggingUseCase).should().completeTagging(STAR_RECORD_ID);
+            then(completeAiTaggingUseCase)
+                    .should()
+                    .completeTagging(STAR_RECORD_ID, "PROBLEM_SOLVING", List.of("문제해결", "개선"));
             then(aiTaggingJobPort).should(times(2)).saveJob(job);
         }
     }
@@ -132,7 +134,9 @@ class AiTaggingClientAdapterTest {
 
             // then
             assertThat(job.getStatus()).isEqualTo(JobStatus.SUCCESS);
-            then(completeAiTaggingUseCase).should().completeTagging(STAR_RECORD_ID);
+            then(completeAiTaggingUseCase)
+                    .should()
+                    .completeTagging(STAR_RECORD_ID, "PROBLEM_SOLVING", List.of("문제해결"));
         }
 
         @Test

--- a/src/test/java/com/groute/groute_server/record/application/service/ScrumSyncServiceTest.java
+++ b/src/test/java/com/groute/groute_server/record/application/service/ScrumSyncServiceTest.java
@@ -48,7 +48,7 @@ class ScrumSyncServiceTest {
 
     private static final Long USER_ID = 1L;
     private static final LocalDate DATE = LocalDate.of(2026, 5, 4);
-    private static final LocalDate YESTERDAY = DATE.minusDays(1);
+    private static final LocalDate YESTERDAY = LocalDate.now().minusDays(1);
 
     @Mock ScrumTitleRepositoryPort scrumTitleRepositoryPort;
     @Mock ScrumQueryPort scrumQueryPort;

--- a/src/test/java/com/groute/groute_server/record/service/AiTaggingServiceTest.java
+++ b/src/test/java/com/groute/groute_server/record/service/AiTaggingServiceTest.java
@@ -34,6 +34,7 @@ import com.groute.groute_server.record.application.port.out.scrum.ScrumQueryPort
 import com.groute.groute_server.record.application.port.out.scrumtitle.ScrumTitleRepositoryPort;
 import com.groute.groute_server.record.application.port.out.star.StarRecordRepositoryPort;
 import com.groute.groute_server.record.application.port.out.star.StarTagQueryPort;
+import com.groute.groute_server.record.application.port.out.star.StarTagSavePort;
 import com.groute.groute_server.record.application.service.AiTaggingAsyncExecutor;
 import com.groute.groute_server.record.application.service.AiTaggingService;
 import com.groute.groute_server.record.domain.AiTaggingJob;
@@ -59,6 +60,7 @@ class AiTaggingServiceTest {
     @Mock private StarRecordRepositoryPort starRecordPort;
     @Mock private AiTaggingJobPort aiTaggingJobPort;
     @Mock private StarTagQueryPort starTagPort;
+    @Mock private StarTagSavePort starTagSavePort;
     @Mock private ScrumQueryPort scrumQueryPort;
     @Mock private ScrumTitleRepositoryPort scrumTitleRepositoryPort;
     @Mock private UserPort userPort;
@@ -413,7 +415,7 @@ class AiTaggingServiceTest {
             given(starRecordPort.countTaggedByUserId(USER_ID)).willReturn(5L);
             given(userPort.findById(USER_ID)).willReturn(User.createForSocialLogin());
 
-            aiTaggingService.completeTagging(STAR_RECORD_ID);
+            aiTaggingService.completeTagging(STAR_RECORD_ID, "PROBLEM_SOLVING", List.of("문제해결"));
 
             assertThat(record.getStatus()).isEqualTo(StarRecordStatus.TAGGED);
             verify(scrumTitleRepositoryPort).commitAllByIds(List.of(100L));
@@ -428,7 +430,7 @@ class AiTaggingServiceTest {
             given(starRecordPort.countTaggedByUserId(USER_ID)).willReturn(5L);
             given(userPort.findById(USER_ID)).willReturn(User.createForSocialLogin());
 
-            aiTaggingService.completeTagging(STAR_RECORD_ID);
+            aiTaggingService.completeTagging(STAR_RECORD_ID, "PROBLEM_SOLVING", List.of("문제해결"));
 
             assertThat(record.getStatus()).isEqualTo(StarRecordStatus.TAGGED);
             verify(scrumTitleRepositoryPort, never()).commitAllByIds(any());
@@ -439,7 +441,10 @@ class AiTaggingServiceTest {
         void throwsNotFound_whenStarRecordMissing() {
             given(starRecordPort.findByIdWithScrum(STAR_RECORD_ID)).willReturn(Optional.empty());
 
-            assertThatThrownBy(() -> aiTaggingService.completeTagging(STAR_RECORD_ID))
+            assertThatThrownBy(
+                            () ->
+                                    aiTaggingService.completeTagging(
+                                            STAR_RECORD_ID, "PROBLEM_SOLVING", List.of("문제해결")))
                     .asInstanceOf(InstanceOfAssertFactories.type(BusinessException.class))
                     .extracting(BusinessException::getErrorCode)
                     .isEqualTo(ErrorCode.STAR_RECORD_NOT_FOUND);

--- a/src/test/java/com/groute/groute_server/report/application/service/ReportQueryServiceTest.java
+++ b/src/test/java/com/groute/groute_server/report/application/service/ReportQueryServiceTest.java
@@ -54,7 +54,7 @@ class ReportQueryServiceTest {
         @DisplayName("신규 유저: 리포트 없으면 전체 완료 심화기록 수를 currentCount로 반환한다")
         void should_returnTotalCount_when_noReport() {
             given(reportQueryPort.findLatestSuccessByUserId(USER_ID)).willReturn(Optional.empty());
-            given(starRecordCountQueryPort.countCompletedAfter(USER_ID, null)).willReturn(7);
+            given(starRecordCountQueryPort.countCompletedAfter(USER_ID, null)).willReturn(7L);
 
             ReportGaugeView view = service.getGauge(USER_ID);
 
@@ -73,7 +73,7 @@ class ReportQueryServiceTest {
             given(reportQueryPort.findLatestSuccessByUserId(USER_ID))
                     .willReturn(Optional.of(lastReport));
             given(starRecordCountQueryPort.countCompletedAfter(USER_ID, lastReportAt))
-                    .willReturn(4);
+                    .willReturn(4L);
 
             ReportGaugeView view = service.getGauge(USER_ID);
 
@@ -91,7 +91,7 @@ class ReportQueryServiceTest {
             given(reportQueryPort.findLatestSuccessByUserId(USER_ID))
                     .willReturn(Optional.of(lastReport));
             given(starRecordCountQueryPort.countCompletedAfter(USER_ID, lastReportAt))
-                    .willReturn(10);
+                    .willReturn(10L);
 
             ReportGaugeView view = service.getGauge(USER_ID);
 
@@ -103,7 +103,7 @@ class ReportQueryServiceTest {
         @DisplayName("currentCount > 10이면 progressRate가 1.0을 초과한다")
         void should_returnProgressRateOverOne_when_currentCountExceedsThreshold() {
             given(reportQueryPort.findLatestSuccessByUserId(USER_ID)).willReturn(Optional.empty());
-            given(starRecordCountQueryPort.countCompletedAfter(USER_ID, null)).willReturn(12);
+            given(starRecordCountQueryPort.countCompletedAfter(USER_ID, null)).willReturn(12L);
 
             ReportGaugeView view = service.getGauge(USER_ID);
 


### PR DESCRIPTION
## 요약
- dev 브랜치에서 `./gradlew test` 실패하던 문제 수정 (컴파일 실패 6건 + 런타임 실패 3건)
- CI는 `build -x test` 로 테스트를 스킵해 사전에 감지되지 못함 (CI 개선은 별도 이슈)

## 상세 내용

### 1. AI 태깅 테스트 — `completeTagging()` 시그니처 변경 반영
`completeTagging(Long)` → `completeTagging(Long, String, List<String>)` 로 변경됐는데 테스트가 따라가지 않아 컴파일 실패
- `AiTaggingClientAdapterTest`: verify 호출 인자에 `primaryCategory`, `detailTags` 추가
- `AiTaggingServiceTest`: 호출부 3곳 인자 추가 + `StarTagSavePort` `@Mock` 누락 보완

### 2. 리포트 테스트 — `countCompletedAfter()` 반환 타입 변경 반영
반환 타입 `int` → `long` 변경 후 테스트가 따라가지 않아 컴파일 실패
- `ReportQueryServiceTest`: `willReturn(7)` 같은 int 리터럴을 `7L` 등 long으로 수정 (4건)

### 3. ScrumSyncServiceTest — 14일 윈도우 타임봄 수정
`YESTERDAY = DATE.minusDays(1)` 가 고정 날짜(2026-05-03) 기반이라, 실제 시스템 시간이 14일 이상 지나면 `SCRUM_EDIT_LOCKED_14D` 가 무조건 발생해 update/delete/mixed 테스트 3건 실패
- `YESTERDAY` 를 `LocalDate.now().minusDays(1)` 로 변경해 상대 시간 기반으로 통일 (14일경계 테스트는 이미 동일 패턴 사용 중)

## 변경 사항
- [ ] 기능
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 문서
- [x] 테스트
- [ ] 기타

## 테스트
- [x] 로컬 테스트 완료 (`./gradlew test` BUILD SUCCESSFUL)
- 테스트 방법:
    - dev 브랜치 체크아웃 후 `./gradlew test` 실패 확인
    - 본 PR 머지 후 다시 실행해 전체 통과 확인

### 커버리지 (JaCoCo)
- 라인 커버리지: __%  (기준: 60% 이상)
- [ ] `./gradlew test` 실행 후 `build/reports/jacoco/index.html`에서 수치 확인

## 스크린샷/로그 (선택)
- 필요한 경우 첨부

## 롤백/리스크
- 리스크 포인트: 테스트 코드만 수정, 프로덕션 코드 변경 없음
- 롤백 방법: 해당 커밋 revert

## 관련 이슈
Closes #145

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **테스트**
  * AI 태깅 관련 테스트 검증이 강화되었습니다.
  * 테스트 데이터 기준값이 동적으로 변경되어 테스트 신뢰성이 개선되었습니다.
  * 리포트 조회 테스트의 데이터 타입 일관성이 개선되었습니다.

**참고**: 본 변경사항은 내부 테스트 코드 개선으로, 사용자에게 직접적인 영향은 없습니다.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/2026-KUSITMS-GLIT/2026-KUSITMS-GLIT-BACK/pull/146?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->