### PR TITLE
chore: AI 서버 호출 경로를 /api에서 /v1으로 변경

### DIFF
--- a/src/main/java/com/groute/groute_server/record/adapter/out/ai/AiTaggingClientAdapter.java
+++ b/src/main/java/com/groute/groute_server/record/adapter/out/ai/AiTaggingClientAdapter.java
@@ -29,7 +29,7 @@ import lombok.extern.slf4j.Slf4j;
 /**
  * {@link AiTaggingClient}의 FastAPI 실 구현체.
  *
- * <p>STAR 기록의 ST/A/R 텍스트와 직군, 선택 역량을 FastAPI {@code POST /api/tagging}에 전송하고, 응답으로 받은
+ * <p>STAR 기록의 ST/A/R 텍스트와 직군, 선택 역량을 FastAPI {@code POST /v1/tagging}에 전송하고, 응답으로 받은
  * primaryCategory + detailTags를 {@link CompleteAiTaggingUseCase}에 전달한다. 실패 시 최대 1회 재시도하며, 재시도 후에도
  * 실패 시 FAILED로 확정한다.
  */
@@ -127,7 +127,7 @@ public class AiTaggingClientAdapter implements AiTaggingClient {
         try {
             return restClient
                     .post()
-                    .uri("/api/tagging")
+                    .uri("/v1/tagging")
                     .body(request)
                     .retrieve()
                     .body(AiTaggingResponse.class);

--- a/src/main/java/com/groute/groute_server/record/adapter/out/ai/dto/AiTaggingRequest.java
+++ b/src/main/java/com/groute/groute_server/record/adapter/out/ai/dto/AiTaggingRequest.java
@@ -2,7 +2,7 @@ package com.groute.groute_server.record.adapter.out.ai.dto;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 
-/** FastAPI POST /api/tagging 요청 body. */
+/** FastAPI POST /v1/tagging 요청 body. */
 public record AiTaggingRequest(
         @JsonProperty("jobRole") String jobRole,
         @JsonProperty("selectedCompetency") String selectedCompetency,

--- a/src/main/java/com/groute/groute_server/report/adapter/out/ai/AiReportClientAdapter.java
+++ b/src/main/java/com/groute/groute_server/report/adapter/out/ai/AiReportClientAdapter.java
@@ -43,7 +43,7 @@ import lombok.extern.slf4j.Slf4j;
 /**
  * {@link RequestAiReportPort}의 FastAPI 실 구현체.
  *
- * <p>MINI 타입은 {@code /api/reports/mini} 1회 호출, CAREER 타입은 branding / narrative / highlights /
+ * <p>MINI 타입은 {@code /v1/reports/mini} 1회 호출, CAREER 타입은 branding / narrative / highlights /
  * strengths-and-interview 4개 순차 호출 후 결과를 합쳐 반환한다. 모든 요청에 {@code X-Internal-Token} 헤더를 포함한다.
  */
 @Slf4j
@@ -110,7 +110,7 @@ public class AiReportClientAdapter implements RequestAiReportPort {
             AiMiniReportResponse response =
                     restClient
                             .post()
-                            .uri("/api/reports/mini")
+                            .uri("/v1/reports/mini")
                             .body(request)
                             .retrieve()
                             .body(AiMiniReportResponse.class);
@@ -144,7 +144,7 @@ public class AiReportClientAdapter implements RequestAiReportPort {
             AiCareerBrandingResponse branding =
                     restClient
                             .post()
-                            .uri("/api/reports/career/branding")
+                            .uri("/v1/reports/career/branding")
                             .body(request)
                             .retrieve()
                             .body(AiCareerBrandingResponse.class);
@@ -152,7 +152,7 @@ public class AiReportClientAdapter implements RequestAiReportPort {
             AiCareerNarrativeResponse narrative =
                     restClient
                             .post()
-                            .uri("/api/reports/career/narrative")
+                            .uri("/v1/reports/career/narrative")
                             .body(request)
                             .retrieve()
                             .body(AiCareerNarrativeResponse.class);
@@ -160,7 +160,7 @@ public class AiReportClientAdapter implements RequestAiReportPort {
             AiCareerHighlightsResponse highlights =
                     restClient
                             .post()
-                            .uri("/api/reports/career/highlights")
+                            .uri("/v1/reports/career/highlights")
                             .body(request)
                             .retrieve()
                             .body(AiCareerHighlightsResponse.class);
@@ -168,7 +168,7 @@ public class AiReportClientAdapter implements RequestAiReportPort {
             AiCareerStrengthsAndInterviewResponse strengthsAndInterview =
                     restClient
                             .post()
-                            .uri("/api/reports/career/strengths-and-interview")
+                            .uri("/v1/reports/career/strengths-and-interview")
                             .body(request)
                             .retrieve()
                             .body(AiCareerStrengthsAndInterviewResponse.class);

--- a/src/main/java/com/groute/groute_server/report/adapter/out/ai/dto/AiMiniReportResponse.java
+++ b/src/main/java/com/groute/groute_server/report/adapter/out/ai/dto/AiMiniReportResponse.java
@@ -4,7 +4,7 @@ import java.util.List;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 
-/** FastAPI /api/reports/mini 응답. */
+/** FastAPI /v1/reports/mini 응답. */
 public record AiMiniReportResponse(
         @JsonProperty("activitySummary") String activitySummary,
         @JsonProperty("nextFocusPoint") String nextFocusPoint,

--- a/src/test/java/com/groute/groute_server/record/adapter/out/ai/AiTaggingClientAdapterTest.java
+++ b/src/test/java/com/groute/groute_server/record/adapter/out/ai/AiTaggingClientAdapterTest.java
@@ -60,7 +60,7 @@ class AiTaggingClientAdapterTest {
         responseSpec = mock(RestClient.ResponseSpec.class);
 
         given(mockRestClient.post()).willReturn(uriSpec);
-        given(uriSpec.uri("/api/tagging")).willReturn(bodySpec);
+        given(uriSpec.uri("/v1/tagging")).willReturn(bodySpec);
         given(bodySpec.body(ArgumentMatchers.any(AiTaggingRequest.class))).willReturn(bodySpec);
         given(bodySpec.retrieve()).willReturn(responseSpec);
 


### PR DESCRIPTION
## 요약
AI 서버의 더미 응답 경로(/api/*) 대신 실제 LLM이 붙은 /v1/* 경로로 호출 경로 변경

## 변경 사항
- [ ] 기능
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 문서
- [ ] 테스트
- [x] 기타

## 테스트
- [x] 로컬 테스트 완료
- 테스트 방법:
    - ./gradlew test

### 커버리지 (JaCoCo)
- 라인 커버리지: __%  (기준: 60% 이상)
- [ ] `./gradlew test` 실행 후 `build/reports/jacoco/index.html`에서 수치 확인
- (선택) 리포트 스크린샷 또는 60% 미달/특이사항 공유:

## 스크린샷/로그 (선택)
- 필요한 경우 첨부

## 롤백/리스크
- 리스크 포인트: AI 서버 /v1/ 라우터에 내부 토큰 인증이 추가되어야 정상 동작. AI 담당자 작업 선행 필요
- 롤백 방법:

## 관련 이슈
Closes #154 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Refactor**
  * AI 태깅 및 보고서 생성 서비스의 API 엔드포인트를 v1 버전으로 업데이트했습니다.

* **Tests**
  * 해당 테스트 케이스를 업데이트했습니다.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/2026-KUSITMS-GLIT/2026-KUSITMS-GLIT-BACK/pull/155?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->