### PR TITLE
feat: 일자별 스크럼 조회 응답 item에 primaryCategory·starRecordId 노출 (#151)

### DIFF
--- a/src/main/java/com/groute/groute_server/record/adapter/in/web/dto/CalendarDailyResponse.java
+++ b/src/main/java/com/groute/groute_server/record/adapter/in/web/dto/CalendarDailyResponse.java
@@ -26,11 +26,6 @@ public record CalendarDailyResponse(
             @Schema(description = "스크럼 제목 ID", example = "12") Long titleId,
             @Schema(description = "프로젝트 태그 (최대 15자)", example = "밋업 프로젝트") String projectTag,
             @Schema(description = "자유작성 (최대 20자)", example = "기획 작업") String freeText,
-            @Schema(
-                            description =
-                                    "그룹 내 STAR 완료된 스크럼들의 distinct primaryCategory 배열. STAR 완료가 없으면 빈 배열.",
-                            example = "[\"PLANNING_EXECUTION\", \"COLLABORATION\"]")
-                    List<CompetencyCategory> primaryCategories,
             @Schema(description = "그룹 내 수정 가능한 항목이 하나라도 있는지", example = "true") boolean isEditable,
             @Schema(description = "그룹 내 항목 목록") List<ItemResponse> items) {
 
@@ -39,7 +34,6 @@ public record CalendarDailyResponse(
                     group.titleId(),
                     group.projectTag(),
                     group.freeText(),
-                    group.primaryCategories(),
                     group.isEditable(),
                     group.items().stream().map(ItemResponse::from).toList());
         }
@@ -49,13 +43,28 @@ public record CalendarDailyResponse(
     public record ItemResponse(
             @Schema(description = "스크럼 ID", example = "37") Long scrumId,
             @Schema(description = "본문 (최대 50자)", example = "와이어프레임 설계") String content,
-            @Schema(description = "심화기록(STAR) 작성 여부", example = "false") boolean hasStar,
+            @Schema(description = "심화기록(STAR) 작성 여부", example = "true") boolean hasStar,
+            @Schema(
+                            description = "STAR 완료 시 대표 역량(막대기 색상 결정). 미완료 또는 hasStar=false면 null",
+                            example = "PLANNING_EXECUTION",
+                            nullable = true)
+                    CompetencyCategory primaryCategory,
+            @Schema(
+                            description = "hasStar=true인 경우 연결된 STAR id(상세 페이지 이동용). 아니면 null",
+                            example = "108",
+                            nullable = true)
+                    Long starRecordId,
             @Schema(description = "수정 가능 여부 (14일 이내 + hasStar=false)", example = "true")
                     boolean isEditable) {
 
         static ItemResponse from(DailyCalendarView.ItemView item) {
             return new ItemResponse(
-                    item.scrumId(), item.content(), item.hasStar(), item.isEditable());
+                    item.scrumId(),
+                    item.content(),
+                    item.hasStar(),
+                    item.primaryCategory(),
+                    item.starRecordId(),
+                    item.isEditable());
         }
     }
 }

--- a/src/main/java/com/groute/groute_server/record/adapter/out/persistence/StarTagJpaRepository.java
+++ b/src/main/java/com/groute/groute_server/record/adapter/out/persistence/StarTagJpaRepository.java
@@ -22,14 +22,14 @@ public interface StarTagJpaRepository extends JpaRepository<StarTag, Long> {
     List<StarTag> findAllByStarRecordId(@Param("starRecordId") Long starRecordId);
 
     /**
-     * scrumId 집합의 완료 STAR 태그 row(scrumId/primaryCategory/detailTag).
+     * scrumId 집합의 완료 STAR 태그 row(scrumId/starRecordId/primaryCategory/detailTag).
      *
      * <p>userId로 한 번 더 필터(defense-in-depth)하고, soft-delete된 starRecord는 JOIN 조건으로 자연 제외한다. 정렬은
      * {@code st.id ASC}로 안정적.
      */
     @Query(
             "SELECT new com.groute.groute_server.record.application.port.out.star.ScrumStarTagProjection("
-                    + "sr.scrum.id, st.primaryCategory, st.detailTag) "
+                    + "sr.scrum.id, sr.id, st.primaryCategory, st.detailTag) "
                     + "FROM StarTag st "
                     + "JOIN st.starRecord sr "
                     + "WHERE sr.scrum.id IN :scrumIds "

--- a/src/main/java/com/groute/groute_server/record/application/port/in/calendar/DailyCalendarView.java
+++ b/src/main/java/com/groute/groute_server/record/application/port/in/calendar/DailyCalendarView.java
@@ -17,21 +17,27 @@ public record DailyCalendarView(List<String> detailTags, List<GroupView> groups)
     /**
      * ScrumTitle 단위 그룹.
      *
-     * @param primaryCategories 그룹 내 STAR 완료된 스크럼들의 distinct primaryCategory 배열. STAR 완료가 없으면 빈 배열.
      * @param isEditable 그룹 내 수정 가능한 item이 하나라도 있는지 (UI 그룹 X 버튼 노출 기준)
      */
     public record GroupView(
             Long titleId,
             String projectTag,
             String freeText,
-            List<CompetencyCategory> primaryCategories,
             boolean isEditable,
             List<ItemView> items) {}
 
     /**
      * Scrum 단위 항목.
      *
+     * @param primaryCategory STAR 완료 시 대표 역량(막대기 색상 결정), 아니면 null
+     * @param starRecordId hasStar=true인 경우 연결된 STAR id(상세 페이지 이동용), 아니면 null
      * @param isEditable 작성 14일 이내이고 hasStar=false 일 때 true
      */
-    public record ItemView(Long scrumId, String content, boolean hasStar, boolean isEditable) {}
+    public record ItemView(
+            Long scrumId,
+            String content,
+            boolean hasStar,
+            CompetencyCategory primaryCategory,
+            Long starRecordId,
+            boolean isEditable) {}
 }

--- a/src/main/java/com/groute/groute_server/record/application/port/out/star/ScrumStarTagProjection.java
+++ b/src/main/java/com/groute/groute_server/record/application/port/out/star/ScrumStarTagProjection.java
@@ -5,8 +5,8 @@ import com.groute.groute_server.record.domain.enums.CompetencyCategory;
 /**
  * 스크럼당 완료 STAR 태그 row.
  *
- * <p>한 Scrum(=StarRecord 1:1)에 1~3개의 row가 생성된다. {@code primaryCategory}는 같은 scrumId 내에서 동일 값이며
- * {@code detailTag}는 row마다 다르다. 호출 측이 distinct·그룹 집계를 책임진다.
+ * <p>한 Scrum(=StarRecord 1:1)에 1~3개의 row가 생성된다. {@code starRecordId}와 {@code primaryCategory}는 같은
+ * scrumId 내에서 동일 값이며 {@code detailTag}는 row마다 다르다. 호출 측이 distinct·그룹 집계를 책임진다.
  */
 public record ScrumStarTagProjection(
-        Long scrumId, CompetencyCategory primaryCategory, String detailTag) {}
+        Long scrumId, Long starRecordId, CompetencyCategory primaryCategory, String detailTag) {}

--- a/src/main/java/com/groute/groute_server/record/application/service/CalendarQueryService.java
+++ b/src/main/java/com/groute/groute_server/record/application/service/CalendarQueryService.java
@@ -3,6 +3,7 @@ package com.groute.groute_server.record.application.service;
 import java.time.LocalDate;
 import java.time.ZoneId;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -29,8 +30,8 @@ import lombok.RequiredArgsConstructor;
  *
  * <p>해당 일자의 사용자 스크럼 전체를 ScrumTitle 단위로 그룹핑하여 반환한다. 각 스크럼은 작성 14일 이내이고 hasStar=false 일 때만 수정 가능하다.
  *
- * <p>응답에는 그날 STAR가 완료된 스크럼들의 카드(그룹) 단위 distinct {@code primaryCategory} 배열과 일자 단위 distinct {@code
- * detailTag} 목록도 함께 포함된다.
+ * <p>응답에는 각 item별 STAR 완료 시 {@code primaryCategory}·{@code starRecordId}와 일자 단위 distinct {@code
+ * detailTag} 목록이 포함된다. 그룹 단위 핵심역량 표시는 프론트가 item들의 primaryCategory를 조합해 처리한다.
  */
 @Service
 @RequiredArgsConstructor
@@ -46,7 +47,7 @@ public class CalendarQueryService implements GetDailyCalendarUseCase {
      * 일자별 스크럼 전체를 ScrumTitle 단위로 묶어 group/item 2계층 View로 반환.
      *
      * <p>스크럼이 없는 일자는 빈 그룹 배열·빈 detailTags를 반환한다. 그룹·항목의 정렬은 레포지토리 쿼리(titleId asc, id asc)에 위임한다.
-     * primaryCategories는 그룹별 distinct 등장 순서, detailTags는 일자 단위 distinct 등장 순서를 유지한다.
+     * detailTags는 일자 단위 distinct 등장 순서를 유지한다.
      */
     @Override
     public DailyCalendarView getDailyCalendar(GetDailyCalendarQuery query) {
@@ -56,17 +57,17 @@ public class CalendarQueryService implements GetDailyCalendarUseCase {
             return new DailyCalendarView(List.of(), List.of());
         }
 
-        // 2. 완료 STAR 태그 로드 — 카드 primaryCategories + 일자 detailTags 집계 소스
+        // 2. 완료 STAR 태그 로드 — item primaryCategory·starRecordId + 일자 detailTags 집계 소스
         List<Long> scrumIds = scrums.stream().map(Scrum::getId).toList();
         List<ScrumStarTagProjection> tagRows =
                 starTagQueryPort.findCompletedTagsByScrumIds(query.userId(), scrumIds);
 
-        Map<Long, Set<CompetencyCategory>> primaryByScrumId = new LinkedHashMap<>();
+        Map<Long, CompetencyCategory> primaryByScrumId = new HashMap<>();
+        Map<Long, Long> starRecordIdByScrumId = new HashMap<>();
         Set<String> detailTags = new LinkedHashSet<>();
         for (ScrumStarTagProjection row : tagRows) {
-            primaryByScrumId
-                    .computeIfAbsent(row.scrumId(), k -> new LinkedHashSet<>())
-                    .add(row.primaryCategory());
+            primaryByScrumId.putIfAbsent(row.scrumId(), row.primaryCategory());
+            starRecordIdByScrumId.putIfAbsent(row.scrumId(), row.starRecordId());
             detailTags.add(row.detailTag());
         }
 
@@ -80,24 +81,24 @@ public class CalendarQueryService implements GetDailyCalendarUseCase {
             grouped.computeIfAbsent(scrum.getTitle().getId(), k -> new ArrayList<>()).add(scrum);
         }
 
-        // 5. 그룹별로 ItemView + primaryCategories + group editable 집계
+        // 5. 그룹별로 ItemView + group editable 집계
         List<DailyCalendarView.GroupView> groups = new ArrayList<>(grouped.size());
         for (List<Scrum> bucket : grouped.values()) {
             ScrumTitle title = bucket.get(0).getTitle();
             List<DailyCalendarView.ItemView> items = new ArrayList<>(bucket.size());
-            Set<CompetencyCategory> groupPrimary = new LinkedHashSet<>();
             boolean groupEditable = false;
             for (Scrum scrum : bucket) {
                 boolean editable = isEditable(scrum, today, zone);
                 items.add(
                         new DailyCalendarView.ItemView(
-                                scrum.getId(), scrum.getContent(), scrum.isHasStar(), editable));
+                                scrum.getId(),
+                                scrum.getContent(),
+                                scrum.isHasStar(),
+                                primaryByScrumId.get(scrum.getId()),
+                                starRecordIdByScrumId.get(scrum.getId()),
+                                editable));
                 if (editable) {
                     groupEditable = true;
-                }
-                Set<CompetencyCategory> scrumPrimary = primaryByScrumId.get(scrum.getId());
-                if (scrumPrimary != null) {
-                    groupPrimary.addAll(scrumPrimary);
                 }
             }
             groups.add(
@@ -105,7 +106,6 @@ public class CalendarQueryService implements GetDailyCalendarUseCase {
                             title.getId(),
                             title.getProject().getName(),
                             title.getFreeText(),
-                            List.copyOf(groupPrimary),
                             groupEditable,
                             items));
         }

--- a/src/test/java/com/groute/groute_server/record/application/service/CalendarQueryServiceTest.java
+++ b/src/test/java/com/groute/groute_server/record/application/service/CalendarQueryServiceTest.java
@@ -200,13 +200,13 @@ class CalendarQueryServiceTest {
     }
 
     @Nested
-    @DisplayName("primaryCategories·detailTags 집계")
+    @DisplayName("item primaryCategory·starRecordId·detailTags 집계")
     class TagAggregation {
 
         @Test
-        @DisplayName("같은 카드 내 여러 STAR의 primaryCategory를 distinct로 모은다")
-        void should_aggregateGroupPrimaryCategories_distinctByCard() {
-            // given — 한 카드 안에 2개 스크럼, 서로 다른 primaryCategory
+        @DisplayName("STAR 완료된 item에 primaryCategory와 starRecordId를 매핑한다")
+        void should_setItemPrimaryCategoryAndStarRecordId_when_starCompleted() {
+            // given — 한 카드 안에 2개 스크럼, 서로 다른 primaryCategory와 starRecordId
             ScrumTitle t = title(1L, "P", "F");
             Scrum a = scrum(10L, t, "x", true, LocalDate.now().minusDays(1));
             Scrum b = scrum(11L, t, "y", true, LocalDate.now().minusDays(1));
@@ -215,23 +215,62 @@ class CalendarQueryServiceTest {
                     .willReturn(
                             List.of(
                                     new ScrumStarTagProjection(
-                                            10L, CompetencyCategory.PLANNING_EXECUTION, "UX 설계"),
+                                            10L,
+                                            100L,
+                                            CompetencyCategory.PLANNING_EXECUTION,
+                                            "UX 설계"),
                                     new ScrumStarTagProjection(
-                                            11L, CompetencyCategory.COLLABORATION, "이해관계자 조율")));
+                                            11L,
+                                            101L,
+                                            CompetencyCategory.COLLABORATION,
+                                            "이해관계자 조율")));
 
             // when
             DailyCalendarView view = service.getDailyCalendar(QUERY);
 
             // then
-            assertThat(view.groups().get(0).primaryCategories())
-                    .containsExactly(
-                            CompetencyCategory.PLANNING_EXECUTION,
-                            CompetencyCategory.COLLABORATION);
+            List<DailyCalendarView.ItemView> items = view.groups().get(0).items();
+            assertThat(items.get(0).primaryCategory())
+                    .isEqualTo(CompetencyCategory.PLANNING_EXECUTION);
+            assertThat(items.get(0).starRecordId()).isEqualTo(100L);
+            assertThat(items.get(1).primaryCategory()).isEqualTo(CompetencyCategory.COLLABORATION);
+            assertThat(items.get(1).starRecordId()).isEqualTo(101L);
         }
 
         @Test
-        @DisplayName("STAR 완료가 없는 카드는 primaryCategories=[] 를 반환한다")
-        void should_returnEmptyPrimaryCategories_when_noStarOnCard() {
+        @DisplayName(
+                "같은 scrum의 detailTag가 여러 row여도 primaryCategory·starRecordId는 첫 row 값으로 단일 매핑된다")
+        void should_useFirstRowMapping_when_multipleDetailTagsPerScrum() {
+            // given — scrumId=10에 detailTag가 2개 row
+            ScrumTitle t = title(1L, "P", "F");
+            Scrum s = scrum(10L, t, "x", true, LocalDate.now().minusDays(1));
+            given(scrumQueryPort.findAllByUserAndDate(USER_ID, DATE)).willReturn(List.of(s));
+            given(starTagQueryPort.findCompletedTagsByScrumIds(anyLong(), any()))
+                    .willReturn(
+                            List.of(
+                                    new ScrumStarTagProjection(
+                                            10L,
+                                            100L,
+                                            CompetencyCategory.PLANNING_EXECUTION,
+                                            "UX 설계"),
+                                    new ScrumStarTagProjection(
+                                            10L,
+                                            100L,
+                                            CompetencyCategory.PLANNING_EXECUTION,
+                                            "품질 관리")));
+
+            // when
+            DailyCalendarView view = service.getDailyCalendar(QUERY);
+
+            // then
+            DailyCalendarView.ItemView item = view.groups().get(0).items().get(0);
+            assertThat(item.primaryCategory()).isEqualTo(CompetencyCategory.PLANNING_EXECUTION);
+            assertThat(item.starRecordId()).isEqualTo(100L);
+        }
+
+        @Test
+        @DisplayName("STAR 완료가 없는 item은 primaryCategory·starRecordId가 null이다")
+        void should_returnNullPrimaryCategoryAndStarRecordId_when_noStarOnItem() {
             // given
             ScrumTitle t = title(1L, "P", "F");
             Scrum s = scrum(10L, t, "x", false, LocalDate.now().minusDays(1));
@@ -243,7 +282,9 @@ class CalendarQueryServiceTest {
             DailyCalendarView view = service.getDailyCalendar(QUERY);
 
             // then
-            assertThat(view.groups().get(0).primaryCategories()).isEmpty();
+            DailyCalendarView.ItemView item = view.groups().get(0).items().get(0);
+            assertThat(item.primaryCategory()).isNull();
+            assertThat(item.starRecordId()).isNull();
         }
 
         @Test
@@ -259,13 +300,19 @@ class CalendarQueryServiceTest {
                     .willReturn(
                             List.of(
                                     new ScrumStarTagProjection(
-                                            10L, CompetencyCategory.PLANNING_EXECUTION, "UX 설계"),
+                                            10L,
+                                            100L,
+                                            CompetencyCategory.PLANNING_EXECUTION,
+                                            "UX 설계"),
                                     new ScrumStarTagProjection(
-                                            10L, CompetencyCategory.PLANNING_EXECUTION, "품질 관리"),
+                                            10L,
+                                            100L,
+                                            CompetencyCategory.PLANNING_EXECUTION,
+                                            "품질 관리"),
                                     new ScrumStarTagProjection(
-                                            20L, CompetencyCategory.COLLABORATION, "UX 설계"),
+                                            20L, 200L, CompetencyCategory.COLLABORATION, "UX 설계"),
                                     new ScrumStarTagProjection(
-                                            20L, CompetencyCategory.COLLABORATION, "고객 지원")));
+                                            20L, 200L, CompetencyCategory.COLLABORATION, "고객 지원")));
 
             // when
             DailyCalendarView view = service.getDailyCalendar(QUERY);


### PR DESCRIPTION
## 요약
- 그룹 레벨 `primaryCategories` 제거, 각 item에 `primaryCategory`·`starRecordId` 추가
- 프론트가 item별 hasStar 막대기 색상을 역량별로 매핑할 수 있게 하고, STAR 완료 item 클릭 시 상세 페이지 이동이 가능하도록 starRecordId 노출

## 변경 사항
- [x] 기능
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 문서
- [x] 테스트
- [ ] 기타

## 테스트
- [x] 로컬 테스트 완료
- 테스트 방법:
    - ./gradlew spotlessApply build
    - CalendarQueryServiceTest 신규/수정 케이스 통과 확인
    - Swagger 응답 스키마 확인

### 커버리지 (JaCoCo)
- 라인 커버리지: 기준 60% 이상 유지
- [x] `./gradlew test` 실행 후 `build/reports/jacoco/index.html`에서 수치 확인

## 스크린샷/로그 (선택)
- 필요한 경우 첨부

## 롤백/리스크
- 리스크 포인트: 응답 스키마 breaking change (그룹 `primaryCategories` 필드 제거). 프론트 동시 배포 필요
- 롤백 방법: 해당 커밋 revert

## 관련 이슈
Closes #151

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **기능 개선**
  * 캘린더의 일일 항목 조회 응답 구조가 개선되었습니다. 이제 각 항목별로 대표 역량 카테고리와 상세 정보 접근을 위한 식별자가 명확하게 제공되어, 사용자가 완료된 항목의 세부 내용을 더욱 쉽게 확인할 수 있습니다.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/2026-KUSITMS-GLIT/2026-KUSITMS-GLIT-BACK/pull/152?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->