### PR TITLE
fix: 캘린더 월별·프리뷰 API에서 PENDING 스크럼 노출 (#153)

### DIFF
--- a/src/main/java/com/groute/groute_server/calendar/repository/CalendarHomeRepository.java
+++ b/src/main/java/com/groute/groute_server/calendar/repository/CalendarHomeRepository.java
@@ -8,7 +8,6 @@ import jakarta.persistence.EntityManager;
 import org.springframework.stereotype.Repository;
 
 import com.groute.groute_server.record.domain.Scrum;
-import com.groute.groute_server.record.domain.enums.ScrumTitleStatus;
 
 import lombok.RequiredArgsConstructor;
 
@@ -85,7 +84,8 @@ public class CalendarHomeRepository {
      * 지정 일자의 사용자 스크럼 목록. ScrumTitle·Project를 fetch join 하여 추가 쿼리를 피한다.
      *
      * <p>soft-delete된 scrum은 제외. (title/project는 부모 scrum이 살아있으면 동시 살아있다고 가정하는 record 도메인 컨벤션을 따라
-     * 추가 필터하지 않는다.) ScrumTitle.status=COMMITTED인 스크럼만 반환하여 PENDING(임시저장) 스크럼이 일자 프리뷰에 노출되지 않도록 한다.
+     * 추가 필터하지 않는다.) ScrumTitle.status는 필터하지 않으며 PENDING(STAR 미완료) 스크럼도 반환된다. 기획서 CAL-001 프리뷰 정책에 따라
+     * 심화기록이 없는 카드도 노출되어야 한다.
      */
     public List<Scrum> findScrumsByUserAndDate(Long userId, LocalDate date) {
         return em.createQuery(
@@ -97,13 +97,11 @@ public class CalendarHomeRepository {
                         WHERE s.user.id = :userId
                           AND s.scrumDate = :date
                           AND s.isDeleted = false
-                          AND t.status = :committed
                         ORDER BY s.id
                         """,
                         Scrum.class)
                 .setParameter("userId", userId)
                 .setParameter("date", date)
-                .setParameter("committed", ScrumTitleStatus.COMMITTED)
                 .getResultList();
     }
 

--- a/src/main/java/com/groute/groute_server/calendar/repository/CalendarHomeRepository.java
+++ b/src/main/java/com/groute/groute_server/calendar/repository/CalendarHomeRepository.java
@@ -34,26 +34,23 @@ public class CalendarHomeRepository {
     private final EntityManager em;
 
     /**
-     * 사용자가 해당 기간에 스크럼을 작성한 날짜 set. soft-delete된 scrum은 제외. ScrumTitle.status=COMMITTED인 스크럼만 포함하여
-     * PENDING(임시저장) 스크럼이 캘린더에 노출되지 않도록 한다.
+     * 사용자가 해당 기간에 스크럼을 작성한 날짜 set. soft-delete된 scrum은 제외. ScrumTitle.status는 필터하지 않으며 PENDING(STAR
+     * 미완료) 스크럼도 포함된다. 기획서 CAL-001 정책에 따라 스크럼만 작성된 날도 캘린더 잔디에 노출되어야 한다.
      */
     public List<LocalDate> findScrumDatesInRange(Long userId, LocalDate start, LocalDate end) {
         return em.createQuery(
                         """
                         SELECT DISTINCT s.scrumDate
                         FROM Scrum s
-                        JOIN s.title t
                         WHERE s.user.id = :userId
                           AND s.scrumDate BETWEEN :start AND :end
                           AND s.isDeleted = false
-                          AND t.status = :committed
                         ORDER BY s.scrumDate
                         """,
                         LocalDate.class)
                 .setParameter("userId", userId)
                 .setParameter("start", start)
                 .setParameter("end", end)
-                .setParameter("committed", ScrumTitleStatus.COMMITTED)
                 .getResultList();
     }
 


### PR DESCRIPTION
## 요약
- 캘린더 월별/프리뷰 API에서 ScrumTitle.status=COMMITTED 필터를 제거하여 스크럼만 작성된 PENDING 카드도 노출되도록 수정

## 변경 사항
- [ ] 기능
- [x] 버그 수정
- [ ] 리팩토링
- [ ] 문서
- [ ] 테스트
- [ ] 기타

`CalendarHomeRepository`
- `findScrumDatesInRange`: `AND t.status = :committed` 제거 (월별 잔디)
- `findScrumsByUserAndDate`: `AND t.status = :committed` 제거 (날짜 프리뷰)
- 사용하지 않게 된 `ScrumTitleStatus` import 정리
- 두 메서드의 Javadoc을 새 정책(기획서 CAL-001)에 맞게 갱신

`findCompletedStarRowsInRange`/`findCompletedStarTagsByScrumIds`는 STAR 집계용이라 현행 유지.

## 테스트
- [x] 로컬 테스트 완료
- 테스트 방법:
    - `./gradlew spotlessApply build`
    - `CalendarHomeServiceTest` 통과 (repository mock 기반이라 정책 변경과 무관하게 그대로 통과)

### 커버리지 (JaCoCo)
- 라인 커버리지: 기존 수치 유지 (코드 라인 감소, 추가 분기 없음)
- [x] `./gradlew build` 실행 시 `jacocoTestCoverageVerification` 통과

## 스크린샷/로그 (선택)
- 필요한 경우 첨부

## 롤백/리스크
- 리스크 포인트:
  - 캘린더 메인 홈에 스크럼만 작성된 날도 잔디 표시되고, 프리뷰 카드도 노출됨 (기획 의도와 일치)
  - 프론트는 카드 내 `primaryCategories` 빈 배열 처리가 이미 되어있어야 정상 렌더 (CAL-001 기획 명시)
- 롤백 방법: 두 커밋(`ce6cdad`, `777330f`) revert

## 관련 이슈
Closes #153

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 캘린더에서 보류 중인 스크럼이 날짜 조회 시 포함되도록 개선했습니다.

* **최적화**
  * 스크럼 검색 쿼리 로직을 단순화하여 성능을 개선했습니다.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/2026-KUSITMS-GLIT/2026-KUSITMS-GLIT-BACK/pull/156?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->