### PR TITLE
fix: AI 태깅 실패 시에도 심화기록 정상 표시 및 리포트 카운트 포함

### DIFF
--- a/src/main/java/com/groute/groute_server/calendar/repository/CalendarHomeRepository.java
+++ b/src/main/java/com/groute/groute_server/calendar/repository/CalendarHomeRepository.java
@@ -69,8 +69,8 @@ public class CalendarHomeRepository {
                         """
                         SELECT new com.groute.groute_server.calendar.repository.StarDailyRow(
                             sr.id, sr.scrum.scrumDate, sr.completedAt, st.primaryCategory)
-                        FROM StarTag st
-                        JOIN st.starRecord sr
+                        FROM StarRecord sr
+                        LEFT JOIN StarTag st ON st.starRecord = sr
                         WHERE sr.user.id = :userId
                           AND sr.isCompleted = true
                           AND sr.isDeleted = false
@@ -125,8 +125,8 @@ public class CalendarHomeRepository {
                         """
                         SELECT new com.groute.groute_server.calendar.repository.ScrumStarTagRow(
                             sr.scrum.id, st.primaryCategory, st.detailTag)
-                        FROM StarTag st
-                        JOIN st.starRecord sr
+                        FROM StarRecord sr
+                        LEFT JOIN StarTag st ON st.starRecord = sr
                         WHERE sr.scrum.id IN :scrumIds
                           AND sr.user.id = :userId
                           AND sr.isCompleted = true

--- a/src/main/java/com/groute/groute_server/calendar/repository/ScrumStarTagRow.java
+++ b/src/main/java/com/groute/groute_server/calendar/repository/ScrumStarTagRow.java
@@ -5,7 +5,8 @@ import com.groute.groute_server.record.domain.enums.CompetencyCategory;
 /**
  * 날짜 프리뷰용 STAR 태그 row projection.
  *
- * <p>한 StarRecord에 StarTag가 1~3개 row 있으므로 동일 {@code scrumId}로 1~3 row가 반환된다. {@code
- * primaryCategory}는 모든 row가 같은 값을 가지며, {@code detailTag}는 row마다 다르다.
+ * <p>StarTag가 있는 StarRecord는 동일 {@code scrumId}로 1~3 row가 반환된다. {@code primaryCategory}는 모든 row가 같은
+ * 값을 가지며, {@code detailTag}는 row마다 다르다. StarTag가 없는 StarRecord(태깅 실패 케이스)는 1 row가 반환되며 {@code
+ * primaryCategory}와 {@code detailTag}는 null이다.
  */
 public record ScrumStarTagRow(Long scrumId, CompetencyCategory primaryCategory, String detailTag) {}

--- a/src/main/java/com/groute/groute_server/calendar/repository/StarDailyRow.java
+++ b/src/main/java/com/groute/groute_server/calendar/repository/StarDailyRow.java
@@ -8,8 +8,9 @@ import com.groute.groute_server.record.domain.enums.CompetencyCategory;
 /**
  * 월별 캘린더 집계용 STAR row projection.
  *
- * <p>한 StarRecord에 StarTag가 1~3개 있으므로 동일 {@code starRecordId}로 1~3 row가 반환될 수 있다. 그날 STAR 카운트를 셀 때는
- * {@code starRecordId} 기준 distinct가 필요하며, 대표 역량은 한 record 내 모든 row가 같은 값을 가진다.
+ * <p>StarTag가 있는 StarRecord는 동일 {@code starRecordId}로 1~3 row가 반환될 수 있다. StarTag가 없는 StarRecord(태깅
+ * 실패 케이스)는 {@code starRecordId}당 정확히 1 row가 반환되며 이 경우 {@code primaryCategory}는 null이다. 그날 STAR 카운트를
+ * 셀 때는 {@code starRecordId} 기준 distinct가 필요하다.
  */
 public record StarDailyRow(
         Long starRecordId,

--- a/src/main/java/com/groute/groute_server/record/adapter/out/persistence/StarRecordJpaRepository.java
+++ b/src/main/java/com/groute/groute_server/record/adapter/out/persistence/StarRecordJpaRepository.java
@@ -1,6 +1,5 @@
 package com.groute.groute_server.record.adapter.out.persistence;
 
-import java.time.LocalDate;
 import java.time.OffsetDateTime;
 import java.util.Collection;
 import java.util.List;
@@ -85,19 +84,6 @@ public interface StarRecordJpaRepository extends JpaRepository<StarRecord, Long>
                     + "GROUP BY s.selectedCompetency")
     List<CompetencyCount> countCompletedByCompetency(
             @Param("userId") Long userId, @Param("status") StarRecordStatus status);
-
-    /** 해당 날짜에 TAGGED 미완료 StarRecord가 존재하는지 확인. */
-    @Query(
-            "SELECT (COUNT(sr) > 0) FROM StarRecord sr "
-                    + "JOIN sr.scrum s "
-                    + "WHERE sr.user.id = :userId "
-                    + "AND s.scrumDate = :date "
-                    + "AND sr.status <> :tagged "
-                    + "AND sr.isDeleted = false")
-    boolean existsUntaggedByUserAndDate(
-            @Param("userId") Long userId,
-            @Param("date") LocalDate date,
-            @Param("tagged") StarRecordStatus tagged);
 
     /** 전체 완료된 심화기록 수를 카운트한다. 리포트가 없는 신규 유저 케이스에 사용한다. */
     @Query(

--- a/src/main/java/com/groute/groute_server/record/adapter/out/persistence/StarRecordPersistenceAdapter.java
+++ b/src/main/java/com/groute/groute_server/record/adapter/out/persistence/StarRecordPersistenceAdapter.java
@@ -69,6 +69,11 @@ class StarRecordPersistenceAdapter implements StarRecordRepositoryPort, StarReco
     }
 
     @Override
+    public long countCompleted(Long userId) {
+        return jpaRepository.countCompleted(userId);
+    }
+
+    @Override
     public List<CompetencyCount> countCompletedByCompetency(Long userId, StarRecordStatus status) {
         return jpaRepository.countCompletedByCompetency(userId, status);
     }

--- a/src/main/java/com/groute/groute_server/record/adapter/out/persistence/StarRecordPersistenceAdapter.java
+++ b/src/main/java/com/groute/groute_server/record/adapter/out/persistence/StarRecordPersistenceAdapter.java
@@ -1,6 +1,5 @@
 package com.groute.groute_server.record.adapter.out.persistence;
 
-import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
 
@@ -56,11 +55,6 @@ class StarRecordPersistenceAdapter implements StarRecordRepositoryPort, StarReco
     @Override
     public StarRecord save(StarRecord starRecord) {
         return jpaRepository.save(starRecord);
-    }
-
-    @Override
-    public boolean existsUntaggedByUserAndDate(Long userId, LocalDate date) {
-        return jpaRepository.existsUntaggedByUserAndDate(userId, date, StarRecordStatus.TAGGED);
     }
 
     @Override

--- a/src/main/java/com/groute/groute_server/record/application/port/out/star/StarRecordRepositoryPort.java
+++ b/src/main/java/com/groute/groute_server/record/application/port/out/star/StarRecordRepositoryPort.java
@@ -36,6 +36,9 @@ public interface StarRecordRepositoryPort {
     /** 사용자의 TAGGED 심화기록 총 개수. */
     long countTaggedByUserId(Long userId);
 
+    /** 사용자의 완료된(isCompleted=true) 심화기록 총 개수. */
+    long countCompleted(Long userId);
+
     /** TAGGED 완료된 STAR 기록의 역량 카테고리별 건수. selectedCompetency가 NULL인 스크럼은 제외. */
     List<CompetencyCount> countCompletedByCompetency(Long userId, StarRecordStatus status);
 }

--- a/src/main/java/com/groute/groute_server/record/application/port/out/star/StarRecordRepositoryPort.java
+++ b/src/main/java/com/groute/groute_server/record/application/port/out/star/StarRecordRepositoryPort.java
@@ -1,6 +1,5 @@
 package com.groute.groute_server.record.application.port.out.star;
 
-import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
 
@@ -29,9 +28,6 @@ public interface StarRecordRepositoryPort {
 
     /** PENDING 세션 취소 시 해당 스크럼들에 연결된 StarRecord 일괄 soft-delete. */
     int softDeleteByScrumIds(List<Long> scrumIds);
-
-    /** 해당 날짜에 TAGGED 미완료(WRITING·WRITTEN) StarRecord가 남아있는지 확인. */
-    boolean existsUntaggedByUserAndDate(Long userId, LocalDate date);
 
     /** 사용자의 TAGGED 심화기록 총 개수. */
     long countTaggedByUserId(Long userId);

--- a/src/main/java/com/groute/groute_server/record/application/service/AiTaggingService.java
+++ b/src/main/java/com/groute/groute_server/record/application/service/AiTaggingService.java
@@ -1,6 +1,5 @@
 package com.groute.groute_server.record.application.service;
 
-import java.time.LocalDate;
 import java.util.List;
 
 import org.springframework.stereotype.Service;
@@ -17,19 +16,14 @@ import com.groute.groute_server.record.application.port.in.GetAiTaggingResultUse
 import com.groute.groute_server.record.application.port.in.GetAiTaggingStatusUseCase;
 import com.groute.groute_server.record.application.port.in.TriggerAiTaggingUseCase;
 import com.groute.groute_server.record.application.port.out.AiTaggingJobPort;
-import com.groute.groute_server.record.application.port.out.UserPort;
-import com.groute.groute_server.record.application.port.out.scrum.ScrumQueryPort;
-import com.groute.groute_server.record.application.port.out.scrumtitle.ScrumTitleRepositoryPort;
 import com.groute.groute_server.record.application.port.out.star.StarRecordRepositoryPort;
 import com.groute.groute_server.record.application.port.out.star.StarTagQueryPort;
 import com.groute.groute_server.record.application.port.out.star.StarTagSavePort;
 import com.groute.groute_server.record.domain.AiTaggingJob;
-import com.groute.groute_server.record.domain.Scrum;
 import com.groute.groute_server.record.domain.StarRecord;
 import com.groute.groute_server.record.domain.StarTag;
 import com.groute.groute_server.record.domain.enums.CompetencyCategory;
 import com.groute.groute_server.record.domain.enums.JobStatus;
-import com.groute.groute_server.user.entity.User;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -53,9 +47,6 @@ public class AiTaggingService
     private final AiTaggingJobPort aiTaggingJobPort;
     private final StarTagQueryPort starTagPort;
     private final StarTagSavePort starTagSavePort;
-    private final ScrumQueryPort scrumQueryPort;
-    private final ScrumTitleRepositoryPort scrumTitleRepositoryPort;
-    private final UserPort userPort;
     private final AiTaggingAsyncExecutor aiTaggingAsyncExecutor;
 
     /**
@@ -220,30 +211,6 @@ public class AiTaggingService
                                 .toList();
                 starTagSavePort.saveAll(tags);
             }
-        }
-
-        Long userId = record.getUser().getId();
-        LocalDate date = record.getScrum().getScrumDate();
-
-        if (!starRecordPort.existsUntaggedByUserAndDate(userId, date)) {
-            List<Long> titleIds =
-                    scrumQueryPort.findAllByUserAndDate(userId, date).stream()
-                            .map(Scrum::getTitle)
-                            .map(t -> t.getId())
-                            .distinct()
-                            .toList();
-            scrumTitleRepositoryPort.commitAllByIds(titleIds);
-        }
-
-        long taggedCount = starRecordPort.countTaggedByUserId(userId);
-        User user = userPort.findById(userId);
-        if (taggedCount == 1) {
-            user.markPendingCoachMark();
-        }
-        if (taggedCount == 10) {
-            user.markPendingReportModal("MINI");
-        } else if (taggedCount >= 20 && taggedCount % 10 == 0) {
-            user.markPendingReportModal("FULL");
         }
     }
 }

--- a/src/main/java/com/groute/groute_server/record/application/service/UpdateStarRecordStepService.java
+++ b/src/main/java/com/groute/groute_server/record/application/service/UpdateStarRecordStepService.java
@@ -1,6 +1,7 @@
 package com.groute.groute_server.record.application.service;
 
 import java.time.OffsetDateTime;
+import java.util.List;
 
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -9,19 +10,23 @@ import com.groute.groute_server.common.exception.BusinessException;
 import com.groute.groute_server.common.exception.ErrorCode;
 import com.groute.groute_server.record.application.port.in.star.UpdateStarRecordStepCommand;
 import com.groute.groute_server.record.application.port.in.star.UpdateStarRecordStepUseCase;
+import com.groute.groute_server.record.application.port.out.UserPort;
+import com.groute.groute_server.record.application.port.out.scrum.ScrumQueryPort;
 import com.groute.groute_server.record.application.port.out.scrum.ScrumWritePort;
+import com.groute.groute_server.record.application.port.out.scrumtitle.ScrumTitleRepositoryPort;
 import com.groute.groute_server.record.application.port.out.star.StarRecordRepositoryPort;
 import com.groute.groute_server.record.domain.Scrum;
 import com.groute.groute_server.record.domain.StarRecord;
 import com.groute.groute_server.record.domain.enums.StarStep;
+import com.groute.groute_server.user.entity.User;
 
 import lombok.RequiredArgsConstructor;
 
 /**
  * STAR 단계별 저장 서비스 (POST /api/star-records/{id}/steps/{step}).
  *
- * <p>R 단계 저장 시 StarRecord를 완료 처리하고 연결된 Scrum의 hasStar를 true로 설정한다. ScrumTitle COMMITTED 전환은 StarTag
- * 생성 완료 시점에 별도로 처리한다.
+ * <p>R 단계 저장 시 StarRecord를 완료 처리하고 연결된 Scrum의 hasStar를 true로 설정한다.
+ * ScrumTitle COMMITTED 전환과 리포트/코치마크 팝업 트리거도 R단계 완료 시점에 함께 처리한다.
  */
 @Service
 @RequiredArgsConstructor
@@ -30,6 +35,9 @@ public class UpdateStarRecordStepService implements UpdateStarRecordStepUseCase 
 
     private final StarRecordRepositoryPort starRecordRepositoryPort;
     private final ScrumWritePort scrumWritePort;
+    private final ScrumQueryPort scrumQueryPort;
+    private final ScrumTitleRepositoryPort scrumTitleRepositoryPort;
+    private final UserPort userPort;
 
     @Override
     public void updateStep(UpdateStarRecordStepCommand command) {
@@ -53,6 +61,25 @@ public class UpdateStarRecordStepService implements UpdateStarRecordStepUseCase 
             Scrum scrum = record.getScrum();
             if (scrumWritePort.completeStar(scrum.getId()) == 0) {
                 throw new BusinessException(ErrorCode.SCRUM_NOT_FOUND);
+            }
+            List<Long> titleIds =
+                    scrumQueryPort.findAllByUserAndDate(command.userId(), scrum.getScrumDate())
+                            .stream()
+                            .map(Scrum::getTitle)
+                            .map(t -> t.getId())
+                            .distinct()
+                            .toList();
+            scrumTitleRepositoryPort.commitAllByIds(titleIds);
+
+            long completedCount = starRecordRepositoryPort.countCompleted(command.userId());
+            User user = userPort.findById(command.userId());
+            if (completedCount == 1) {
+                user.markPendingCoachMark();
+            }
+            if (completedCount == 10) {
+                user.markPendingReportModal("MINI");
+            } else if (completedCount >= 20 && completedCount % 10 == 0) {
+                user.markPendingReportModal("FULL");
             }
         }
     }

--- a/src/main/java/com/groute/groute_server/record/application/service/UpdateStarRecordStepService.java
+++ b/src/main/java/com/groute/groute_server/record/application/service/UpdateStarRecordStepService.java
@@ -25,8 +25,8 @@ import lombok.RequiredArgsConstructor;
 /**
  * STAR 단계별 저장 서비스 (POST /api/star-records/{id}/steps/{step}).
  *
- * <p>R 단계 저장 시 StarRecord를 완료 처리하고 연결된 Scrum의 hasStar를 true로 설정한다.
- * ScrumTitle COMMITTED 전환과 리포트/코치마크 팝업 트리거도 R단계 완료 시점에 함께 처리한다.
+ * <p>R 단계 저장 시 StarRecord를 완료 처리하고 연결된 Scrum의 hasStar를 true로 설정한다. ScrumTitle COMMITTED 전환과
+ * 리포트/코치마크 팝업 트리거도 R단계 완료 시점에 함께 처리한다.
  */
 @Service
 @RequiredArgsConstructor
@@ -63,7 +63,8 @@ public class UpdateStarRecordStepService implements UpdateStarRecordStepUseCase 
                 throw new BusinessException(ErrorCode.SCRUM_NOT_FOUND);
             }
             List<Long> titleIds =
-                    scrumQueryPort.findAllByUserAndDate(command.userId(), scrum.getScrumDate())
+                    scrumQueryPort
+                            .findAllByUserAndDate(command.userId(), scrum.getScrumDate())
                             .stream()
                             .map(Scrum::getTitle)
                             .map(t -> t.getId())

--- a/src/main/java/com/groute/groute_server/record/domain/StarRecord.java
+++ b/src/main/java/com/groute/groute_server/record/domain/StarRecord.java
@@ -97,11 +97,12 @@ public class StarRecord extends SoftDeleteEntity {
         }
     }
 
-    /** R 단계 완료 처리. status=WRITTEN, currentStep=DONE, completedAt 설정. */
+    /** R 단계 완료 처리. status=WRITTEN, currentStep=DONE, completedAt 설정. isCompleted=true로 설정하여 리포트 카운트에 포함한다. */
     public void complete(OffsetDateTime completedAt) {
         this.status = StarRecordStatus.WRITTEN;
         this.currentStep = StarStep.DONE;
         this.completedAt = Objects.requireNonNull(completedAt, "completedAt");
+        this.isCompleted = true;
     }
 
     /** AI 태깅 완료 처리. status=TAGGED로 전환하고 isCompleted=true로 설정. */

--- a/src/main/java/com/groute/groute_server/record/domain/StarRecord.java
+++ b/src/main/java/com/groute/groute_server/record/domain/StarRecord.java
@@ -97,7 +97,10 @@ public class StarRecord extends SoftDeleteEntity {
         }
     }
 
-    /** R 단계 완료 처리. status=WRITTEN, currentStep=DONE, completedAt 설정. isCompleted=true로 설정하여 리포트 카운트에 포함한다. */
+    /**
+     * R 단계 완료 처리. status=WRITTEN, currentStep=DONE, completedAt 설정. isCompleted=true로 설정하여 리포트 카운트에
+     * 포함한다.
+     */
     public void complete(OffsetDateTime completedAt) {
         this.status = StarRecordStatus.WRITTEN;
         this.currentStep = StarStep.DONE;

--- a/src/main/java/com/groute/groute_server/record/domain/StarRecord.java
+++ b/src/main/java/com/groute/groute_server/record/domain/StarRecord.java
@@ -16,7 +16,7 @@ import lombok.NoArgsConstructor;
 /**
  * 심화 STAR 기록.
  *
- * <p>스크럼과 1:1(REC008). 단계별로 작성이 진행되며, 3단계 완료 후 AI 태깅 호출로 완료된다. {@link #currentStep} + 각 단계 필드(S/T,
+ * <p>스크럼과 1:1(REC008). 단계별로 작성이 진행되며, 3단계 완료 시 완료 처리된다. AI 태깅 결과는 별도 상태(status=TAGGED)로 관리된다. {@link #currentStep} + 각 단계 필드(S/T,
  * A, R)로 임시저장을 대체한다(REC010).
  */
 @Getter
@@ -64,7 +64,7 @@ public class StarRecord extends SoftDeleteEntity {
     @Column(name = "completed_at")
     private OffsetDateTime completedAt;
 
-    /** AI 태깅 완료 여부. status=TAGGED 전환 시 true로 설정. JPQL 조건절 호환용. */
+    /** R단계 완료(리포트 집계 기준). AI 태깅 성공/실패 무관하게 R단계 완료 시 true로 설정. JPQL 조건절 호환용. */
     @Column(name = "is_completed", nullable = false)
     private boolean isCompleted = false;
 

--- a/src/main/java/com/groute/groute_server/record/domain/StarRecord.java
+++ b/src/main/java/com/groute/groute_server/record/domain/StarRecord.java
@@ -16,8 +16,8 @@ import lombok.NoArgsConstructor;
 /**
  * 심화 STAR 기록.
  *
- * <p>스크럼과 1:1(REC008). 단계별로 작성이 진행되며, 3단계 완료 시 완료 처리된다. AI 태깅 결과는 별도 상태(status=TAGGED)로 관리된다. {@link #currentStep} + 각 단계 필드(S/T,
- * A, R)로 임시저장을 대체한다(REC010).
+ * <p>스크럼과 1:1(REC008). 단계별로 작성이 진행되며, 3단계 완료 시 완료 처리된다. AI 태깅 결과는 별도 상태(status=TAGGED)로 관리된다.
+ * {@link #currentStep} + 각 단계 필드(S/T, A, R)로 임시저장을 대체한다(REC010).
  */
 @Getter
 @NoArgsConstructor

--- a/src/test/java/com/groute/groute_server/record/application/service/UpdateStarRecordStepServiceTest.java
+++ b/src/test/java/com/groute/groute_server/record/application/service/UpdateStarRecordStepServiceTest.java
@@ -1,6 +1,7 @@
 package com.groute.groute_server.record.application.service;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.never;
@@ -8,6 +9,7 @@ import static org.mockito.Mockito.verify;
 
 import java.time.LocalDate;
 import java.time.OffsetDateTime;
+import java.util.List;
 import java.util.Optional;
 
 import org.junit.jupiter.api.BeforeEach;
@@ -17,13 +19,17 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.util.ReflectionTestUtils;
 
 import com.groute.groute_server.common.exception.BusinessException;
 import com.groute.groute_server.common.exception.ErrorCode;
 import com.groute.groute_server.record.application.port.in.star.UpdateStarRecordStepCommand;
+import com.groute.groute_server.record.application.port.out.UserPort;
+import com.groute.groute_server.record.application.port.out.scrum.ScrumQueryPort;
 import com.groute.groute_server.record.application.port.out.scrum.ScrumWritePort;
+import com.groute.groute_server.record.application.port.out.scrumtitle.ScrumTitleRepositoryPort;
 import com.groute.groute_server.record.application.port.out.star.StarRecordRepositoryPort;
 import com.groute.groute_server.record.domain.Scrum;
 import com.groute.groute_server.record.domain.ScrumTitle;
@@ -41,10 +47,14 @@ class UpdateStarRecordStepServiceTest {
 
     @Mock StarRecordRepositoryPort starRecordRepositoryPort;
     @Mock ScrumWritePort scrumWritePort;
+    @Mock ScrumQueryPort scrumQueryPort;
+    @Mock ScrumTitleRepositoryPort scrumTitleRepositoryPort;
+    @Mock UserPort userPort;
 
     @InjectMocks UpdateStarRecordStepService service;
 
     private User owner;
+    private User mockOwner;
     private Scrum scrum;
     private StarRecord record;
 
@@ -52,6 +62,9 @@ class UpdateStarRecordStepServiceTest {
     void setUp() {
         owner = User.createForSocialLogin();
         ReflectionTestUtils.setField(owner, "id", USER_ID);
+
+        mockOwner = Mockito.mock(User.class);
+        Mockito.lenient().when(mockOwner.getId()).thenReturn(USER_ID);
 
         ScrumTitle title = new ScrumTitle();
         ReflectionTestUtils.setField(title, "id", 10L);
@@ -141,14 +154,21 @@ class UpdateStarRecordStepServiceTest {
     @DisplayName("R 단계 완료 처리")
     class CompleteStep {
 
-        @Test
-        @DisplayName("R 단계 저장 시 record.complete()와 scrumWritePort.completeStar가 호출된다")
-        void should_callCompleteStar_when_stepIsR() {
+        @BeforeEach
+        void setUpR() {
             record.saveStep(StarStep.ST, "ST 답변");
             record.saveStep(StarStep.A, "A 답변");
             given(starRecordRepositoryPort.findByIdWithScrum(STAR_ID))
                     .willReturn(Optional.of(record));
+            Mockito.lenient().when(scrumQueryPort.findAllByUserAndDate(any(), any())).thenReturn(List.of(scrum));
+            Mockito.lenient().when(userPort.findById(USER_ID)).thenReturn(mockOwner);
+        }
+
+        @Test
+        @DisplayName("R 단계 저장 시 record.complete()와 scrumWritePort.completeStar가 호출된다")
+        void should_callCompleteStar_when_stepIsR() {
             given(scrumWritePort.completeStar(scrum.getId())).willReturn(1);
+            given(starRecordRepositoryPort.countCompleted(USER_ID)).willReturn(1L);
 
             service.updateStep(command(StarStep.R));
 
@@ -158,16 +178,67 @@ class UpdateStarRecordStepServiceTest {
         @Test
         @DisplayName("completeStar가 0을 반환하면 SCRUM_NOT_FOUND를 던진다")
         void should_throwScrumNotFound_when_completeStarUpdatesNothing() {
-            record.saveStep(StarStep.ST, "ST 답변");
-            record.saveStep(StarStep.A, "A 답변");
-            given(starRecordRepositoryPort.findByIdWithScrum(STAR_ID))
-                    .willReturn(Optional.of(record));
             given(scrumWritePort.completeStar(scrum.getId())).willReturn(0);
 
             assertThatThrownBy(() -> service.updateStep(command(StarStep.R)))
                     .isInstanceOf(BusinessException.class)
                     .extracting("errorCode")
                     .isEqualTo(ErrorCode.SCRUM_NOT_FOUND);
+        }
+
+        @Test
+        @DisplayName("R 단계 완료 시 isCompleted=true로 세팅된다")
+        void should_setIsCompleted_when_stepIsR() {
+            given(scrumWritePort.completeStar(scrum.getId())).willReturn(1);
+            given(starRecordRepositoryPort.countCompleted(USER_ID)).willReturn(1L);
+
+            service.updateStep(command(StarStep.R));
+
+            org.assertj.core.api.Assertions.assertThat(record.isCompleted()).isTrue();
+        }
+
+        @Test
+        @DisplayName("R 단계 완료 시 commitAllByIds가 호출된다")
+        void should_callCommitAllByIds_when_stepIsR() {
+            given(scrumWritePort.completeStar(scrum.getId())).willReturn(1);
+            given(starRecordRepositoryPort.countCompleted(USER_ID)).willReturn(1L);
+
+            service.updateStep(command(StarStep.R));
+
+            verify(scrumTitleRepositoryPort).commitAllByIds(any());
+        }
+
+        @Test
+        @DisplayName("완료 개수 1회일 때 코치마크 노출 플래그가 세팅된다")
+        void should_markCoachMark_when_completedCountIs1() {
+            given(scrumWritePort.completeStar(scrum.getId())).willReturn(1);
+            given(starRecordRepositoryPort.countCompleted(USER_ID)).willReturn(1L);
+
+            service.updateStep(command(StarStep.R));
+
+            verify(mockOwner).markPendingCoachMark();
+        }
+
+        @Test
+        @DisplayName("완료 개수 10회일 때 MINI 리포트 모달 노출 플래그가 세팅된다")
+        void should_markMiniReportModal_when_completedCountIs10() {
+            given(scrumWritePort.completeStar(scrum.getId())).willReturn(1);
+            given(starRecordRepositoryPort.countCompleted(USER_ID)).willReturn(10L);
+
+            service.updateStep(command(StarStep.R));
+
+            verify(mockOwner).markPendingReportModal("MINI");
+        }
+
+        @Test
+        @DisplayName("완료 개수 20회일 때 FULL 리포트 모달 노출 플래그가 세팅된다")
+        void should_markFullReportModal_when_completedCountIs20() {
+            given(scrumWritePort.completeStar(scrum.getId())).willReturn(1);
+            given(starRecordRepositoryPort.countCompleted(USER_ID)).willReturn(20L);
+
+            service.updateStep(command(StarStep.R));
+
+            verify(mockOwner).markPendingReportModal("FULL");
         }
     }
 

--- a/src/test/java/com/groute/groute_server/record/application/service/UpdateStarRecordStepServiceTest.java
+++ b/src/test/java/com/groute/groute_server/record/application/service/UpdateStarRecordStepServiceTest.java
@@ -160,7 +160,9 @@ class UpdateStarRecordStepServiceTest {
             record.saveStep(StarStep.A, "A 답변");
             given(starRecordRepositoryPort.findByIdWithScrum(STAR_ID))
                     .willReturn(Optional.of(record));
-            Mockito.lenient().when(scrumQueryPort.findAllByUserAndDate(any(), any())).thenReturn(List.of(scrum));
+            Mockito.lenient()
+                    .when(scrumQueryPort.findAllByUserAndDate(any(), any()))
+                    .thenReturn(List.of(scrum));
             Mockito.lenient().when(userPort.findById(USER_ID)).thenReturn(mockOwner);
         }
 

--- a/src/test/java/com/groute/groute_server/record/service/AiTaggingServiceTest.java
+++ b/src/test/java/com/groute/groute_server/record/service/AiTaggingServiceTest.java
@@ -405,30 +405,21 @@ class AiTaggingServiceTest {
     class CompleteTagging {
 
         @Test
-        @DisplayName("성공 — 세션 내 마지막 태깅 완료 시 StarRecord TAGGED + ScrumTitle COMMITTED")
-        void marksTaggedAndCommits_whenAllTagged() {
+        @DisplayName("성공 — 세션 내 마지막 태깅 완료 시 StarRecord TAGGED 전환")
+        void marksTagged_whenCompleteTagging() {
             StarRecord record = makeStarRecordWithScrum(USER_ID, StarStep.DONE);
             given(starRecordPort.findByIdWithScrum(STAR_RECORD_ID)).willReturn(Optional.of(record));
-            given(starRecordPort.existsUntaggedByUserAndDate(USER_ID, DATE)).willReturn(false);
-            given(scrumQueryPort.findAllByUserAndDate(USER_ID, DATE))
-                    .willReturn(List.of(scrumWithTitle(1L, 100L), scrumWithTitle(2L, 100L)));
-            given(starRecordPort.countTaggedByUserId(USER_ID)).willReturn(5L);
-            given(userPort.findById(USER_ID)).willReturn(User.createForSocialLogin());
 
             aiTaggingService.completeTagging(STAR_RECORD_ID, "PROBLEM_SOLVING", List.of("문제해결"));
 
             assertThat(record.getStatus()).isEqualTo(StarRecordStatus.TAGGED);
-            verify(scrumTitleRepositoryPort).commitAllByIds(List.of(100L));
         }
 
         @Test
-        @DisplayName("성공 — 아직 미완료 StarRecord 있으면 TAGGED 전환만 하고 COMMITTED 안 함")
+        @DisplayName("성공 — 아직 미완료 StarRecord 있어도 TAGGED 전환 된다")
         void marksTaggedOnly_whenUntaggedRemain() {
             StarRecord record = makeStarRecordWithScrum(USER_ID, StarStep.DONE);
             given(starRecordPort.findByIdWithScrum(STAR_RECORD_ID)).willReturn(Optional.of(record));
-            given(starRecordPort.existsUntaggedByUserAndDate(USER_ID, DATE)).willReturn(true);
-            given(starRecordPort.countTaggedByUserId(USER_ID)).willReturn(5L);
-            given(userPort.findById(USER_ID)).willReturn(User.createForSocialLogin());
 
             aiTaggingService.completeTagging(STAR_RECORD_ID, "PROBLEM_SOLVING", List.of("문제해결"));
 


### PR DESCRIPTION
## 요약
- AI 태깅 실패 시에도 기획 의도에 맞게 캘린더 표시(심화기록 여부), 리포트 카운트, 모달 노출 플래그가 정상 동작하도록 수정
- 기존 태깅 성공시에 발생하는 것들을 -> 심화기록 r단계 작성시로 변경 
- 기획의도가 태깅에 실패하더라도 심화기록이 남고, 태깅실패 심화기록으로도 리포트 생성 가능

## 상세내용
- StarRecord.complete()에서 isCompleted=true 추가 → R단계 완료 시점에 리포트 카운트 포함
- UpdateStarRecordStepService R단계 완료 시 commitAllByIds() 호출 → hasScrums=true
- CalendarHomeRepository 쿼리를 StarTag JOIN → StarRecord LEFT JOIN StarTag로 변경 → hasStar=true
- AiTaggingServiceTest completeTagging 테스트를 변경된 로직에 맞게 수정
- UpdateStarRecordStepServiceTest R단계 완료 처리 테스트 추가

<현정 확인: /api/star-records/home-summary관련>
- 리포트 모달 노출 플래그 트리거를 completeTagging() → R단계 완료 시점으로 이동
- 모달 트리거 카운트 기준을 countTaggedByUserId → countCompleted(isCompleted=true)로 변경


## 변경 사항
- [ ] 기능
- [x] 버그 수정
- [ ] 리팩토링
- [ ] 문서
- [x] 테스트
- [ ] 기타

## 테스트
- [x] 로컬 테스트 완료
- 테스트 방법:
    - 예) ./gradlew test
    - Swagger에서 STAR R단계 완료 후 AI 서버 없는 상태로 태깅 트리거 → GET /api/calendar/monthly 에서 hasScrums=true, hasStar=true 확인
    - GET /api/reports/gauge 에서 태깅 실패한 기록도 currentCount에 포함 확인

### 커버리지 (JaCoCo)
- 라인 커버리지: 70%  (기준: 60% 이상)
- [x] `./gradlew test` 실행 후 `build/reports/jacoco/index.html`에서 수치 확인
- (선택) 리포트 스크린샷 또는 60% 미달/특이사항 공유:

## 스크린샷/로그 (선택)
- 필요한 경우 첨부

## 롤백/리스크
- 리스크 포인트:
- 롤백 방법:

## 관련 이슈
Closes #161

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Bug Fixes**
  * STAR 기록 데이터 조회 시 태그가 없는 레코드도 올바르게 조회되도록 개선

* **Refactor**
  * STAR 기록 완료 처리 시 스크럼 제목 전환 및 리포트/코치 마크 팝업 트리거 로직 통합
  * 불필요한 태깅 상태 확인 로직 제거로 기능 단순화
  * STAR 기록 완료 상태 추적 메커니즘 개선

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/2026-KUSITMS-GLIT/2026-KUSITMS-GLIT-BACK/pull/173?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->