### PR TITLE
fix: 일자별 스크럼 조회 응답에 카드 primaryCategories·세부역량태그 누락

### DIFF
--- a/src/main/java/com/groute/groute_server/record/adapter/in/web/dto/CalendarDailyResponse.java
+++ b/src/main/java/com/groute/groute_server/record/adapter/in/web/dto/CalendarDailyResponse.java
@@ -3,16 +3,22 @@ package com.groute.groute_server.record.adapter.in.web.dto;
 import java.util.List;
 
 import com.groute.groute_server.record.application.port.in.calendar.DailyCalendarView;
+import com.groute.groute_server.record.domain.enums.CompetencyCategory;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 
 /** 일자별 스크럼 조회 응답 DTO. {@link DailyCalendarView}의 Web 표현. */
 @Schema(description = "일자별 스크럼 조회 응답")
 public record CalendarDailyResponse(
+        @Schema(
+                        description = "해당 일자 STAR 완료 스크럼들의 distinct 세부역량태그 목록 (없으면 빈 배열)",
+                        example = "[\"UX 설계\", \"품질 관리\", \"데이터 분석\", \"고객 지원\"]")
+                List<String> detailTags,
         @Schema(description = "ScrumTitle 단위 그룹 목록 (없으면 빈 배열)") List<GroupResponse> groups) {
 
     public static CalendarDailyResponse from(DailyCalendarView view) {
-        return new CalendarDailyResponse(view.groups().stream().map(GroupResponse::from).toList());
+        return new CalendarDailyResponse(
+                view.detailTags(), view.groups().stream().map(GroupResponse::from).toList());
     }
 
     @Schema(description = "ScrumTitle 그룹")
@@ -20,6 +26,11 @@ public record CalendarDailyResponse(
             @Schema(description = "스크럼 제목 ID", example = "12") Long titleId,
             @Schema(description = "프로젝트 태그 (최대 15자)", example = "밋업 프로젝트") String projectTag,
             @Schema(description = "자유작성 (최대 20자)", example = "기획 작업") String freeText,
+            @Schema(
+                            description =
+                                    "그룹 내 STAR 완료된 스크럼들의 distinct primaryCategory 배열. STAR 완료가 없으면 빈 배열.",
+                            example = "[\"PLANNING_EXECUTION\", \"COLLABORATION\"]")
+                    List<CompetencyCategory> primaryCategories,
             @Schema(description = "그룹 내 수정 가능한 항목이 하나라도 있는지", example = "true") boolean isEditable,
             @Schema(description = "그룹 내 항목 목록") List<ItemResponse> items) {
 
@@ -28,6 +39,7 @@ public record CalendarDailyResponse(
                     group.titleId(),
                     group.projectTag(),
                     group.freeText(),
+                    group.primaryCategories(),
                     group.isEditable(),
                     group.items().stream().map(ItemResponse::from).toList());
         }

--- a/src/main/java/com/groute/groute_server/record/adapter/out/persistence/StarTagJpaRepository.java
+++ b/src/main/java/com/groute/groute_server/record/adapter/out/persistence/StarTagJpaRepository.java
@@ -7,6 +7,7 @@ import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import com.groute.groute_server.record.application.port.out.star.ScrumStarTagProjection;
 import com.groute.groute_server.record.domain.StarTag;
 
 /**
@@ -19,6 +20,25 @@ public interface StarTagJpaRepository extends JpaRepository<StarTag, Long> {
 
     @Query("SELECT t FROM StarTag t WHERE t.starRecord.id = :starRecordId ORDER BY t.id ASC")
     List<StarTag> findAllByStarRecordId(@Param("starRecordId") Long starRecordId);
+
+    /**
+     * scrumId 집합의 완료 STAR 태그 row(scrumId/primaryCategory/detailTag).
+     *
+     * <p>userId로 한 번 더 필터(defense-in-depth)하고, soft-delete된 starRecord는 JOIN 조건으로 자연 제외한다. 정렬은
+     * {@code st.id ASC}로 안정적.
+     */
+    @Query(
+            "SELECT new com.groute.groute_server.record.application.port.out.star.ScrumStarTagProjection("
+                    + "sr.scrum.id, st.primaryCategory, st.detailTag) "
+                    + "FROM StarTag st "
+                    + "JOIN st.starRecord sr "
+                    + "WHERE sr.scrum.id IN :scrumIds "
+                    + "  AND sr.user.id = :userId "
+                    + "  AND sr.isCompleted = true "
+                    + "  AND sr.isDeleted = false "
+                    + "ORDER BY st.id ASC")
+    List<ScrumStarTagProjection> findCompletedTagsByScrumIds(
+            @Param("userId") Long userId, @Param("scrumIds") List<Long> scrumIds);
 
     /**
      * 해당 사용자가 소유한 모든 StarTag 물리 삭제(MYP-005 hard delete 배치).

--- a/src/main/java/com/groute/groute_server/record/adapter/out/persistence/StarTagPersistenceAdapter.java
+++ b/src/main/java/com/groute/groute_server/record/adapter/out/persistence/StarTagPersistenceAdapter.java
@@ -4,6 +4,7 @@ import java.util.List;
 
 import org.springframework.stereotype.Component;
 
+import com.groute.groute_server.record.application.port.out.star.ScrumStarTagProjection;
 import com.groute.groute_server.record.application.port.out.star.StarTagQueryPort;
 import com.groute.groute_server.record.application.port.out.star.StarTagSavePort;
 import com.groute.groute_server.record.domain.StarTag;
@@ -24,6 +25,15 @@ class StarTagPersistenceAdapter implements StarTagQueryPort, StarTagSavePort {
     @Override
     public List<StarTag> findAllByStarRecordId(Long starRecordId) {
         return jpaRepository.findAllByStarRecordId(starRecordId);
+    }
+
+    @Override
+    public List<ScrumStarTagProjection> findCompletedTagsByScrumIds(
+            Long userId, List<Long> scrumIds) {
+        if (scrumIds == null || scrumIds.isEmpty()) {
+            return List.of();
+        }
+        return jpaRepository.findCompletedTagsByScrumIds(userId, scrumIds);
     }
 
     @Override

--- a/src/main/java/com/groute/groute_server/record/application/port/in/calendar/DailyCalendarView.java
+++ b/src/main/java/com/groute/groute_server/record/application/port/in/calendar/DailyCalendarView.java
@@ -2,23 +2,29 @@ package com.groute.groute_server.record.application.port.in.calendar;
 
 import java.util.List;
 
+import com.groute.groute_server.record.domain.enums.CompetencyCategory;
+
 /**
  * 일자별 스크럼 조회·sync 응답 모델.
  *
  * <p>ScrumTitle 단위로 그룹핑된 2계층 구조. {@code GetDailyCalendarUseCase}와 {@code SyncDailyScrumUseCase}가 동일
  * schema를 반환한다.
+ *
+ * @param detailTags 해당 일자의 모든 STAR에서 추출된 distinct 세부역량태그 목록. STAR가 한 건도 없으면 빈 배열.
  */
-public record DailyCalendarView(List<GroupView> groups) {
+public record DailyCalendarView(List<String> detailTags, List<GroupView> groups) {
 
     /**
      * ScrumTitle 단위 그룹.
      *
+     * @param primaryCategories 그룹 내 STAR 완료된 스크럼들의 distinct primaryCategory 배열. STAR 완료가 없으면 빈 배열.
      * @param isEditable 그룹 내 수정 가능한 item이 하나라도 있는지 (UI 그룹 X 버튼 노출 기준)
      */
     public record GroupView(
             Long titleId,
             String projectTag,
             String freeText,
+            List<CompetencyCategory> primaryCategories,
             boolean isEditable,
             List<ItemView> items) {}
 

--- a/src/main/java/com/groute/groute_server/record/application/port/out/star/ScrumStarTagProjection.java
+++ b/src/main/java/com/groute/groute_server/record/application/port/out/star/ScrumStarTagProjection.java
@@ -5,8 +5,8 @@ import com.groute.groute_server.record.domain.enums.CompetencyCategory;
 /**
  * 스크럼당 완료 STAR 태그 row.
  *
- * <p>한 Scrum(=StarRecord 1:1)에 1~3개의 row가 생성된다. {@code primaryCategory}는 같은 scrumId 내에서 동일 값이며 {@code
- * detailTag}는 row마다 다르다. 호출 측이 distinct·그룹 집계를 책임진다.
+ * <p>한 Scrum(=StarRecord 1:1)에 1~3개의 row가 생성된다. {@code primaryCategory}는 같은 scrumId 내에서 동일 값이며
+ * {@code detailTag}는 row마다 다르다. 호출 측이 distinct·그룹 집계를 책임진다.
  */
 public record ScrumStarTagProjection(
         Long scrumId, CompetencyCategory primaryCategory, String detailTag) {}

--- a/src/main/java/com/groute/groute_server/record/application/port/out/star/ScrumStarTagProjection.java
+++ b/src/main/java/com/groute/groute_server/record/application/port/out/star/ScrumStarTagProjection.java
@@ -1,0 +1,12 @@
+package com.groute.groute_server.record.application.port.out.star;
+
+import com.groute.groute_server.record.domain.enums.CompetencyCategory;
+
+/**
+ * 스크럼당 완료 STAR 태그 row.
+ *
+ * <p>한 Scrum(=StarRecord 1:1)에 1~3개의 row가 생성된다. {@code primaryCategory}는 같은 scrumId 내에서 동일 값이며 {@code
+ * detailTag}는 row마다 다르다. 호출 측이 distinct·그룹 집계를 책임진다.
+ */
+public record ScrumStarTagProjection(
+        Long scrumId, CompetencyCategory primaryCategory, String detailTag) {}

--- a/src/main/java/com/groute/groute_server/record/application/port/out/star/StarTagQueryPort.java
+++ b/src/main/java/com/groute/groute_server/record/application/port/out/star/StarTagQueryPort.java
@@ -8,4 +8,13 @@ import com.groute.groute_server.record.domain.StarTag;
 public interface StarTagQueryPort {
 
     List<StarTag> findAllByStarRecordId(Long starRecordId);
+
+    /**
+     * 지정 scrumId 집합 중 완료된 STAR의 태그 row 목록.
+     *
+     * <p>일자별 스크럼 조회에서 카드 단위 primaryCategory 배열과 일자 단위 detailTag 집합을 동시에 산출하기 위해 사용한다. 호출 측에서 본인
+     * scrumIds만 전달한다고 신뢰하지 않고 저장소 단에서도 {@code userId}로 한 번 더 강제(defense-in-depth). soft-delete된
+     * starRecord는 제외. 빈 입력엔 빈 리스트.
+     */
+    List<ScrumStarTagProjection> findCompletedTagsByScrumIds(Long userId, List<Long> scrumIds);
 }

--- a/src/main/java/com/groute/groute_server/record/application/service/CalendarQueryService.java
+++ b/src/main/java/com/groute/groute_server/record/application/service/CalendarQueryService.java
@@ -4,8 +4,10 @@ import java.time.LocalDate;
 import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -14,8 +16,11 @@ import com.groute.groute_server.record.application.port.in.calendar.DailyCalenda
 import com.groute.groute_server.record.application.port.in.calendar.GetDailyCalendarQuery;
 import com.groute.groute_server.record.application.port.in.calendar.GetDailyCalendarUseCase;
 import com.groute.groute_server.record.application.port.out.scrum.ScrumQueryPort;
+import com.groute.groute_server.record.application.port.out.star.ScrumStarTagProjection;
+import com.groute.groute_server.record.application.port.out.star.StarTagQueryPort;
 import com.groute.groute_server.record.domain.Scrum;
 import com.groute.groute_server.record.domain.ScrumTitle;
+import com.groute.groute_server.record.domain.enums.CompetencyCategory;
 
 import lombok.RequiredArgsConstructor;
 
@@ -23,6 +28,9 @@ import lombok.RequiredArgsConstructor;
  * 일자별 스크럼 조회 서비스 (CAL-002).
  *
  * <p>해당 일자의 사용자 스크럼 전체를 ScrumTitle 단위로 그룹핑하여 반환한다. 각 스크럼은 작성 14일 이내이고 hasStar=false 일 때만 수정 가능하다.
+ *
+ * <p>응답에는 그날 STAR가 완료된 스크럼들의 카드(그룹) 단위 distinct {@code primaryCategory} 배열과 일자 단위 distinct {@code
+ * detailTag} 목록도 함께 포함된다.
  */
 @Service
 @RequiredArgsConstructor
@@ -32,35 +40,52 @@ public class CalendarQueryService implements GetDailyCalendarUseCase {
     private static final int EDIT_WINDOW_DAYS = 14;
 
     private final ScrumQueryPort scrumQueryPort;
+    private final StarTagQueryPort starTagQueryPort;
 
     /**
      * 일자별 스크럼 전체를 ScrumTitle 단위로 묶어 group/item 2계층 View로 반환.
      *
-     * <p>스크럼이 없는 일자는 빈 그룹 배열을 반환한다. 그룹·항목의 정렬은 레포지토리 쿼리(titleId asc, id asc)에 위임한다.
+     * <p>스크럼이 없는 일자는 빈 그룹 배열·빈 detailTags를 반환한다. 그룹·항목의 정렬은 레포지토리 쿼리(titleId asc, id asc)에 위임한다.
+     * primaryCategories는 그룹별 distinct 등장 순서, detailTags는 일자 단위 distinct 등장 순서를 유지한다.
      */
     @Override
     public DailyCalendarView getDailyCalendar(GetDailyCalendarQuery query) {
         // 1. 해당 일자의 사용자 스크럼 전체 로드 (Title·Project fetch join)
         List<Scrum> scrums = scrumQueryPort.findAllByUserAndDate(query.userId(), query.date());
         if (scrums.isEmpty()) {
-            return new DailyCalendarView(List.of());
+            return new DailyCalendarView(List.of(), List.of());
         }
 
-        // 2. 14일 경계 비교용 today (DB UTC ↔ 시스템 zone 정합)
+        // 2. 완료 STAR 태그 로드 — 카드 primaryCategories + 일자 detailTags 집계 소스
+        List<Long> scrumIds = scrums.stream().map(Scrum::getId).toList();
+        List<ScrumStarTagProjection> tagRows =
+                starTagQueryPort.findCompletedTagsByScrumIds(query.userId(), scrumIds);
+
+        Map<Long, Set<CompetencyCategory>> primaryByScrumId = new LinkedHashMap<>();
+        Set<String> detailTags = new LinkedHashSet<>();
+        for (ScrumStarTagProjection row : tagRows) {
+            primaryByScrumId
+                    .computeIfAbsent(row.scrumId(), k -> new LinkedHashSet<>())
+                    .add(row.primaryCategory());
+            detailTags.add(row.detailTag());
+        }
+
+        // 3. 14일 경계 비교용 today (DB UTC ↔ 시스템 zone 정합)
         ZoneId zone = ZoneId.systemDefault();
         LocalDate today = LocalDate.now(zone);
 
-        // 3. titleId 기준 그룹핑 (LinkedHashMap으로 정렬 보존)
+        // 4. titleId 기준 그룹핑 (LinkedHashMap으로 정렬 보존)
         Map<Long, List<Scrum>> grouped = new LinkedHashMap<>();
         for (Scrum scrum : scrums) {
             grouped.computeIfAbsent(scrum.getTitle().getId(), k -> new ArrayList<>()).add(scrum);
         }
 
-        // 4. 그룹별로 ItemView 생성 + 그룹 editable 집계
+        // 5. 그룹별로 ItemView + primaryCategories + group editable 집계
         List<DailyCalendarView.GroupView> groups = new ArrayList<>(grouped.size());
         for (List<Scrum> bucket : grouped.values()) {
             ScrumTitle title = bucket.get(0).getTitle();
             List<DailyCalendarView.ItemView> items = new ArrayList<>(bucket.size());
+            Set<CompetencyCategory> groupPrimary = new LinkedHashSet<>();
             boolean groupEditable = false;
             for (Scrum scrum : bucket) {
                 boolean editable = isEditable(scrum, today, zone);
@@ -70,16 +95,21 @@ public class CalendarQueryService implements GetDailyCalendarUseCase {
                 if (editable) {
                     groupEditable = true;
                 }
+                Set<CompetencyCategory> scrumPrimary = primaryByScrumId.get(scrum.getId());
+                if (scrumPrimary != null) {
+                    groupPrimary.addAll(scrumPrimary);
+                }
             }
             groups.add(
                     new DailyCalendarView.GroupView(
                             title.getId(),
                             title.getProject().getName(),
                             title.getFreeText(),
+                            List.copyOf(groupPrimary),
                             groupEditable,
                             items));
         }
-        return new DailyCalendarView(groups);
+        return new DailyCalendarView(List.copyOf(detailTags), groups);
     }
 
     /**

--- a/src/test/java/com/groute/groute_server/record/application/service/CalendarQueryServiceTest.java
+++ b/src/test/java/com/groute/groute_server/record/application/service/CalendarQueryServiceTest.java
@@ -225,7 +225,8 @@ class CalendarQueryServiceTest {
             // then
             assertThat(view.groups().get(0).primaryCategories())
                     .containsExactly(
-                            CompetencyCategory.PLANNING_EXECUTION, CompetencyCategory.COLLABORATION);
+                            CompetencyCategory.PLANNING_EXECUTION,
+                            CompetencyCategory.COLLABORATION);
         }
 
         @Test
@@ -253,8 +254,7 @@ class CalendarQueryServiceTest {
             ScrumTitle t2 = title(2L, "P2", "F2");
             Scrum s10 = scrum(10L, t1, "a", true, LocalDate.now().minusDays(1));
             Scrum s20 = scrum(20L, t2, "b", true, LocalDate.now().minusDays(1));
-            given(scrumQueryPort.findAllByUserAndDate(USER_ID, DATE))
-                    .willReturn(List.of(s10, s20));
+            given(scrumQueryPort.findAllByUserAndDate(USER_ID, DATE)).willReturn(List.of(s10, s20));
             given(starTagQueryPort.findCompletedTagsByScrumIds(anyLong(), any()))
                     .willReturn(
                             List.of(

--- a/src/test/java/com/groute/groute_server/record/application/service/CalendarQueryServiceTest.java
+++ b/src/test/java/com/groute/groute_server/record/application/service/CalendarQueryServiceTest.java
@@ -1,6 +1,8 @@
 package com.groute.groute_server.record.application.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.BDDMockito.given;
 
 import java.time.LocalDate;
@@ -20,9 +22,12 @@ import org.springframework.test.util.ReflectionTestUtils;
 import com.groute.groute_server.record.application.port.in.calendar.DailyCalendarView;
 import com.groute.groute_server.record.application.port.in.calendar.GetDailyCalendarQuery;
 import com.groute.groute_server.record.application.port.out.scrum.ScrumQueryPort;
+import com.groute.groute_server.record.application.port.out.star.ScrumStarTagProjection;
+import com.groute.groute_server.record.application.port.out.star.StarTagQueryPort;
 import com.groute.groute_server.record.domain.Project;
 import com.groute.groute_server.record.domain.Scrum;
 import com.groute.groute_server.record.domain.ScrumTitle;
+import com.groute.groute_server.record.domain.enums.CompetencyCategory;
 import com.groute.groute_server.user.entity.User;
 
 @ExtendWith(MockitoExtension.class)
@@ -33,6 +38,7 @@ class CalendarQueryServiceTest {
     private static final GetDailyCalendarQuery QUERY = new GetDailyCalendarQuery(USER_ID, DATE);
 
     @Mock ScrumQueryPort scrumQueryPort;
+    @Mock StarTagQueryPort starTagQueryPort;
 
     @InjectMocks CalendarQueryService service;
 
@@ -41,8 +47,8 @@ class CalendarQueryServiceTest {
     class Empty {
 
         @Test
-        @DisplayName("스크럼이 없으면 빈 그룹 배열을 반환한다")
-        void should_returnEmptyGroups_when_noScrumOnDate() {
+        @DisplayName("스크럼이 없으면 빈 그룹·빈 detailTags를 반환한다")
+        void should_returnEmptyGroupsAndTags_when_noScrumOnDate() {
             // given
             given(scrumQueryPort.findAllByUserAndDate(USER_ID, DATE)).willReturn(List.of());
 
@@ -51,6 +57,7 @@ class CalendarQueryServiceTest {
 
             // then
             assertThat(view.groups()).isEmpty();
+            assertThat(view.detailTags()).isEmpty();
         }
     }
 
@@ -69,6 +76,8 @@ class CalendarQueryServiceTest {
             Scrum s20 = scrum(20L, t2, "c", false, DATE.minusDays(1));
             given(scrumQueryPort.findAllByUserAndDate(USER_ID, DATE))
                     .willReturn(List.of(s10, s11, s20));
+            given(starTagQueryPort.findCompletedTagsByScrumIds(anyLong(), any()))
+                    .willReturn(List.of());
 
             // when
             DailyCalendarView view = service.getDailyCalendar(QUERY);
@@ -101,6 +110,8 @@ class CalendarQueryServiceTest {
             ScrumTitle t = title(1L, "P", "F");
             Scrum scrum = scrum(10L, t, "x", false, LocalDate.now().minusDays(13));
             given(scrumQueryPort.findAllByUserAndDate(USER_ID, DATE)).willReturn(List.of(scrum));
+            given(starTagQueryPort.findCompletedTagsByScrumIds(anyLong(), any()))
+                    .willReturn(List.of());
 
             // when
             DailyCalendarView view = service.getDailyCalendar(QUERY);
@@ -116,6 +127,8 @@ class CalendarQueryServiceTest {
             ScrumTitle t = title(1L, "P", "F");
             Scrum scrum = scrum(10L, t, "x", false, LocalDate.now().minusDays(15));
             given(scrumQueryPort.findAllByUserAndDate(USER_ID, DATE)).willReturn(List.of(scrum));
+            given(starTagQueryPort.findCompletedTagsByScrumIds(anyLong(), any()))
+                    .willReturn(List.of());
 
             // when
             DailyCalendarView view = service.getDailyCalendar(QUERY);
@@ -131,6 +144,8 @@ class CalendarQueryServiceTest {
             ScrumTitle t = title(1L, "P", "F");
             Scrum scrum = scrum(10L, t, "x", true, LocalDate.now().minusDays(1));
             given(scrumQueryPort.findAllByUserAndDate(USER_ID, DATE)).willReturn(List.of(scrum));
+            given(starTagQueryPort.findCompletedTagsByScrumIds(anyLong(), any()))
+                    .willReturn(List.of());
 
             // when
             DailyCalendarView view = service.getDailyCalendar(QUERY);
@@ -155,6 +170,8 @@ class CalendarQueryServiceTest {
             Scrum open = scrum(11L, t, "y", false, LocalDate.now().minusDays(1));
             given(scrumQueryPort.findAllByUserAndDate(USER_ID, DATE))
                     .willReturn(List.of(locked, open));
+            given(starTagQueryPort.findCompletedTagsByScrumIds(anyLong(), any()))
+                    .willReturn(List.of());
 
             // when
             DailyCalendarView view = service.getDailyCalendar(QUERY);
@@ -171,12 +188,90 @@ class CalendarQueryServiceTest {
             Scrum a = scrum(10L, t, "x", true, LocalDate.now().minusDays(1));
             Scrum b = scrum(11L, t, "y", true, LocalDate.now().minusDays(1));
             given(scrumQueryPort.findAllByUserAndDate(USER_ID, DATE)).willReturn(List.of(a, b));
+            given(starTagQueryPort.findCompletedTagsByScrumIds(anyLong(), any()))
+                    .willReturn(List.of());
 
             // when
             DailyCalendarView view = service.getDailyCalendar(QUERY);
 
             // then
             assertThat(view.groups().get(0).isEditable()).isFalse();
+        }
+    }
+
+    @Nested
+    @DisplayName("primaryCategories·detailTags 집계")
+    class TagAggregation {
+
+        @Test
+        @DisplayName("같은 카드 내 여러 STAR의 primaryCategory를 distinct로 모은다")
+        void should_aggregateGroupPrimaryCategories_distinctByCard() {
+            // given — 한 카드 안에 2개 스크럼, 서로 다른 primaryCategory
+            ScrumTitle t = title(1L, "P", "F");
+            Scrum a = scrum(10L, t, "x", true, LocalDate.now().minusDays(1));
+            Scrum b = scrum(11L, t, "y", true, LocalDate.now().minusDays(1));
+            given(scrumQueryPort.findAllByUserAndDate(USER_ID, DATE)).willReturn(List.of(a, b));
+            given(starTagQueryPort.findCompletedTagsByScrumIds(anyLong(), any()))
+                    .willReturn(
+                            List.of(
+                                    new ScrumStarTagProjection(
+                                            10L, CompetencyCategory.PLANNING_EXECUTION, "UX 설계"),
+                                    new ScrumStarTagProjection(
+                                            11L, CompetencyCategory.COLLABORATION, "이해관계자 조율")));
+
+            // when
+            DailyCalendarView view = service.getDailyCalendar(QUERY);
+
+            // then
+            assertThat(view.groups().get(0).primaryCategories())
+                    .containsExactly(
+                            CompetencyCategory.PLANNING_EXECUTION, CompetencyCategory.COLLABORATION);
+        }
+
+        @Test
+        @DisplayName("STAR 완료가 없는 카드는 primaryCategories=[] 를 반환한다")
+        void should_returnEmptyPrimaryCategories_when_noStarOnCard() {
+            // given
+            ScrumTitle t = title(1L, "P", "F");
+            Scrum s = scrum(10L, t, "x", false, LocalDate.now().minusDays(1));
+            given(scrumQueryPort.findAllByUserAndDate(USER_ID, DATE)).willReturn(List.of(s));
+            given(starTagQueryPort.findCompletedTagsByScrumIds(anyLong(), any()))
+                    .willReturn(List.of());
+
+            // when
+            DailyCalendarView view = service.getDailyCalendar(QUERY);
+
+            // then
+            assertThat(view.groups().get(0).primaryCategories()).isEmpty();
+        }
+
+        @Test
+        @DisplayName("일자 전체 detailTag 합집합을 distinct·등장순서로 노출한다")
+        void should_aggregateDetailTags_distinctAcrossCards() {
+            // given — 서로 다른 카드의 스크럼이 같은 detailTag를 공유
+            ScrumTitle t1 = title(1L, "P1", "F1");
+            ScrumTitle t2 = title(2L, "P2", "F2");
+            Scrum s10 = scrum(10L, t1, "a", true, LocalDate.now().minusDays(1));
+            Scrum s20 = scrum(20L, t2, "b", true, LocalDate.now().minusDays(1));
+            given(scrumQueryPort.findAllByUserAndDate(USER_ID, DATE))
+                    .willReturn(List.of(s10, s20));
+            given(starTagQueryPort.findCompletedTagsByScrumIds(anyLong(), any()))
+                    .willReturn(
+                            List.of(
+                                    new ScrumStarTagProjection(
+                                            10L, CompetencyCategory.PLANNING_EXECUTION, "UX 설계"),
+                                    new ScrumStarTagProjection(
+                                            10L, CompetencyCategory.PLANNING_EXECUTION, "품질 관리"),
+                                    new ScrumStarTagProjection(
+                                            20L, CompetencyCategory.COLLABORATION, "UX 설계"),
+                                    new ScrumStarTagProjection(
+                                            20L, CompetencyCategory.COLLABORATION, "고객 지원")));
+
+            // when
+            DailyCalendarView view = service.getDailyCalendar(QUERY);
+
+            // then
+            assertThat(view.detailTags()).containsExactly("UX 설계", "품질 관리", "고객 지원");
         }
     }
 


### PR DESCRIPTION
## 요약
- `GET /api/calendar/daily` 응답에 카드별 `primaryCategories` 배열과 일자 전체 distinct `detailTags` 목록을 추가해 화면 렌더에 필요한 두 필드 누락을 메움

## 변경 사항
- [x] 기능
- [x] 버그 수정
- [ ] 리팩토링
- [ ] 문서
- [x] 테스트
- [ ] 기타

상세:
- `StarTagQueryPort`에 scrumId 집합 기반 완료 STAR 태그 일괄 조회 메서드 추가, JPA 어댑터·쿼리 구현
- `DailyCalendarView`에 루트 `detailTags` 필드와 그룹 `primaryCategories` 필드 추가
- `CalendarQueryService`에서 완료 태그를 한 번 로드해 카드 단위 distinct primaryCategory 배열과 일자 단위 distinct detailTag 집합을 산출
- `CalendarDailyResponse` DTO에 두 필드 노출 + Swagger 스키마 갱신
- 단위 테스트 3건 추가 (카드 distinct 집계, STAR 없는 카드 빈 배열, 일자 detailTag 합집합)

## 테스트
- [x] 로컬 테스트 완료
- 테스트 방법:
    - `./gradlew spotlessApply check` 통과 (exit 0)
    - `./gradlew test --tests CalendarQueryServiceTest` 통과

### 커버리지 (JaCoCo)
- 라인 커버리지: 미측정 (기준: 60% 이상)
- [ ] `./gradlew test` 실행 후 `build/reports/jacoco/index.html`에서 수치 확인

## 응답 예시
```json
{
  "code": 200,
  "message": "성공",
  "data": {
    "detailTags": ["UX 설계", "품질 관리", "데이터 분석", "고객 지원"],
    "groups": [
      {
        "titleId": 50,
        "projectTag": "밋업 프로젝트",
        "freeText": "기획 작업",
        "primaryCategories": ["PLANNING_EXECUTION", "DISCOVERY_ANALYSIS", "COLLABORATION"],
        "isEditable": true,
        "items": [
          { "scrumId": 101, "content": "와이어프레임 작업", "hasStar": true, "isEditable": false }
        ]
      }
    ]
  }
}
```

스크럼이 없는 일자는 `detailTags: []`, `groups: []`. STAR 완료가 없는 카드는 `primaryCategories: []`.

## 롤백/리스크
- 리스크 포인트: 응답 스키마에 필드 2개가 추가되는 변경 (기존 필드 제거·변경 없음). FE는 신규 필드를 사용하기 전까지 무시 가능.
- 롤백 방법: 본 PR revert.

## 관련 이슈
Closes #147