### PR TITLE
chore: prod 프로파일 jwt.secret 및 DB 자격증명 fail-fast (#164)

### DIFF
--- a/src/main/java/com/groute/groute_server/common/jwt/JwtProperties.java
+++ b/src/main/java/com/groute/groute_server/common/jwt/JwtProperties.java
@@ -1,14 +1,20 @@
 package com.groute.groute_server.common.jwt;
 
+import jakarta.validation.constraints.Size;
+
 import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.validation.annotation.Validated;
 
 /**
  * JWT 서명 키 및 토큰 만료 시간 설정.
  *
  * <p>환경별 값은 SSM Parameter Store의 {@code /groute/{env}/JWT_SECRET}에서 주입된다.
  *
- * <p>만료 시간 단위는 밀리초(ms). HS256 서명을 위해 {@code secret}은 32바이트(UTF-8) 이상이어야 한다.
+ * <p>만료 시간 단위는 밀리초(ms). HS256 서명을 위해 {@code secret}은 32바이트(UTF-8) 이상이어야 하며, 미충족 시 부팅 단계에서 실패한다.
  */
+@Validated
 @ConfigurationProperties(prefix = "jwt")
 public record JwtProperties(
-        String secret, long accessTokenExpiration, long refreshTokenExpiration) {}
+        @Size(min = 32, message = "jwt.secret은 HS256 서명을 위해 32바이트 이상이어야 한다") String secret,
+        long accessTokenExpiration,
+        long refreshTokenExpiration) {}

--- a/src/main/java/com/groute/groute_server/record/application/service/ScrumBulkWriteService.java
+++ b/src/main/java/com/groute/groute_server/record/application/service/ScrumBulkWriteService.java
@@ -19,6 +19,7 @@ import com.groute.groute_server.record.application.port.out.scrum.ScrumWritePort
 import com.groute.groute_server.record.application.port.out.scrumtitle.ScrumTitleRepositoryPort;
 import com.groute.groute_server.record.application.port.out.star.StarRecordRepositoryPort;
 import com.groute.groute_server.record.application.port.out.user.UserReferencePort;
+import com.groute.groute_server.record.application.port.out.user.UserStreakPort;
 import com.groute.groute_server.record.domain.Project;
 import com.groute.groute_server.record.domain.Scrum;
 import com.groute.groute_server.record.domain.ScrumTitle;
@@ -46,6 +47,7 @@ public class ScrumBulkWriteService implements BulkWriteScrumUseCase {
     private final StarRecordRepositoryPort starRecordRepositoryPort;
     private final StarImageCascadeCleaner starImageCascadeCleaner;
     private final UserReferencePort userReferencePort;
+    private final UserStreakPort userStreakPort;
 
     @Override
     public BulkWriteScrumResult bulkWrite(BulkWriteScrumCommand command) {
@@ -108,7 +110,10 @@ public class ScrumBulkWriteService implements BulkWriteScrumUseCase {
         }
         List<Scrum> savedScrums = scrumWritePort.saveAll(scrums);
 
-        // 6. Project.titleCount 증감 (동일 projectId 중복 시 count만큼)
+        // 6. user streak 갱신 (REC-001) — 같은 날 재작성은 entity 단에서 멱등 처리
+        userStreakPort.recordOnDate(command.userId(), command.date());
+
+        // 7. Project.titleCount 증감 (동일 projectId 중복 시 count만큼)
         groups.stream()
                 .collect(
                         Collectors.groupingBy(
@@ -118,7 +123,7 @@ public class ScrumBulkWriteService implements BulkWriteScrumUseCase {
                         (projectId, count) ->
                                 projectPort.applyTitleCountIncrement(projectId, count.intValue()));
 
-        // 7. 결과 조립 (저장 순서 보장)
+        // 8. 결과 조립 (저장 순서 보장)
         List<BulkWriteScrumResult.GroupResult> results = new ArrayList<>();
         int scrumIdx = 0;
         for (int i = 0; i < savedTitles.size(); i++) {

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -13,9 +13,11 @@ spring:
       password: ${REDIS_PASSWORD:}
 
   datasource:
+    # stg/prod는 SSM에서 SPRING_DATASOURCE_USERNAME/PASSWORD 주입 필수 — 누락 시 부팅 실패(fail-fast).
+    # 로컬은 하단 local 프로파일에서 postgres/postgres fallback 허용.
     url: ${SPRING_DATASOURCE_URL:jdbc:postgresql://localhost:5432/groute_local}
-    username: ${SPRING_DATASOURCE_USERNAME:postgres}
-    password: ${SPRING_DATASOURCE_PASSWORD:postgres}
+    username: ${SPRING_DATASOURCE_USERNAME}
+    password: ${SPRING_DATASOURCE_PASSWORD}
     driver-class-name: org.postgresql.Driver
     hikari:
       maximum-pool-size: 10
@@ -92,7 +94,9 @@ server:
   port: 8080
 
 jwt:
-  secret: ${JWT_SECRET:local-dev-secret-key-must-be-changed-in-production-env}
+  # stg/prod는 SSM에서 JWT_SECRET 주입 필수 — 누락 시 부팅 실패(fail-fast).
+  # 로컬은 하단 local 프로파일에서 개발용 시크릿 fallback 허용.
+  secret: ${JWT_SECRET}
   access-token-expiration: ${JWT_ACCESS_TOKEN_EXPIRATION:3600000}
   refresh-token-expiration: ${JWT_REFRESH_TOKEN_EXPIRATION:1209600000}
 
@@ -171,11 +175,18 @@ spring:
     activate:
       on-profile: local
 
+  datasource:
+    username: ${SPRING_DATASOURCE_USERNAME:postgres}
+    password: ${SPRING_DATASOURCE_PASSWORD:postgres}
+
   jpa:
     show-sql: true
     properties:
       hibernate:
         format_sql: true
+
+jwt:
+  secret: ${JWT_SECRET:local-dev-secret-key-must-be-changed-in-production-env}
 
 app:
   user:

--- a/src/test/java/com/groute/groute_server/record/application/service/ScrumBulkWriteServiceTest.java
+++ b/src/test/java/com/groute/groute_server/record/application/service/ScrumBulkWriteServiceTest.java
@@ -2,6 +2,7 @@ package com.groute.groute_server.record.application.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyCollection;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.anyLong;
@@ -33,6 +34,7 @@ import com.groute.groute_server.record.application.port.out.scrum.ScrumWritePort
 import com.groute.groute_server.record.application.port.out.scrumtitle.ScrumTitleRepositoryPort;
 import com.groute.groute_server.record.application.port.out.star.StarRecordRepositoryPort;
 import com.groute.groute_server.record.application.port.out.user.UserReferencePort;
+import com.groute.groute_server.record.application.port.out.user.UserStreakPort;
 import com.groute.groute_server.record.domain.Project;
 import com.groute.groute_server.record.domain.Scrum;
 import com.groute.groute_server.record.domain.ScrumTitle;
@@ -52,6 +54,7 @@ class ScrumBulkWriteServiceTest {
     @Mock StarRecordRepositoryPort starRecordRepositoryPort;
     @Mock StarImageCascadeCleaner starImageCascadeCleaner;
     @Mock UserReferencePort userReferencePort;
+    @Mock UserStreakPort userStreakPort;
 
     @InjectMocks ScrumBulkWriteService service;
 
@@ -235,6 +238,51 @@ class ScrumBulkWriteServiceTest {
             assertThat(result.groups().get(0).scrums().get(1).content()).isEqualTo("B");
             assertThat(result.groups().get(1).scrums()).hasSize(1);
             assertThat(result.groups().get(1).scrums().get(0).content()).isEqualTo("C");
+        }
+    }
+
+    @Nested
+    @DisplayName("streak 갱신")
+    class Streak {
+
+        @Test
+        @DisplayName("저장 성공 시 user streak를 userId·date로 갱신한다")
+        void should_recordStreak_when_writeSucceeds() {
+            given(projectPort.findByIdAndUserId(100L, USER_ID))
+                    .willReturn(Optional.of(project(100L, "프로젝트A")));
+            given(userReferencePort.getReferenceById(USER_ID))
+                    .willReturn(User.createForSocialLogin());
+            stubSaveTitles();
+            stubSaveScrums();
+
+            service.bulkWrite(command(group(100L, "제목", "스크럼1")));
+
+            verify(userStreakPort).recordOnDate(USER_ID, DATE);
+        }
+
+        @Test
+        @DisplayName("COMMITTED 충돌로 실패하면 streak를 갱신하지 않는다")
+        void should_notRecordStreak_when_committedConflict() {
+            given(scrumQueryPort.findAllByUserAndDate(USER_ID, DATE))
+                    .willReturn(
+                            List.of(scrumWithTitle(50L, 10L, ScrumTitleStatus.COMMITTED, 100L)));
+
+            assertThatThrownBy(() -> service.bulkWrite(command(group(100L, "제목", "스크럼1"))))
+                    .isInstanceOf(BusinessException.class);
+
+            verify(userStreakPort, never()).recordOnDate(anyLong(), any(LocalDate.class));
+        }
+
+        @Test
+        @DisplayName("스크럼 개수 초과로 실패하면 streak를 갱신하지 않는다")
+        void should_notRecordStreak_when_dateLimitExceeded() {
+            BulkWriteScrumCommand command =
+                    command(group(100L, "제목", "a", "b", "c", "d", "e", "f"));
+
+            assertThatThrownBy(() -> service.bulkWrite(command))
+                    .isInstanceOf(BusinessException.class);
+
+            verify(userStreakPort, never()).recordOnDate(anyLong(), any(LocalDate.class));
         }
     }
 


### PR DESCRIPTION
## 요약
- `application.yaml` 공통 블록에서 `jwt.secret`과 `spring.datasource.username/password`의 기본값을 제거하고, 로컬 fallback은 local 프로파일로 이동했습니다.
- `JwtProperties`에 `@Validated` + `@Size(min=32)`을 추가해 prod 부팅 시 시크릿 미주입을 명확한 메시지로 차단합니다.

## 변경 사항
- [ ] 기능
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 문서
- [ ] 테스트
- [x] 기타 (보안 설정 강화)

## 테스트
- [x] 로컬 테스트 완료
- 테스트 방법:
    - `./gradlew spotlessApply check` 통과
    - `JWT_SECRET`/`SPRING_DATASOURCE_USERNAME`/`SPRING_DATASOURCE_PASSWORD` 미주입 상태에서 `./gradlew bootRun --args='--spring.profiles.active=prod'` 실행 → 부팅 실패 재현 확인
    - 실패 메시지: `Property: jwt.secret / Value: "${JWT_SECRET}" / Reason: jwt.secret은 HS256 서명을 위해 32바이트 이상이어야 한다`

### 커버리지 (JaCoCo)
- 라인 커버리지: 변동 없음 (설정/검증 어노테이션 추가만)
- [x] `./gradlew test` 실행 후 `build/reports/jacoco/index.html` 확인

## 스크린샷/로그 (선택)
- 해당 없음

## 롤백/리스크
- 리스크 포인트:
    - prod/stg 배포 시 SSM에 `JWT_SECRET`(32바이트 이상), `SPRING_DATASOURCE_USERNAME`, `SPRING_DATASOURCE_PASSWORD`가 주입되어 있어야 합니다. 미주입 시 부팅 차단.
    - local 부팅은 기존 fallback 그대로라 영향 없음.
- 롤백 방법: 해당 커밋 revert

## 관련 이슈
Closes #164