### PR TITLE
refactor: DateTimeFormatters placeholder Javadoc 제거 (#162)

### DIFF
--- a/src/main/java/com/groute/groute_server/common/util/DateTimeFormatters.java
+++ b/src/main/java/com/groute/groute_server/common/util/DateTimeFormatters.java
@@ -2,36 +2,9 @@ package com.groute.groute_server.common.util;
 
 import java.time.ZoneId;
 
-/**
- * 사람이 읽는 시간 문자열 포맷을 한 곳에서 관리하는 유틸리티.
- *
- * <h2>포지셔닝</h2>
- *
- * <ul>
- *   <li>엔티티/DB에 저장되는 시간은 {@link java.time.OffsetDateTime} UTC를 기준으로 한다.
- *   <li>응답 DTO에 <b>raw {@code OffsetDateTime}</b> 필드를 노출하는 경우, 직렬화는 {@link
- *       com.groute.groute_server.common.config.JacksonConfig}가 ISO-8601 UTC로 처리한다. (예: 클라이언트가 직접
- *       상대시간("2시간 전")을 계산하는 케이스)
- *   <li>응답 DTO에 <b>사람이 읽는 문자열</b>(예: "2026.04.18", "04.18 15:45")을 내려야 하는 경우, 서비스/어셈블러 레이어에서 본 클래스의
- *       포맷터/헬퍼를 사용해 {@code String}으로 채운다.
- * </ul>
- *
- * <h2>사용 위치</h2>
- *
- * 서비스 레이어 또는 DTO 어셈블러에서만 호출한다. 엔티티와 컨트롤러는 시간 포맷팅에 관여하지 않는다.
- *
- * <h2>타임존 변환 책임</h2>
- *
- * UTC로 저장된 시간을 KST 표현으로 변환하는 로직은 본 클래스 내부에서 처리한다. 호출부는 UTC/KST 변환을 신경 쓰지 않고 "어떤 포맷으로 보여줄지"만 결정한다.
- *
- * <h2>현재 상태</h2>
- *
- * 응답 DTO 작업 전이므로 실제 포맷터 상수/메서드는 비어 있다. 클라이언트 요구 패턴이 확정되는 대로 이곳에 상수와 헬퍼 메서드를 추가한다. (예: {@code
- * KST_DATE_DOT}, {@code KST_DATE_TIME_DOT}, {@code toKstDate(OffsetDateTime)} 등)
- */
+/** KST 타임존 단일 출처. UTC로 저장된 시간을 한국 표시 기준으로 변환할 때 공통으로 참조한다. */
 public final class DateTimeFormatters {
 
-    /** 한국 서비스 기준 표시용 타임존. UTC로 저장된 시간을 KST로 환산할 때 모든 포맷터/헬퍼가 공통으로 사용한다. */
     public static final ZoneId ZONE_KST = ZoneId.of("Asia/Seoul");
 
     private DateTimeFormatters() {}

--- a/src/main/java/com/groute/groute_server/record/application/service/ScrumBulkWriteService.java
+++ b/src/main/java/com/groute/groute_server/record/application/service/ScrumBulkWriteService.java
@@ -19,6 +19,7 @@ import com.groute.groute_server.record.application.port.out.scrum.ScrumWritePort
 import com.groute.groute_server.record.application.port.out.scrumtitle.ScrumTitleRepositoryPort;
 import com.groute.groute_server.record.application.port.out.star.StarRecordRepositoryPort;
 import com.groute.groute_server.record.application.port.out.user.UserReferencePort;
+import com.groute.groute_server.record.application.port.out.user.UserStreakPort;
 import com.groute.groute_server.record.domain.Project;
 import com.groute.groute_server.record.domain.Scrum;
 import com.groute.groute_server.record.domain.ScrumTitle;
@@ -46,6 +47,7 @@ public class ScrumBulkWriteService implements BulkWriteScrumUseCase {
     private final StarRecordRepositoryPort starRecordRepositoryPort;
     private final StarImageCascadeCleaner starImageCascadeCleaner;
     private final UserReferencePort userReferencePort;
+    private final UserStreakPort userStreakPort;
 
     @Override
     public BulkWriteScrumResult bulkWrite(BulkWriteScrumCommand command) {
@@ -108,7 +110,10 @@ public class ScrumBulkWriteService implements BulkWriteScrumUseCase {
         }
         List<Scrum> savedScrums = scrumWritePort.saveAll(scrums);
 
-        // 6. Project.titleCount 증감 (동일 projectId 중복 시 count만큼)
+        // 6. user streak 갱신 (REC-001) — 같은 날 재작성은 entity 단에서 멱등 처리
+        userStreakPort.recordOnDate(command.userId(), command.date());
+
+        // 7. Project.titleCount 증감 (동일 projectId 중복 시 count만큼)
         groups.stream()
                 .collect(
                         Collectors.groupingBy(
@@ -118,7 +123,7 @@ public class ScrumBulkWriteService implements BulkWriteScrumUseCase {
                         (projectId, count) ->
                                 projectPort.applyTitleCountIncrement(projectId, count.intValue()));
 
-        // 7. 결과 조립 (저장 순서 보장)
+        // 8. 결과 조립 (저장 순서 보장)
         List<BulkWriteScrumResult.GroupResult> results = new ArrayList<>();
         int scrumIdx = 0;
         for (int i = 0; i < savedTitles.size(); i++) {

--- a/src/test/java/com/groute/groute_server/record/application/service/ScrumBulkWriteServiceTest.java
+++ b/src/test/java/com/groute/groute_server/record/application/service/ScrumBulkWriteServiceTest.java
@@ -2,6 +2,7 @@ package com.groute.groute_server.record.application.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyCollection;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.anyLong;
@@ -33,6 +34,7 @@ import com.groute.groute_server.record.application.port.out.scrum.ScrumWritePort
 import com.groute.groute_server.record.application.port.out.scrumtitle.ScrumTitleRepositoryPort;
 import com.groute.groute_server.record.application.port.out.star.StarRecordRepositoryPort;
 import com.groute.groute_server.record.application.port.out.user.UserReferencePort;
+import com.groute.groute_server.record.application.port.out.user.UserStreakPort;
 import com.groute.groute_server.record.domain.Project;
 import com.groute.groute_server.record.domain.Scrum;
 import com.groute.groute_server.record.domain.ScrumTitle;
@@ -52,6 +54,7 @@ class ScrumBulkWriteServiceTest {
     @Mock StarRecordRepositoryPort starRecordRepositoryPort;
     @Mock StarImageCascadeCleaner starImageCascadeCleaner;
     @Mock UserReferencePort userReferencePort;
+    @Mock UserStreakPort userStreakPort;
 
     @InjectMocks ScrumBulkWriteService service;
 
@@ -235,6 +238,51 @@ class ScrumBulkWriteServiceTest {
             assertThat(result.groups().get(0).scrums().get(1).content()).isEqualTo("B");
             assertThat(result.groups().get(1).scrums()).hasSize(1);
             assertThat(result.groups().get(1).scrums().get(0).content()).isEqualTo("C");
+        }
+    }
+
+    @Nested
+    @DisplayName("streak 갱신")
+    class Streak {
+
+        @Test
+        @DisplayName("저장 성공 시 user streak를 userId·date로 갱신한다")
+        void should_recordStreak_when_writeSucceeds() {
+            given(projectPort.findByIdAndUserId(100L, USER_ID))
+                    .willReturn(Optional.of(project(100L, "프로젝트A")));
+            given(userReferencePort.getReferenceById(USER_ID))
+                    .willReturn(User.createForSocialLogin());
+            stubSaveTitles();
+            stubSaveScrums();
+
+            service.bulkWrite(command(group(100L, "제목", "스크럼1")));
+
+            verify(userStreakPort).recordOnDate(USER_ID, DATE);
+        }
+
+        @Test
+        @DisplayName("COMMITTED 충돌로 실패하면 streak를 갱신하지 않는다")
+        void should_notRecordStreak_when_committedConflict() {
+            given(scrumQueryPort.findAllByUserAndDate(USER_ID, DATE))
+                    .willReturn(
+                            List.of(scrumWithTitle(50L, 10L, ScrumTitleStatus.COMMITTED, 100L)));
+
+            assertThatThrownBy(() -> service.bulkWrite(command(group(100L, "제목", "스크럼1"))))
+                    .isInstanceOf(BusinessException.class);
+
+            verify(userStreakPort, never()).recordOnDate(anyLong(), any(LocalDate.class));
+        }
+
+        @Test
+        @DisplayName("스크럼 개수 초과로 실패하면 streak를 갱신하지 않는다")
+        void should_notRecordStreak_when_dateLimitExceeded() {
+            BulkWriteScrumCommand command =
+                    command(group(100L, "제목", "a", "b", "c", "d", "e", "f"));
+
+            assertThatThrownBy(() -> service.bulkWrite(command))
+                    .isInstanceOf(BusinessException.class);
+
+            verify(userStreakPort, never()).recordOnDate(anyLong(), any(LocalDate.class));
         }
     }
 


### PR DESCRIPTION
## 요약
- 사용하지 않는 placeholder Javadoc을 제거하고 `ZONE_KST` 상수만 유지해 KST 타임존 단일 출처로 책임을 좁혔습니다.

## 변경 사항
- [ ] 기능
- [ ] 버그 수정
- [x] 리팩토링
- [ ] 문서
- [ ] 테스트
- [ ] 기타

## 테스트
- [x] 로컬 테스트 완료
- 테스트 방법:
    - `./gradlew spotlessApply check` 통과

### 커버리지 (JaCoCo)
- 라인 커버리지: 변동 없음 (코드 제거만, 신규 분기 없음)
- [x] `./gradlew test` 실행 후 `build/reports/jacoco/index.html` 확인

## 스크린샷/로그 (선택)
- 해당 없음

## 롤백/리스크
- 리스크 포인트: 없음 (Javadoc·미사용 설명 제거, 동작 변화 없음)
- 롤백 방법: 해당 커밋 revert

## 관련 이슈
Closes #162

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * 내부 문서화 구조가 간소화되었습니다.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/2026-KUSITMS-GLIT/2026-KUSITMS-GLIT-BACK/pull/165?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->