### PR TITLE
fix: 스크럼 작성 시 user streak 갱신 호출 추가 (#159)

### DIFF
--- a/src/main/java/com/groute/groute_server/record/application/service/ScrumBulkWriteService.java
+++ b/src/main/java/com/groute/groute_server/record/application/service/ScrumBulkWriteService.java
@@ -19,6 +19,7 @@ import com.groute.groute_server.record.application.port.out.scrum.ScrumWritePort
 import com.groute.groute_server.record.application.port.out.scrumtitle.ScrumTitleRepositoryPort;
 import com.groute.groute_server.record.application.port.out.star.StarRecordRepositoryPort;
 import com.groute.groute_server.record.application.port.out.user.UserReferencePort;
+import com.groute.groute_server.record.application.port.out.user.UserStreakPort;
 import com.groute.groute_server.record.domain.Project;
 import com.groute.groute_server.record.domain.Scrum;
 import com.groute.groute_server.record.domain.ScrumTitle;
@@ -46,6 +47,7 @@ public class ScrumBulkWriteService implements BulkWriteScrumUseCase {
     private final StarRecordRepositoryPort starRecordRepositoryPort;
     private final StarImageCascadeCleaner starImageCascadeCleaner;
     private final UserReferencePort userReferencePort;
+    private final UserStreakPort userStreakPort;
 
     @Override
     public BulkWriteScrumResult bulkWrite(BulkWriteScrumCommand command) {
@@ -108,7 +110,10 @@ public class ScrumBulkWriteService implements BulkWriteScrumUseCase {
         }
         List<Scrum> savedScrums = scrumWritePort.saveAll(scrums);
 
-        // 6. Project.titleCount 증감 (동일 projectId 중복 시 count만큼)
+        // 6. user streak 갱신 (REC-001) — 같은 날 재작성은 entity 단에서 멱등 처리
+        userStreakPort.recordOnDate(command.userId(), command.date());
+
+        // 7. Project.titleCount 증감 (동일 projectId 중복 시 count만큼)
         groups.stream()
                 .collect(
                         Collectors.groupingBy(
@@ -118,7 +123,7 @@ public class ScrumBulkWriteService implements BulkWriteScrumUseCase {
                         (projectId, count) ->
                                 projectPort.applyTitleCountIncrement(projectId, count.intValue()));
 
-        // 7. 결과 조립 (저장 순서 보장)
+        // 8. 결과 조립 (저장 순서 보장)
         List<BulkWriteScrumResult.GroupResult> results = new ArrayList<>();
         int scrumIdx = 0;
         for (int i = 0; i < savedTitles.size(); i++) {

--- a/src/test/java/com/groute/groute_server/record/application/service/ScrumBulkWriteServiceTest.java
+++ b/src/test/java/com/groute/groute_server/record/application/service/ScrumBulkWriteServiceTest.java
@@ -2,6 +2,7 @@ package com.groute.groute_server.record.application.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyCollection;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.anyLong;
@@ -33,6 +34,7 @@ import com.groute.groute_server.record.application.port.out.scrum.ScrumWritePort
 import com.groute.groute_server.record.application.port.out.scrumtitle.ScrumTitleRepositoryPort;
 import com.groute.groute_server.record.application.port.out.star.StarRecordRepositoryPort;
 import com.groute.groute_server.record.application.port.out.user.UserReferencePort;
+import com.groute.groute_server.record.application.port.out.user.UserStreakPort;
 import com.groute.groute_server.record.domain.Project;
 import com.groute.groute_server.record.domain.Scrum;
 import com.groute.groute_server.record.domain.ScrumTitle;
@@ -52,6 +54,7 @@ class ScrumBulkWriteServiceTest {
     @Mock StarRecordRepositoryPort starRecordRepositoryPort;
     @Mock StarImageCascadeCleaner starImageCascadeCleaner;
     @Mock UserReferencePort userReferencePort;
+    @Mock UserStreakPort userStreakPort;
 
     @InjectMocks ScrumBulkWriteService service;
 
@@ -235,6 +238,51 @@ class ScrumBulkWriteServiceTest {
             assertThat(result.groups().get(0).scrums().get(1).content()).isEqualTo("B");
             assertThat(result.groups().get(1).scrums()).hasSize(1);
             assertThat(result.groups().get(1).scrums().get(0).content()).isEqualTo("C");
+        }
+    }
+
+    @Nested
+    @DisplayName("streak 갱신")
+    class Streak {
+
+        @Test
+        @DisplayName("저장 성공 시 user streak를 userId·date로 갱신한다")
+        void should_recordStreak_when_writeSucceeds() {
+            given(projectPort.findByIdAndUserId(100L, USER_ID))
+                    .willReturn(Optional.of(project(100L, "프로젝트A")));
+            given(userReferencePort.getReferenceById(USER_ID))
+                    .willReturn(User.createForSocialLogin());
+            stubSaveTitles();
+            stubSaveScrums();
+
+            service.bulkWrite(command(group(100L, "제목", "스크럼1")));
+
+            verify(userStreakPort).recordOnDate(USER_ID, DATE);
+        }
+
+        @Test
+        @DisplayName("COMMITTED 충돌로 실패하면 streak를 갱신하지 않는다")
+        void should_notRecordStreak_when_committedConflict() {
+            given(scrumQueryPort.findAllByUserAndDate(USER_ID, DATE))
+                    .willReturn(
+                            List.of(scrumWithTitle(50L, 10L, ScrumTitleStatus.COMMITTED, 100L)));
+
+            assertThatThrownBy(() -> service.bulkWrite(command(group(100L, "제목", "스크럼1"))))
+                    .isInstanceOf(BusinessException.class);
+
+            verify(userStreakPort, never()).recordOnDate(anyLong(), any(LocalDate.class));
+        }
+
+        @Test
+        @DisplayName("스크럼 개수 초과로 실패하면 streak를 갱신하지 않는다")
+        void should_notRecordStreak_when_dateLimitExceeded() {
+            BulkWriteScrumCommand command =
+                    command(group(100L, "제목", "a", "b", "c", "d", "e", "f"));
+
+            assertThatThrownBy(() -> service.bulkWrite(command))
+                    .isInstanceOf(BusinessException.class);
+
+            verify(userStreakPort, never()).recordOnDate(anyLong(), any(LocalDate.class));
         }
     }
 


### PR DESCRIPTION
## 요약
- 스크럼 일괄 저장 시 `UserStreakPort.recordOnDate`가 호출되지 않아 `consecutiveRecordDays`가 항상 0으로 반환되던 문제 수정.

## 변경 사항
- [ ] 기능
- [x] 버그 수정
- [ ] 리팩토링
- [ ] 문서
- [x] 테스트
- [ ] 기타

상세:
- `ScrumBulkWriteService`에 `UserStreakPort` 주입, `scrumWritePort.saveAll` 직후 `userStreakPort.recordOnDate(userId, date)` 호출.
- 같은 날 재작성/백데이트는 `User.recordOnDate` 단에서 멱등 처리되므로 호출은 무조건 1회.

## 테스트
- [x] 로컬 테스트 완료
- 테스트 방법:
    - `./gradlew spotlessApply test --tests "*ScrumBulkWriteServiceTest*"` ✅
- 추가된 케이스:
    - 저장 성공 시 `recordOnDate(userId, date)` 호출 검증
    - COMMITTED 충돌 실패 시 streak 갱신 미호출 검증
    - 스크럼 개수 초과 실패 시 streak 갱신 미호출 검증

### 커버리지 (JaCoCo)
- 라인 커버리지: __%  (기준: 60% 이상)
- [ ] `./gradlew test` 실행 후 `build/reports/jacoco/index.html`에서 수치 확인

## 롤백/리스크
- 리스크 포인트: 동일 트랜잭션 내 `EntityManager.find(User)` 1회 추가 → 작성당 SELECT 1회 증가. 빈도 낮아 영향 미미.
- 롤백 방법: 해당 커밋 revert.

## 관련 이슈
Closes #159

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * 스크럼 및 타이틀을 일괄 저장할 때 해당 날짜의 사용자 스트릭이 자동으로 갱신됩니다.

* **Tests**
  * 스트릭 갱신 기능의 정상 작동과 예외 상황을 검증하는 테스트를 추가했습니다.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/2026-KUSITMS-GLIT/2026-KUSITMS-GLIT-BACK/pull/160?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->