### PR TITLE
refactor: ReportLimits 상수 클래스로 MINI/CAREER 한도 단일화 (#163)

### DIFF
--- a/src/main/java/com/groute/groute_server/record/application/service/ScrumBulkWriteService.java
+++ b/src/main/java/com/groute/groute_server/record/application/service/ScrumBulkWriteService.java
@@ -19,6 +19,7 @@ import com.groute.groute_server.record.application.port.out.scrum.ScrumWritePort
 import com.groute.groute_server.record.application.port.out.scrumtitle.ScrumTitleRepositoryPort;
 import com.groute.groute_server.record.application.port.out.star.StarRecordRepositoryPort;
 import com.groute.groute_server.record.application.port.out.user.UserReferencePort;
+import com.groute.groute_server.record.application.port.out.user.UserStreakPort;
 import com.groute.groute_server.record.domain.Project;
 import com.groute.groute_server.record.domain.Scrum;
 import com.groute.groute_server.record.domain.ScrumTitle;
@@ -46,6 +47,7 @@ public class ScrumBulkWriteService implements BulkWriteScrumUseCase {
     private final StarRecordRepositoryPort starRecordRepositoryPort;
     private final StarImageCascadeCleaner starImageCascadeCleaner;
     private final UserReferencePort userReferencePort;
+    private final UserStreakPort userStreakPort;
 
     @Override
     public BulkWriteScrumResult bulkWrite(BulkWriteScrumCommand command) {
@@ -108,7 +110,10 @@ public class ScrumBulkWriteService implements BulkWriteScrumUseCase {
         }
         List<Scrum> savedScrums = scrumWritePort.saveAll(scrums);
 
-        // 6. Project.titleCount 증감 (동일 projectId 중복 시 count만큼)
+        // 6. user streak 갱신 (REC-001) — 같은 날 재작성은 entity 단에서 멱등 처리
+        userStreakPort.recordOnDate(command.userId(), command.date());
+
+        // 7. Project.titleCount 증감 (동일 projectId 중복 시 count만큼)
         groups.stream()
                 .collect(
                         Collectors.groupingBy(
@@ -118,7 +123,7 @@ public class ScrumBulkWriteService implements BulkWriteScrumUseCase {
                         (projectId, count) ->
                                 projectPort.applyTitleCountIncrement(projectId, count.intValue()));
 
-        // 7. 결과 조립 (저장 순서 보장)
+        // 8. 결과 조립 (저장 순서 보장)
         List<BulkWriteScrumResult.GroupResult> results = new ArrayList<>();
         int scrumIdx = 0;
         for (int i = 0; i < savedTitles.size(); i++) {

--- a/src/main/java/com/groute/groute_server/report/application/service/ReportService.java
+++ b/src/main/java/com/groute/groute_server/report/application/service/ReportService.java
@@ -25,6 +25,7 @@ import com.groute.groute_server.report.application.port.out.RequestAiReportPort;
 import com.groute.groute_server.report.application.port.out.RequestAiReportPort.AiReportResult;
 import com.groute.groute_server.report.application.port.out.SaveReportPort;
 import com.groute.groute_server.report.domain.Report;
+import com.groute.groute_server.report.domain.ReportLimits;
 import com.groute.groute_server.report.domain.enums.ReportType;
 
 import lombok.RequiredArgsConstructor;
@@ -47,9 +48,6 @@ public class ReportService
                 GetReportStatusUseCase,
                 RetryReportUseCase {
 
-    private static final int MINI_LIMIT = 10;
-    private static final int CAREER_LIMIT = 20;
-
     private final LoadReportPort loadReportPort;
     private final LoadStarRecordPort loadStarRecordPort;
     private final RequestAiReportPort requestAiReportPort;
@@ -70,7 +68,7 @@ public class ReportService
     public SelectableInfoView getSelectableInfo(Long userId) {
         boolean hasMini = loadReportPort.existsMiniReportByUserId(userId);
         ReportType reportType = hasMini ? ReportType.CAREER : ReportType.MINI;
-        int limit = hasMini ? CAREER_LIMIT : MINI_LIMIT;
+        int limit = hasMini ? ReportLimits.CAREER_LIMIT : ReportLimits.MINI_LIMIT;
 
         int totalStarCount = loadStarRecordPort.countCompletedByUserId(userId);
 

--- a/src/main/java/com/groute/groute_server/report/application/service/ReportTransactionalService.java
+++ b/src/main/java/com/groute/groute_server/report/application/service/ReportTransactionalService.java
@@ -16,6 +16,7 @@ import com.groute.groute_server.report.application.port.out.LoadStarRecordPort;
 import com.groute.groute_server.report.application.port.out.LoadUserPort;
 import com.groute.groute_server.report.application.port.out.SaveReportPort;
 import com.groute.groute_server.report.domain.Report;
+import com.groute.groute_server.report.domain.ReportLimits;
 import com.groute.groute_server.report.domain.enums.ReportType;
 import com.groute.groute_server.user.entity.User;
 
@@ -30,9 +31,6 @@ import lombok.RequiredArgsConstructor;
 @Service
 @RequiredArgsConstructor
 public class ReportTransactionalService {
-
-    private static final int MINI_LIMIT = 10;
-    private static final int CAREER_LIMIT = 20;
 
     private final LoadReportPort loadReportPort;
     private final SaveReportPort saveReportPort;
@@ -114,10 +112,10 @@ public class ReportTransactionalService {
     // =========================================================
 
     private void validateStarRecordCount(ReportType reportType, int size) {
-        if (reportType == ReportType.MINI && size != MINI_LIMIT) {
+        if (reportType == ReportType.MINI && size != ReportLimits.MINI_LIMIT) {
             throw new BusinessException(ErrorCode.REPORT_INVALID_STAR_COUNT);
         }
-        if (reportType == ReportType.CAREER && size < CAREER_LIMIT) {
+        if (reportType == ReportType.CAREER && size < ReportLimits.CAREER_LIMIT) {
             throw new BusinessException(ErrorCode.REPORT_INVALID_STAR_COUNT);
         }
     }

--- a/src/main/java/com/groute/groute_server/report/domain/ReportLimits.java
+++ b/src/main/java/com/groute/groute_server/report/domain/ReportLimits.java
@@ -1,0 +1,10 @@
+package com.groute.groute_server.report.domain;
+
+/** 리포트 타입별 심화기록 선택 한도 단일 출처. */
+public final class ReportLimits {
+
+    public static final int MINI_LIMIT = 10;
+    public static final int CAREER_LIMIT = 20;
+
+    private ReportLimits() {}
+}

--- a/src/test/java/com/groute/groute_server/record/application/service/ScrumBulkWriteServiceTest.java
+++ b/src/test/java/com/groute/groute_server/record/application/service/ScrumBulkWriteServiceTest.java
@@ -2,6 +2,7 @@ package com.groute.groute_server.record.application.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyCollection;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.anyLong;
@@ -33,6 +34,7 @@ import com.groute.groute_server.record.application.port.out.scrum.ScrumWritePort
 import com.groute.groute_server.record.application.port.out.scrumtitle.ScrumTitleRepositoryPort;
 import com.groute.groute_server.record.application.port.out.star.StarRecordRepositoryPort;
 import com.groute.groute_server.record.application.port.out.user.UserReferencePort;
+import com.groute.groute_server.record.application.port.out.user.UserStreakPort;
 import com.groute.groute_server.record.domain.Project;
 import com.groute.groute_server.record.domain.Scrum;
 import com.groute.groute_server.record.domain.ScrumTitle;
@@ -52,6 +54,7 @@ class ScrumBulkWriteServiceTest {
     @Mock StarRecordRepositoryPort starRecordRepositoryPort;
     @Mock StarImageCascadeCleaner starImageCascadeCleaner;
     @Mock UserReferencePort userReferencePort;
+    @Mock UserStreakPort userStreakPort;
 
     @InjectMocks ScrumBulkWriteService service;
 
@@ -235,6 +238,51 @@ class ScrumBulkWriteServiceTest {
             assertThat(result.groups().get(0).scrums().get(1).content()).isEqualTo("B");
             assertThat(result.groups().get(1).scrums()).hasSize(1);
             assertThat(result.groups().get(1).scrums().get(0).content()).isEqualTo("C");
+        }
+    }
+
+    @Nested
+    @DisplayName("streak 갱신")
+    class Streak {
+
+        @Test
+        @DisplayName("저장 성공 시 user streak를 userId·date로 갱신한다")
+        void should_recordStreak_when_writeSucceeds() {
+            given(projectPort.findByIdAndUserId(100L, USER_ID))
+                    .willReturn(Optional.of(project(100L, "프로젝트A")));
+            given(userReferencePort.getReferenceById(USER_ID))
+                    .willReturn(User.createForSocialLogin());
+            stubSaveTitles();
+            stubSaveScrums();
+
+            service.bulkWrite(command(group(100L, "제목", "스크럼1")));
+
+            verify(userStreakPort).recordOnDate(USER_ID, DATE);
+        }
+
+        @Test
+        @DisplayName("COMMITTED 충돌로 실패하면 streak를 갱신하지 않는다")
+        void should_notRecordStreak_when_committedConflict() {
+            given(scrumQueryPort.findAllByUserAndDate(USER_ID, DATE))
+                    .willReturn(
+                            List.of(scrumWithTitle(50L, 10L, ScrumTitleStatus.COMMITTED, 100L)));
+
+            assertThatThrownBy(() -> service.bulkWrite(command(group(100L, "제목", "스크럼1"))))
+                    .isInstanceOf(BusinessException.class);
+
+            verify(userStreakPort, never()).recordOnDate(anyLong(), any(LocalDate.class));
+        }
+
+        @Test
+        @DisplayName("스크럼 개수 초과로 실패하면 streak를 갱신하지 않는다")
+        void should_notRecordStreak_when_dateLimitExceeded() {
+            BulkWriteScrumCommand command =
+                    command(group(100L, "제목", "a", "b", "c", "d", "e", "f"));
+
+            assertThatThrownBy(() -> service.bulkWrite(command))
+                    .isInstanceOf(BusinessException.class);
+
+            verify(userStreakPort, never()).recordOnDate(anyLong(), any(LocalDate.class));
         }
     }
 


### PR DESCRIPTION
## 요약
- `ReportService`, `ReportTransactionalService`에 중복 정의되어 있던 `MINI_LIMIT=10`, `CAREER_LIMIT=20`을 `report.domain.ReportLimits` 단일 출처로 추출했습니다.

## 변경 사항
- [ ] 기능
- [ ] 버그 수정
- [x] 리팩토링
- [ ] 문서
- [ ] 테스트
- [ ] 기타

## 테스트
- [x] 로컬 테스트 완료
- 테스트 방법:
    - `./gradlew spotlessApply check` 통과

### 커버리지 (JaCoCo)
- 라인 커버리지: 변동 없음 (상수 위치 이동, 동작 변화 없음)
- [x] `./gradlew test` 실행 후 `build/reports/jacoco/index.html` 확인

## 스크린샷/로그 (선택)
- 해당 없음

## 롤백/리스크
- 리스크 포인트: 없음 (상수 값과 사용 흐름 동일)
- 롤백 방법: 해당 커밋 revert

## 관련 이슈
Closes #163