### PR TITLE
fix: 일자별 캘린더 조회에서 PENDING 스크럼 제외 (#157)

### DIFF
--- a/src/main/java/com/groute/groute_server/record/application/service/CalendarQueryService.java
+++ b/src/main/java/com/groute/groute_server/record/application/service/CalendarQueryService.java
@@ -21,6 +21,7 @@ import com.groute.groute_server.record.application.port.out.star.StarTagQueryPor
 import com.groute.groute_server.record.domain.Scrum;
 import com.groute.groute_server.record.domain.ScrumTitle;
 import com.groute.groute_server.record.domain.enums.CompetencyCategory;
+import com.groute.groute_server.record.domain.enums.ScrumTitleStatus;
 
 import lombok.RequiredArgsConstructor;
 
@@ -51,7 +52,13 @@ public class CalendarQueryService implements GetDailyCalendarUseCase {
     @Override
     public DailyCalendarView getDailyCalendar(GetDailyCalendarQuery query) {
         // 1. 해당 일자의 사용자 스크럼 전체 로드 (Title·Project fetch join)
-        List<Scrum> scrums = scrumQueryPort.findAllByUserAndDate(query.userId(), query.date());
+        //    ScrumTitle.status=COMMITTED 인 스크럼만 노출 (PENDING 임시저장 세션은 사용자에게 보이지 않는다).
+        //    포트는 PENDING 도 함께 반환(ScrumSyncService 의 cleanup 경로가 필요로 함)하므로
+        //    조회 응답 단에서 service-layer 필터를 적용한다.
+        List<Scrum> scrums =
+                scrumQueryPort.findAllByUserAndDate(query.userId(), query.date()).stream()
+                        .filter(s -> s.getTitle().getStatus() == ScrumTitleStatus.COMMITTED)
+                        .toList();
         if (scrums.isEmpty()) {
             return new DailyCalendarView(List.of(), List.of());
         }

--- a/src/test/java/com/groute/groute_server/record/application/service/CalendarQueryServiceTest.java
+++ b/src/test/java/com/groute/groute_server/record/application/service/CalendarQueryServiceTest.java
@@ -28,6 +28,7 @@ import com.groute.groute_server.record.domain.Project;
 import com.groute.groute_server.record.domain.Scrum;
 import com.groute.groute_server.record.domain.ScrumTitle;
 import com.groute.groute_server.record.domain.enums.CompetencyCategory;
+import com.groute.groute_server.record.domain.enums.ScrumTitleStatus;
 import com.groute.groute_server.user.entity.User;
 
 @ExtendWith(MockitoExtension.class)
@@ -51,6 +52,51 @@ class CalendarQueryServiceTest {
         void should_returnEmptyGroupsAndTags_when_noScrumOnDate() {
             // given
             given(scrumQueryPort.findAllByUserAndDate(USER_ID, DATE)).willReturn(List.of());
+
+            // when
+            DailyCalendarView view = service.getDailyCalendar(QUERY);
+
+            // then
+            assertThat(view.groups()).isEmpty();
+            assertThat(view.detailTags()).isEmpty();
+        }
+    }
+
+    @Nested
+    @DisplayName("PENDING 필터")
+    class PendingFilter {
+
+        @Test
+        @DisplayName("ScrumTitle.status=PENDING 인 스크럼은 응답에서 제외된다")
+        void should_excludePendingScrums_when_titleStatusIsPending() {
+            // given — 같은 일자에 PENDING 1개, COMMITTED 1개
+            ScrumTitle pendingTitle = title(1L, "P1", "F1", ScrumTitleStatus.PENDING);
+            ScrumTitle committedTitle = title(2L, "P2", "F2", ScrumTitleStatus.COMMITTED);
+            Scrum pending = scrum(10L, pendingTitle, "x", false, DATE.minusDays(1));
+            Scrum committed = scrum(20L, committedTitle, "y", false, DATE.minusDays(1));
+            given(scrumQueryPort.findAllByUserAndDate(USER_ID, DATE))
+                    .willReturn(List.of(pending, committed));
+            given(starTagQueryPort.findCompletedTagsByScrumIds(anyLong(), any()))
+                    .willReturn(List.of());
+
+            // when
+            DailyCalendarView view = service.getDailyCalendar(QUERY);
+
+            // then — COMMITTED 그룹만 노출
+            assertThat(view.groups()).hasSize(1);
+            assertThat(view.groups().get(0).titleId()).isEqualTo(2L);
+            assertThat(view.groups().get(0).items())
+                    .extracting(DailyCalendarView.ItemView::scrumId)
+                    .containsExactly(20L);
+        }
+
+        @Test
+        @DisplayName("모든 스크럼이 PENDING 이면 빈 그룹·빈 detailTags 를 반환한다")
+        void should_returnEmpty_when_allScrumsArePending() {
+            // given
+            ScrumTitle pendingTitle = title(1L, "P1", "F1", ScrumTitleStatus.PENDING);
+            Scrum pending = scrum(10L, pendingTitle, "x", false, DATE.minusDays(1));
+            given(scrumQueryPort.findAllByUserAndDate(USER_ID, DATE)).willReturn(List.of(pending));
 
             // when
             DailyCalendarView view = service.getDailyCalendar(QUERY);
@@ -278,11 +324,17 @@ class CalendarQueryServiceTest {
     // ============== helpers ==============
 
     private static ScrumTitle title(Long id, String projectName, String freeText) {
+        return title(id, projectName, freeText, ScrumTitleStatus.COMMITTED);
+    }
+
+    private static ScrumTitle title(
+            Long id, String projectName, String freeText, ScrumTitleStatus status) {
         Project project = Project.builder().id(1000L + id).name(projectName).build();
         ScrumTitle title = new ScrumTitle();
         ReflectionTestUtils.setField(title, "id", id);
         ReflectionTestUtils.setField(title, "project", project);
         ReflectionTestUtils.setField(title, "freeText", freeText);
+        ReflectionTestUtils.setField(title, "status", status);
         return title;
     }
 


### PR DESCRIPTION
## 요약
- `GET /api/calendar/daily` 응답에서 ScrumTitle.status=PENDING(임시저장) 스크럼이 노출되던 버그 수정.
- 기획 정책상 스크럼은 STAR 최소 1개 완료 시점에만 사용자에게 보여야 하므로 COMMITTED 만 반환하도록 정합.

## 변경사항
- `CalendarQueryService` 에서 `scrumQueryPort.findAllByUserAndDate` 결과를 service-layer 에서 `ScrumTitle.status == COMMITTED` 로 필터링.
- 포트/JPA 레포지토리 단에서 필터하지 않은 이유: 동일 포트가 `ScrumSyncService` 에서도 사용되며, sync 경로는 PENDING 세션 cleanup 을 위해 PENDING 도 조회해야 함.
- 테스트 헬퍼 `title(...)` 의 기본 status 를 COMMITTED 로 설정하고 status 인자 받는 오버로드 추가.
- `PendingFilter` 케이스 2건 추가: PENDING/COMMITTED 혼재 시 COMMITTED 만 노출 / 모두 PENDING 이면 빈 응답.

## 테스트
- `./gradlew spotlessApply test --tests CalendarQueryServiceTest --tests ScrumSyncServiceTest` BUILD SUCCESSFUL.
- 기존 `CalendarQueryServiceTest` 케이스(헬퍼 기본값 변경 영향) 전부 그린.
- 신규 PENDING 필터 케이스 2건 그린.
- `ScrumSyncService` 영향 없음 확인 (포트 시그니처 미변경).

## JaCoCo
- 변경 클래스 `CalendarQueryService` 의 신규 필터 라인 커버.

## 스크린샷
- 해당 없음 (API 응답 변경).

## 롤백
- 본 PR revert 시 `CalendarQueryService` 의 stream filter 만 제거되어 즉시 이전 동작(PENDING 포함) 으로 복귀.

## 관련 이슈
- Closes #157

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 버그 수정

* 일별 달력 조회 시 완료된 스크럼만 표시되도록 변경되었습니다. 임시저장 상태의 스크럼은 조회 결과에서 제외되어 확정된 일정만 확인할 수 있습니다.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/2026-KUSITMS-GLIT/2026-KUSITMS-GLIT-BACK/pull/158?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->