### PR TITLE
refactor: AiTaggingService.completeTagging 책임 분리 (#168)

### DIFF
--- a/src/main/java/com/groute/groute_server/record/application/service/AiTaggingService.java
+++ b/src/main/java/com/groute/groute_server/record/application/service/AiTaggingService.java
@@ -18,12 +18,9 @@ import com.groute.groute_server.record.application.port.in.GetAiTaggingStatusUse
 import com.groute.groute_server.record.application.port.in.TriggerAiTaggingUseCase;
 import com.groute.groute_server.record.application.port.out.AiTaggingJobPort;
 import com.groute.groute_server.record.application.port.out.UserPort;
-import com.groute.groute_server.record.application.port.out.scrum.ScrumQueryPort;
-import com.groute.groute_server.record.application.port.out.scrumtitle.ScrumTitleRepositoryPort;
 import com.groute.groute_server.record.application.port.out.star.StarRecordRepositoryPort;
 import com.groute.groute_server.record.application.port.out.star.StarTagQueryPort;
 import com.groute.groute_server.record.domain.AiTaggingJob;
-import com.groute.groute_server.record.domain.Scrum;
 import com.groute.groute_server.record.domain.StarRecord;
 import com.groute.groute_server.record.domain.StarTag;
 import com.groute.groute_server.record.domain.enums.JobStatus;
@@ -50,11 +47,10 @@ public class AiTaggingService
     private final StarRecordRepositoryPort starRecordPort;
     private final AiTaggingJobPort aiTaggingJobPort;
     private final StarTagQueryPort starTagPort;
-    private final ScrumQueryPort scrumQueryPort;
-    private final ScrumTitleRepositoryPort scrumTitleRepositoryPort;
     private final UserPort userPort;
     private final AiTaggingAsyncExecutor aiTaggingAsyncExecutor;
     private final StarTagPersister starTagPersister;
+    private final ScrumTitleCommitter scrumTitleCommitter;
 
     /**
      * REC-005: AI 태깅 트리거.
@@ -199,15 +195,7 @@ public class AiTaggingService
         Long userId = record.getUser().getId();
         LocalDate date = record.getScrum().getScrumDate();
 
-        if (!starRecordPort.existsUntaggedByUserAndDate(userId, date)) {
-            List<Long> titleIds =
-                    scrumQueryPort.findAllByUserAndDate(userId, date).stream()
-                            .map(Scrum::getTitle)
-                            .map(t -> t.getId())
-                            .distinct()
-                            .toList();
-            scrumTitleRepositoryPort.commitAllByIds(titleIds);
-        }
+        scrumTitleCommitter.commitIfFullyTagged(userId, date);
 
         long taggedCount = starRecordPort.countTaggedByUserId(userId);
         User user = userPort.findById(userId);

--- a/src/main/java/com/groute/groute_server/record/application/service/AiTaggingService.java
+++ b/src/main/java/com/groute/groute_server/record/application/service/AiTaggingService.java
@@ -22,12 +22,10 @@ import com.groute.groute_server.record.application.port.out.scrum.ScrumQueryPort
 import com.groute.groute_server.record.application.port.out.scrumtitle.ScrumTitleRepositoryPort;
 import com.groute.groute_server.record.application.port.out.star.StarRecordRepositoryPort;
 import com.groute.groute_server.record.application.port.out.star.StarTagQueryPort;
-import com.groute.groute_server.record.application.port.out.star.StarTagSavePort;
 import com.groute.groute_server.record.domain.AiTaggingJob;
 import com.groute.groute_server.record.domain.Scrum;
 import com.groute.groute_server.record.domain.StarRecord;
 import com.groute.groute_server.record.domain.StarTag;
-import com.groute.groute_server.record.domain.enums.CompetencyCategory;
 import com.groute.groute_server.record.domain.enums.JobStatus;
 import com.groute.groute_server.user.entity.User;
 
@@ -52,11 +50,11 @@ public class AiTaggingService
     private final StarRecordRepositoryPort starRecordPort;
     private final AiTaggingJobPort aiTaggingJobPort;
     private final StarTagQueryPort starTagPort;
-    private final StarTagSavePort starTagSavePort;
     private final ScrumQueryPort scrumQueryPort;
     private final ScrumTitleRepositoryPort scrumTitleRepositoryPort;
     private final UserPort userPort;
     private final AiTaggingAsyncExecutor aiTaggingAsyncExecutor;
+    private final StarTagPersister starTagPersister;
 
     /**
      * REC-005: AI 태깅 트리거.
@@ -196,31 +194,7 @@ public class AiTaggingService
 
         record.tag();
 
-        // star_tags 저장
-        if (primaryCategory == null || primaryCategory.isBlank()) {
-            log.warn(
-                    "[AI Tagging] primaryCategory가 비어있어 star_tags 저장 생략 — starRecordId={}",
-                    starRecordId);
-        } else {
-            CompetencyCategory category;
-            try {
-                category = CompetencyCategory.valueOf(primaryCategory);
-            } catch (IllegalArgumentException e) {
-                log.warn(
-                        "[AI Tagging] primaryCategory 값 불일치 — value={}, starRecordId={}",
-                        primaryCategory,
-                        starRecordId);
-                category = null;
-            }
-            if (category != null && detailTags != null && !detailTags.isEmpty()) {
-                final CompetencyCategory finalCategory = category;
-                List<StarTag> tags =
-                        detailTags.stream()
-                                .map(detailTag -> StarTag.of(record, finalCategory, detailTag))
-                                .toList();
-                starTagSavePort.saveAll(tags);
-            }
-        }
+        starTagPersister.persist(record, primaryCategory, detailTags);
 
         Long userId = record.getUser().getId();
         LocalDate date = record.getScrum().getScrumDate();

--- a/src/main/java/com/groute/groute_server/record/application/service/AiTaggingService.java
+++ b/src/main/java/com/groute/groute_server/record/application/service/AiTaggingService.java
@@ -17,14 +17,12 @@ import com.groute.groute_server.record.application.port.in.GetAiTaggingResultUse
 import com.groute.groute_server.record.application.port.in.GetAiTaggingStatusUseCase;
 import com.groute.groute_server.record.application.port.in.TriggerAiTaggingUseCase;
 import com.groute.groute_server.record.application.port.out.AiTaggingJobPort;
-import com.groute.groute_server.record.application.port.out.UserPort;
 import com.groute.groute_server.record.application.port.out.star.StarRecordRepositoryPort;
 import com.groute.groute_server.record.application.port.out.star.StarTagQueryPort;
 import com.groute.groute_server.record.domain.AiTaggingJob;
 import com.groute.groute_server.record.domain.StarRecord;
 import com.groute.groute_server.record.domain.StarTag;
 import com.groute.groute_server.record.domain.enums.JobStatus;
-import com.groute.groute_server.user.entity.User;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -47,10 +45,10 @@ public class AiTaggingService
     private final StarRecordRepositoryPort starRecordPort;
     private final AiTaggingJobPort aiTaggingJobPort;
     private final StarTagQueryPort starTagPort;
-    private final UserPort userPort;
     private final AiTaggingAsyncExecutor aiTaggingAsyncExecutor;
     private final StarTagPersister starTagPersister;
     private final ScrumTitleCommitter scrumTitleCommitter;
+    private final UserMilestoneTracker userMilestoneTracker;
 
     /**
      * REC-005: AI 태깅 트리거.
@@ -197,15 +195,6 @@ public class AiTaggingService
 
         scrumTitleCommitter.commitIfFullyTagged(userId, date);
 
-        long taggedCount = starRecordPort.countTaggedByUserId(userId);
-        User user = userPort.findById(userId);
-        if (taggedCount == 1) {
-            user.markPendingCoachMark();
-        }
-        if (taggedCount == 10) {
-            user.markPendingReportModal("MINI");
-        } else if (taggedCount >= 20 && taggedCount % 10 == 0) {
-            user.markPendingReportModal("FULL");
-        }
+        userMilestoneTracker.track(userId);
     }
 }

--- a/src/main/java/com/groute/groute_server/record/application/service/ScrumBulkWriteService.java
+++ b/src/main/java/com/groute/groute_server/record/application/service/ScrumBulkWriteService.java
@@ -19,6 +19,7 @@ import com.groute.groute_server.record.application.port.out.scrum.ScrumWritePort
 import com.groute.groute_server.record.application.port.out.scrumtitle.ScrumTitleRepositoryPort;
 import com.groute.groute_server.record.application.port.out.star.StarRecordRepositoryPort;
 import com.groute.groute_server.record.application.port.out.user.UserReferencePort;
+import com.groute.groute_server.record.application.port.out.user.UserStreakPort;
 import com.groute.groute_server.record.domain.Project;
 import com.groute.groute_server.record.domain.Scrum;
 import com.groute.groute_server.record.domain.ScrumTitle;
@@ -46,6 +47,7 @@ public class ScrumBulkWriteService implements BulkWriteScrumUseCase {
     private final StarRecordRepositoryPort starRecordRepositoryPort;
     private final StarImageCascadeCleaner starImageCascadeCleaner;
     private final UserReferencePort userReferencePort;
+    private final UserStreakPort userStreakPort;
 
     @Override
     public BulkWriteScrumResult bulkWrite(BulkWriteScrumCommand command) {
@@ -108,7 +110,10 @@ public class ScrumBulkWriteService implements BulkWriteScrumUseCase {
         }
         List<Scrum> savedScrums = scrumWritePort.saveAll(scrums);
 
-        // 6. Project.titleCount 증감 (동일 projectId 중복 시 count만큼)
+        // 6. user streak 갱신 (REC-001) — 같은 날 재작성은 entity 단에서 멱등 처리
+        userStreakPort.recordOnDate(command.userId(), command.date());
+
+        // 7. Project.titleCount 증감 (동일 projectId 중복 시 count만큼)
         groups.stream()
                 .collect(
                         Collectors.groupingBy(
@@ -118,7 +123,7 @@ public class ScrumBulkWriteService implements BulkWriteScrumUseCase {
                         (projectId, count) ->
                                 projectPort.applyTitleCountIncrement(projectId, count.intValue()));
 
-        // 7. 결과 조립 (저장 순서 보장)
+        // 8. 결과 조립 (저장 순서 보장)
         List<BulkWriteScrumResult.GroupResult> results = new ArrayList<>();
         int scrumIdx = 0;
         for (int i = 0; i < savedTitles.size(); i++) {

--- a/src/main/java/com/groute/groute_server/record/application/service/ScrumTitleCommitter.java
+++ b/src/main/java/com/groute/groute_server/record/application/service/ScrumTitleCommitter.java
@@ -1,0 +1,37 @@
+package com.groute.groute_server.record.application.service;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import org.springframework.stereotype.Component;
+
+import com.groute.groute_server.record.application.port.out.scrum.ScrumQueryPort;
+import com.groute.groute_server.record.application.port.out.scrumtitle.ScrumTitleRepositoryPort;
+import com.groute.groute_server.record.application.port.out.star.StarRecordRepositoryPort;
+import com.groute.groute_server.record.domain.Scrum;
+import com.groute.groute_server.record.domain.ScrumTitle;
+
+import lombok.RequiredArgsConstructor;
+
+/** 사용자·일자별로 더 이상 미완료 StarRecord가 없으면 해당 일자의 ScrumTitle을 COMMITTED로 전환한다. */
+@Component
+@RequiredArgsConstructor
+public class ScrumTitleCommitter {
+
+    private final StarRecordRepositoryPort starRecordPort;
+    private final ScrumQueryPort scrumQueryPort;
+    private final ScrumTitleRepositoryPort scrumTitleRepositoryPort;
+
+    public void commitIfFullyTagged(Long userId, LocalDate date) {
+        if (starRecordPort.existsUntaggedByUserAndDate(userId, date)) {
+            return;
+        }
+        List<Long> titleIds =
+                scrumQueryPort.findAllByUserAndDate(userId, date).stream()
+                        .map(Scrum::getTitle)
+                        .map(ScrumTitle::getId)
+                        .distinct()
+                        .toList();
+        scrumTitleRepositoryPort.commitAllByIds(titleIds);
+    }
+}

--- a/src/main/java/com/groute/groute_server/record/application/service/StarTagPersister.java
+++ b/src/main/java/com/groute/groute_server/record/application/service/StarTagPersister.java
@@ -1,0 +1,49 @@
+package com.groute.groute_server.record.application.service;
+
+import java.util.List;
+
+import org.springframework.stereotype.Component;
+
+import com.groute.groute_server.record.application.port.out.star.StarTagSavePort;
+import com.groute.groute_server.record.domain.StarRecord;
+import com.groute.groute_server.record.domain.StarTag;
+import com.groute.groute_server.record.domain.enums.CompetencyCategory;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+/** AI 태깅 결과를 검증한 뒤 star_tags 행을 저장한다. primaryCategory 누락·미일치 시 저장을 생략한다. */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class StarTagPersister {
+
+    private final StarTagSavePort starTagSavePort;
+
+    public void persist(StarRecord record, String primaryCategory, List<String> detailTags) {
+        if (primaryCategory == null || primaryCategory.isBlank()) {
+            log.warn(
+                    "[AI Tagging] primaryCategory가 비어있어 star_tags 저장 생략 — starRecordId={}",
+                    record.getId());
+            return;
+        }
+        CompetencyCategory category;
+        try {
+            category = CompetencyCategory.valueOf(primaryCategory);
+        } catch (IllegalArgumentException e) {
+            log.warn(
+                    "[AI Tagging] primaryCategory 값 불일치 — value={}, starRecordId={}",
+                    primaryCategory,
+                    record.getId());
+            return;
+        }
+        if (detailTags == null || detailTags.isEmpty()) {
+            return;
+        }
+        List<StarTag> tags =
+                detailTags.stream()
+                        .map(detailTag -> StarTag.of(record, category, detailTag))
+                        .toList();
+        starTagSavePort.saveAll(tags);
+    }
+}

--- a/src/main/java/com/groute/groute_server/record/application/service/UserMilestoneTracker.java
+++ b/src/main/java/com/groute/groute_server/record/application/service/UserMilestoneTracker.java
@@ -1,0 +1,36 @@
+package com.groute.groute_server.record.application.service;
+
+import org.springframework.stereotype.Component;
+
+import com.groute.groute_server.record.application.port.out.UserPort;
+import com.groute.groute_server.record.application.port.out.star.StarRecordRepositoryPort;
+import com.groute.groute_server.user.entity.User;
+
+import lombok.RequiredArgsConstructor;
+
+/** AI 태깅 완료 누적 카운트에 따라 사용자의 코치마크·리포트 모달 노출 예약을 갱신한다. */
+@Component
+@RequiredArgsConstructor
+public class UserMilestoneTracker {
+
+    private static final long COACH_MARK_MILESTONE = 1L;
+    private static final long MINI_REPORT_MILESTONE = 10L;
+    private static final long FULL_REPORT_BASE = 20L;
+    private static final long FULL_REPORT_PERIOD = 10L;
+
+    private final StarRecordRepositoryPort starRecordPort;
+    private final UserPort userPort;
+
+    public void track(Long userId) {
+        long taggedCount = starRecordPort.countTaggedByUserId(userId);
+        User user = userPort.findById(userId);
+        if (taggedCount == COACH_MARK_MILESTONE) {
+            user.markPendingCoachMark();
+        }
+        if (taggedCount == MINI_REPORT_MILESTONE) {
+            user.markPendingReportModal("MINI");
+        } else if (taggedCount >= FULL_REPORT_BASE && taggedCount % FULL_REPORT_PERIOD == 0) {
+            user.markPendingReportModal("FULL");
+        }
+    }
+}

--- a/src/test/java/com/groute/groute_server/record/application/service/ScrumBulkWriteServiceTest.java
+++ b/src/test/java/com/groute/groute_server/record/application/service/ScrumBulkWriteServiceTest.java
@@ -2,6 +2,7 @@ package com.groute.groute_server.record.application.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyCollection;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.anyLong;
@@ -33,6 +34,7 @@ import com.groute.groute_server.record.application.port.out.scrum.ScrumWritePort
 import com.groute.groute_server.record.application.port.out.scrumtitle.ScrumTitleRepositoryPort;
 import com.groute.groute_server.record.application.port.out.star.StarRecordRepositoryPort;
 import com.groute.groute_server.record.application.port.out.user.UserReferencePort;
+import com.groute.groute_server.record.application.port.out.user.UserStreakPort;
 import com.groute.groute_server.record.domain.Project;
 import com.groute.groute_server.record.domain.Scrum;
 import com.groute.groute_server.record.domain.ScrumTitle;
@@ -52,6 +54,7 @@ class ScrumBulkWriteServiceTest {
     @Mock StarRecordRepositoryPort starRecordRepositoryPort;
     @Mock StarImageCascadeCleaner starImageCascadeCleaner;
     @Mock UserReferencePort userReferencePort;
+    @Mock UserStreakPort userStreakPort;
 
     @InjectMocks ScrumBulkWriteService service;
 
@@ -235,6 +238,51 @@ class ScrumBulkWriteServiceTest {
             assertThat(result.groups().get(0).scrums().get(1).content()).isEqualTo("B");
             assertThat(result.groups().get(1).scrums()).hasSize(1);
             assertThat(result.groups().get(1).scrums().get(0).content()).isEqualTo("C");
+        }
+    }
+
+    @Nested
+    @DisplayName("streak 갱신")
+    class Streak {
+
+        @Test
+        @DisplayName("저장 성공 시 user streak를 userId·date로 갱신한다")
+        void should_recordStreak_when_writeSucceeds() {
+            given(projectPort.findByIdAndUserId(100L, USER_ID))
+                    .willReturn(Optional.of(project(100L, "프로젝트A")));
+            given(userReferencePort.getReferenceById(USER_ID))
+                    .willReturn(User.createForSocialLogin());
+            stubSaveTitles();
+            stubSaveScrums();
+
+            service.bulkWrite(command(group(100L, "제목", "스크럼1")));
+
+            verify(userStreakPort).recordOnDate(USER_ID, DATE);
+        }
+
+        @Test
+        @DisplayName("COMMITTED 충돌로 실패하면 streak를 갱신하지 않는다")
+        void should_notRecordStreak_when_committedConflict() {
+            given(scrumQueryPort.findAllByUserAndDate(USER_ID, DATE))
+                    .willReturn(
+                            List.of(scrumWithTitle(50L, 10L, ScrumTitleStatus.COMMITTED, 100L)));
+
+            assertThatThrownBy(() -> service.bulkWrite(command(group(100L, "제목", "스크럼1"))))
+                    .isInstanceOf(BusinessException.class);
+
+            verify(userStreakPort, never()).recordOnDate(anyLong(), any(LocalDate.class));
+        }
+
+        @Test
+        @DisplayName("스크럼 개수 초과로 실패하면 streak를 갱신하지 않는다")
+        void should_notRecordStreak_when_dateLimitExceeded() {
+            BulkWriteScrumCommand command =
+                    command(group(100L, "제목", "a", "b", "c", "d", "e", "f"));
+
+            assertThatThrownBy(() -> service.bulkWrite(command))
+                    .isInstanceOf(BusinessException.class);
+
+            verify(userStreakPort, never()).recordOnDate(anyLong(), any(LocalDate.class));
         }
     }
 

--- a/src/test/java/com/groute/groute_server/record/service/AiTaggingServiceTest.java
+++ b/src/test/java/com/groute/groute_server/record/service/AiTaggingServiceTest.java
@@ -29,13 +29,13 @@ import com.groute.groute_server.common.exception.ErrorCode;
 import com.groute.groute_server.record.adapter.in.web.dto.AiTaggingResultResponse;
 import com.groute.groute_server.record.adapter.in.web.dto.AiTaggingStatusResponse;
 import com.groute.groute_server.record.application.port.out.AiTaggingJobPort;
-import com.groute.groute_server.record.application.port.out.UserPort;
 import com.groute.groute_server.record.application.port.out.star.StarRecordRepositoryPort;
 import com.groute.groute_server.record.application.port.out.star.StarTagQueryPort;
 import com.groute.groute_server.record.application.service.AiTaggingAsyncExecutor;
 import com.groute.groute_server.record.application.service.AiTaggingService;
 import com.groute.groute_server.record.application.service.ScrumTitleCommitter;
 import com.groute.groute_server.record.application.service.StarTagPersister;
+import com.groute.groute_server.record.application.service.UserMilestoneTracker;
 import com.groute.groute_server.record.domain.AiTaggingJob;
 import com.groute.groute_server.record.domain.Scrum;
 import com.groute.groute_server.record.domain.ScrumTitle;
@@ -59,10 +59,10 @@ class AiTaggingServiceTest {
     @Mock private StarRecordRepositoryPort starRecordPort;
     @Mock private AiTaggingJobPort aiTaggingJobPort;
     @Mock private StarTagQueryPort starTagPort;
-    @Mock private UserPort userPort;
     @Mock private AiTaggingAsyncExecutor aiTaggingAsyncExecutor;
     @Mock private StarTagPersister starTagPersister;
     @Mock private ScrumTitleCommitter scrumTitleCommitter;
+    @Mock private UserMilestoneTracker userMilestoneTracker;
 
     @InjectMocks private AiTaggingService aiTaggingService;
 
@@ -394,18 +394,18 @@ class AiTaggingServiceTest {
     class CompleteTagging {
 
         @Test
-        @DisplayName("성공 — StarRecord TAGGED 전환 후 starTagPersister·scrumTitleCommitter 위임 호출")
+        @DisplayName(
+                "성공 — TAGGED 전환 후 starTagPersister·scrumTitleCommitter·userMilestoneTracker 위임 호출")
         void delegatesToCollaborators_whenTaggingCompletes() {
             StarRecord record = makeStarRecordWithScrum(USER_ID, StarStep.DONE);
             given(starRecordPort.findByIdWithScrum(STAR_RECORD_ID)).willReturn(Optional.of(record));
-            given(starRecordPort.countTaggedByUserId(USER_ID)).willReturn(5L);
-            given(userPort.findById(USER_ID)).willReturn(User.createForSocialLogin());
 
             aiTaggingService.completeTagging(STAR_RECORD_ID, "PROBLEM_SOLVING", List.of("문제해결"));
 
             assertThat(record.getStatus()).isEqualTo(StarRecordStatus.TAGGED);
             verify(starTagPersister).persist(record, "PROBLEM_SOLVING", List.of("문제해결"));
             verify(scrumTitleCommitter).commitIfFullyTagged(USER_ID, DATE);
+            verify(userMilestoneTracker).track(USER_ID);
         }
 
         @Test

--- a/src/test/java/com/groute/groute_server/record/service/AiTaggingServiceTest.java
+++ b/src/test/java/com/groute/groute_server/record/service/AiTaggingServiceTest.java
@@ -34,9 +34,9 @@ import com.groute.groute_server.record.application.port.out.scrum.ScrumQueryPort
 import com.groute.groute_server.record.application.port.out.scrumtitle.ScrumTitleRepositoryPort;
 import com.groute.groute_server.record.application.port.out.star.StarRecordRepositoryPort;
 import com.groute.groute_server.record.application.port.out.star.StarTagQueryPort;
-import com.groute.groute_server.record.application.port.out.star.StarTagSavePort;
 import com.groute.groute_server.record.application.service.AiTaggingAsyncExecutor;
 import com.groute.groute_server.record.application.service.AiTaggingService;
+import com.groute.groute_server.record.application.service.StarTagPersister;
 import com.groute.groute_server.record.domain.AiTaggingJob;
 import com.groute.groute_server.record.domain.Scrum;
 import com.groute.groute_server.record.domain.ScrumTitle;
@@ -60,11 +60,11 @@ class AiTaggingServiceTest {
     @Mock private StarRecordRepositoryPort starRecordPort;
     @Mock private AiTaggingJobPort aiTaggingJobPort;
     @Mock private StarTagQueryPort starTagPort;
-    @Mock private StarTagSavePort starTagSavePort;
     @Mock private ScrumQueryPort scrumQueryPort;
     @Mock private ScrumTitleRepositoryPort scrumTitleRepositoryPort;
     @Mock private UserPort userPort;
     @Mock private AiTaggingAsyncExecutor aiTaggingAsyncExecutor;
+    @Mock private StarTagPersister starTagPersister;
 
     @InjectMocks private AiTaggingService aiTaggingService;
 

--- a/src/test/java/com/groute/groute_server/record/service/AiTaggingServiceTest.java
+++ b/src/test/java/com/groute/groute_server/record/service/AiTaggingServiceTest.java
@@ -30,12 +30,11 @@ import com.groute.groute_server.record.adapter.in.web.dto.AiTaggingResultRespons
 import com.groute.groute_server.record.adapter.in.web.dto.AiTaggingStatusResponse;
 import com.groute.groute_server.record.application.port.out.AiTaggingJobPort;
 import com.groute.groute_server.record.application.port.out.UserPort;
-import com.groute.groute_server.record.application.port.out.scrum.ScrumQueryPort;
-import com.groute.groute_server.record.application.port.out.scrumtitle.ScrumTitleRepositoryPort;
 import com.groute.groute_server.record.application.port.out.star.StarRecordRepositoryPort;
 import com.groute.groute_server.record.application.port.out.star.StarTagQueryPort;
 import com.groute.groute_server.record.application.service.AiTaggingAsyncExecutor;
 import com.groute.groute_server.record.application.service.AiTaggingService;
+import com.groute.groute_server.record.application.service.ScrumTitleCommitter;
 import com.groute.groute_server.record.application.service.StarTagPersister;
 import com.groute.groute_server.record.domain.AiTaggingJob;
 import com.groute.groute_server.record.domain.Scrum;
@@ -60,11 +59,10 @@ class AiTaggingServiceTest {
     @Mock private StarRecordRepositoryPort starRecordPort;
     @Mock private AiTaggingJobPort aiTaggingJobPort;
     @Mock private StarTagQueryPort starTagPort;
-    @Mock private ScrumQueryPort scrumQueryPort;
-    @Mock private ScrumTitleRepositoryPort scrumTitleRepositoryPort;
     @Mock private UserPort userPort;
     @Mock private AiTaggingAsyncExecutor aiTaggingAsyncExecutor;
     @Mock private StarTagPersister starTagPersister;
+    @Mock private ScrumTitleCommitter scrumTitleCommitter;
 
     @InjectMocks private AiTaggingService aiTaggingService;
 
@@ -108,15 +106,6 @@ class AiTaggingServiceTest {
         ReflectionTestUtils.setField(scrum, "title", title);
         ReflectionTestUtils.setField(record, "scrum", scrum);
         return record;
-    }
-
-    private static Scrum scrumWithTitle(Long scrumId, Long titleId) {
-        ScrumTitle title = new ScrumTitle();
-        ReflectionTestUtils.setField(title, "id", titleId);
-        Scrum scrum = new Scrum();
-        ReflectionTestUtils.setField(scrum, "id", scrumId);
-        ReflectionTestUtils.setField(scrum, "title", title);
-        return scrum;
     }
 
     private AiTaggingJob makeJob(JobStatus status, int retryCount) {
@@ -405,35 +394,18 @@ class AiTaggingServiceTest {
     class CompleteTagging {
 
         @Test
-        @DisplayName("성공 — 세션 내 마지막 태깅 완료 시 StarRecord TAGGED + ScrumTitle COMMITTED")
-        void marksTaggedAndCommits_whenAllTagged() {
+        @DisplayName("성공 — StarRecord TAGGED 전환 후 starTagPersister·scrumTitleCommitter 위임 호출")
+        void delegatesToCollaborators_whenTaggingCompletes() {
             StarRecord record = makeStarRecordWithScrum(USER_ID, StarStep.DONE);
             given(starRecordPort.findByIdWithScrum(STAR_RECORD_ID)).willReturn(Optional.of(record));
-            given(starRecordPort.existsUntaggedByUserAndDate(USER_ID, DATE)).willReturn(false);
-            given(scrumQueryPort.findAllByUserAndDate(USER_ID, DATE))
-                    .willReturn(List.of(scrumWithTitle(1L, 100L), scrumWithTitle(2L, 100L)));
             given(starRecordPort.countTaggedByUserId(USER_ID)).willReturn(5L);
             given(userPort.findById(USER_ID)).willReturn(User.createForSocialLogin());
 
             aiTaggingService.completeTagging(STAR_RECORD_ID, "PROBLEM_SOLVING", List.of("문제해결"));
 
             assertThat(record.getStatus()).isEqualTo(StarRecordStatus.TAGGED);
-            verify(scrumTitleRepositoryPort).commitAllByIds(List.of(100L));
-        }
-
-        @Test
-        @DisplayName("성공 — 아직 미완료 StarRecord 있으면 TAGGED 전환만 하고 COMMITTED 안 함")
-        void marksTaggedOnly_whenUntaggedRemain() {
-            StarRecord record = makeStarRecordWithScrum(USER_ID, StarStep.DONE);
-            given(starRecordPort.findByIdWithScrum(STAR_RECORD_ID)).willReturn(Optional.of(record));
-            given(starRecordPort.existsUntaggedByUserAndDate(USER_ID, DATE)).willReturn(true);
-            given(starRecordPort.countTaggedByUserId(USER_ID)).willReturn(5L);
-            given(userPort.findById(USER_ID)).willReturn(User.createForSocialLogin());
-
-            aiTaggingService.completeTagging(STAR_RECORD_ID, "PROBLEM_SOLVING", List.of("문제해결"));
-
-            assertThat(record.getStatus()).isEqualTo(StarRecordStatus.TAGGED);
-            verify(scrumTitleRepositoryPort, never()).commitAllByIds(any());
+            verify(starTagPersister).persist(record, "PROBLEM_SOLVING", List.of("문제해결"));
+            verify(scrumTitleCommitter).commitIfFullyTagged(USER_ID, DATE);
         }
 
         @Test

--- a/src/test/java/com/groute/groute_server/record/service/ScrumTitleCommitterTest.java
+++ b/src/test/java/com/groute/groute_server/record/service/ScrumTitleCommitterTest.java
@@ -1,0 +1,92 @@
+package com.groute.groute_server.record.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import com.groute.groute_server.record.application.port.out.scrum.ScrumQueryPort;
+import com.groute.groute_server.record.application.port.out.scrumtitle.ScrumTitleRepositoryPort;
+import com.groute.groute_server.record.application.port.out.star.StarRecordRepositoryPort;
+import com.groute.groute_server.record.application.service.ScrumTitleCommitter;
+import com.groute.groute_server.record.domain.Scrum;
+import com.groute.groute_server.record.domain.ScrumTitle;
+
+@ExtendWith(MockitoExtension.class)
+class ScrumTitleCommitterTest {
+
+    private static final long USER_ID = 1L;
+    private static final LocalDate DATE = LocalDate.of(2026, 5, 9);
+
+    @Mock StarRecordRepositoryPort starRecordPort;
+    @Mock ScrumQueryPort scrumQueryPort;
+    @Mock ScrumTitleRepositoryPort scrumTitleRepositoryPort;
+
+    @InjectMocks ScrumTitleCommitter scrumTitleCommitter;
+
+    private static Scrum scrumWithTitle(Long titleId) {
+        ScrumTitle title = new ScrumTitle();
+        ReflectionTestUtils.setField(title, "id", titleId);
+        Scrum scrum = new Scrum();
+        ReflectionTestUtils.setField(scrum, "title", title);
+        return scrum;
+    }
+
+    @Nested
+    @DisplayName("HappyPath")
+    class HappyPath {
+
+        @Test
+        @DisplayName("성공 — 미완료가 없으면 distinct title id로 commitAllByIds 호출")
+        void commitsDistinctTitleIds_whenAllTagged() {
+            // given
+            given(starRecordPort.existsUntaggedByUserAndDate(USER_ID, DATE)).willReturn(false);
+            given(scrumQueryPort.findAllByUserAndDate(USER_ID, DATE))
+                    .willReturn(
+                            List.of(
+                                    scrumWithTitle(100L),
+                                    scrumWithTitle(100L),
+                                    scrumWithTitle(200L)));
+
+            // when
+            scrumTitleCommitter.commitIfFullyTagged(USER_ID, DATE);
+
+            // then
+            ArgumentCaptor<List<Long>> captor = ArgumentCaptor.forClass(List.class);
+            verify(scrumTitleRepositoryPort).commitAllByIds(captor.capture());
+            assertThat(captor.getValue()).containsExactly(100L, 200L);
+        }
+    }
+
+    @Nested
+    @DisplayName("Errors")
+    class Errors {
+
+        @Test
+        @DisplayName("실패 — 미완료 StarRecord가 남아있으면 commit 호출 안 됨")
+        void skipsCommit_whenUntaggedRemain() {
+            // given
+            given(starRecordPort.existsUntaggedByUserAndDate(USER_ID, DATE)).willReturn(true);
+
+            // when
+            scrumTitleCommitter.commitIfFullyTagged(USER_ID, DATE);
+
+            // then
+            verify(scrumTitleRepositoryPort, never()).commitAllByIds(any());
+        }
+    }
+}

--- a/src/test/java/com/groute/groute_server/record/service/StarTagPersisterTest.java
+++ b/src/test/java/com/groute/groute_server/record/service/StarTagPersisterTest.java
@@ -1,0 +1,131 @@
+package com.groute.groute_server.record.service;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import com.groute.groute_server.record.application.port.out.star.StarTagSavePort;
+import com.groute.groute_server.record.application.service.StarTagPersister;
+import com.groute.groute_server.record.domain.StarRecord;
+import com.groute.groute_server.record.domain.StarTag;
+
+@ExtendWith(MockitoExtension.class)
+class StarTagPersisterTest {
+
+    private static final long STAR_RECORD_ID = 10L;
+
+    @Mock StarTagSavePort starTagSavePort;
+
+    @InjectMocks StarTagPersister starTagPersister;
+
+    private StarRecord makeStarRecord() {
+        StarRecord record = new StarRecord();
+        ReflectionTestUtils.setField(record, "id", STAR_RECORD_ID);
+        return record;
+    }
+
+    @Nested
+    @DisplayName("HappyPath")
+    class HappyPath {
+
+        @Test
+        @DisplayName("성공 — primaryCategory와 detailTags가 유효하면 detailTag 수만큼 저장")
+        void savesAllTags_whenInputsAreValid() {
+            // given
+            StarRecord record = makeStarRecord();
+            List<String> detailTags = List.of("이해관계자 조율", "UX 설계");
+
+            // when
+            starTagPersister.persist(record, "DISCOVERY_ANALYSIS", detailTags);
+
+            // then
+            ArgumentCaptor<List<StarTag>> captor = ArgumentCaptor.forClass(List.class);
+            verify(starTagSavePort, times(1)).saveAll(captor.capture());
+            org.assertj.core.api.Assertions.assertThat(captor.getValue()).hasSize(2);
+        }
+    }
+
+    @Nested
+    @DisplayName("Errors")
+    class Errors {
+
+        @Test
+        @DisplayName("실패 — primaryCategory가 null이면 저장 생략")
+        void skips_whenPrimaryCategoryIsNull() {
+            // given
+            StarRecord record = makeStarRecord();
+
+            // when
+            starTagPersister.persist(record, null, List.of("문제해결"));
+
+            // then
+            verify(starTagSavePort, never()).saveAll(any());
+        }
+
+        @Test
+        @DisplayName("실패 — primaryCategory가 공백이면 저장 생략")
+        void skips_whenPrimaryCategoryIsBlank() {
+            // given
+            StarRecord record = makeStarRecord();
+
+            // when
+            starTagPersister.persist(record, "   ", List.of("문제해결"));
+
+            // then
+            verify(starTagSavePort, never()).saveAll(any());
+        }
+
+        @Test
+        @DisplayName("실패 — primaryCategory enum 미일치면 저장 생략")
+        void skips_whenPrimaryCategoryIsInvalid() {
+            // given
+            StarRecord record = makeStarRecord();
+
+            // when
+            starTagPersister.persist(record, "NOT_A_CATEGORY", List.of("문제해결"));
+
+            // then
+            verify(starTagSavePort, never()).saveAll(any());
+        }
+
+        @Test
+        @DisplayName("실패 — detailTags가 비어있으면 저장 생략")
+        void skips_whenDetailTagsEmpty() {
+            // given
+            StarRecord record = makeStarRecord();
+
+            // when
+            starTagPersister.persist(record, "DISCOVERY_ANALYSIS", List.of());
+
+            // then
+            verify(starTagSavePort, never()).saveAll(anyList());
+        }
+
+        @Test
+        @DisplayName("실패 — detailTags가 null이면 저장 생략")
+        void skips_whenDetailTagsNull() {
+            // given
+            StarRecord record = makeStarRecord();
+
+            // when
+            starTagPersister.persist(record, "DISCOVERY_ANALYSIS", null);
+
+            // then
+            verify(starTagSavePort, never()).saveAll(anyList());
+        }
+    }
+}

--- a/src/test/java/com/groute/groute_server/record/service/UserMilestoneTrackerTest.java
+++ b/src/test/java/com/groute/groute_server/record/service/UserMilestoneTrackerTest.java
@@ -1,0 +1,130 @@
+package com.groute.groute_server.record.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.groute.groute_server.record.application.port.out.UserPort;
+import com.groute.groute_server.record.application.port.out.star.StarRecordRepositoryPort;
+import com.groute.groute_server.record.application.service.UserMilestoneTracker;
+import com.groute.groute_server.user.entity.User;
+
+@ExtendWith(MockitoExtension.class)
+class UserMilestoneTrackerTest {
+
+    private static final long USER_ID = 1L;
+
+    @Mock StarRecordRepositoryPort starRecordPort;
+    @Mock UserPort userPort;
+
+    @InjectMocks UserMilestoneTracker userMilestoneTracker;
+
+    @Nested
+    @DisplayName("HappyPath")
+    class HappyPath {
+
+        @Test
+        @DisplayName("성공 — 1번째 태깅이면 코치마크 노출 예약")
+        void schedulesCoachMark_whenFirstTagging() {
+            // given
+            User user = User.createForSocialLogin();
+            given(starRecordPort.countTaggedByUserId(USER_ID)).willReturn(1L);
+            given(userPort.findById(USER_ID)).willReturn(user);
+
+            // when
+            userMilestoneTracker.track(USER_ID);
+
+            // then
+            assertThat(user.isPendingFirstStarCoachMark()).isTrue();
+            assertThat(user.getPendingReportModalType()).isNull();
+        }
+
+        @Test
+        @DisplayName("성공 — 10번째 태깅이면 MINI 리포트 모달 노출 예약")
+        void schedulesMiniReportModal_whenCountIs10() {
+            // given
+            User user = User.createForSocialLogin();
+            given(starRecordPort.countTaggedByUserId(USER_ID)).willReturn(10L);
+            given(userPort.findById(USER_ID)).willReturn(user);
+
+            // when
+            userMilestoneTracker.track(USER_ID);
+
+            // then
+            assertThat(user.getPendingReportModalType()).isEqualTo("MINI");
+        }
+
+        @Test
+        @DisplayName("성공 — 20번째 태깅이면 FULL 리포트 모달 노출 예약")
+        void schedulesFullReportModal_whenCountIs20() {
+            // given
+            User user = User.createForSocialLogin();
+            given(starRecordPort.countTaggedByUserId(USER_ID)).willReturn(20L);
+            given(userPort.findById(USER_ID)).willReturn(user);
+
+            // when
+            userMilestoneTracker.track(USER_ID);
+
+            // then
+            assertThat(user.getPendingReportModalType()).isEqualTo("FULL");
+        }
+
+        @Test
+        @DisplayName("성공 — 30번째 태깅이면 FULL 리포트 모달 노출 예약")
+        void schedulesFullReportModal_whenCountIs30() {
+            // given
+            User user = User.createForSocialLogin();
+            given(starRecordPort.countTaggedByUserId(USER_ID)).willReturn(30L);
+            given(userPort.findById(USER_ID)).willReturn(user);
+
+            // when
+            userMilestoneTracker.track(USER_ID);
+
+            // then
+            assertThat(user.getPendingReportModalType()).isEqualTo("FULL");
+        }
+    }
+
+    @Nested
+    @DisplayName("Skips")
+    class Skips {
+
+        @Test
+        @DisplayName("스킵 — 마일스톤이 아니면 아무 예약도 하지 않음")
+        void skips_whenCountNotMilestone() {
+            // given
+            User user = User.createForSocialLogin();
+            given(starRecordPort.countTaggedByUserId(USER_ID)).willReturn(5L);
+            given(userPort.findById(USER_ID)).willReturn(user);
+
+            // when
+            userMilestoneTracker.track(USER_ID);
+
+            // then
+            assertThat(user.isPendingFirstStarCoachMark()).isFalse();
+            assertThat(user.getPendingReportModalType()).isNull();
+        }
+
+        @Test
+        @DisplayName("스킵 — 20 이상이어도 10의 배수가 아니면 모달 예약 안 함")
+        void skips_whenCountIsNotMultipleOf10AboveBase() {
+            // given
+            User user = User.createForSocialLogin();
+            given(starRecordPort.countTaggedByUserId(USER_ID)).willReturn(25L);
+            given(userPort.findById(USER_ID)).willReturn(user);
+
+            // when
+            userMilestoneTracker.track(USER_ID);
+
+            // then
+            assertThat(user.getPendingReportModalType()).isNull();
+        }
+    }
+}


### PR DESCRIPTION
## 요약
- `AiTaggingService.completeTagging`이 가지고 있던 세 가지 책임을 단일 책임 컴포넌트 세 개로 분리했습니다.
    - `StarTagPersister`: primaryCategory 검증 및 `star_tags` 저장
    - `ScrumTitleCommitter`: 동일 일자 미완료가 없으면 ScrumTitle을 COMMITTED로 전환
    - `UserMilestoneTracker`: 누적 태깅 카운트 기반 코치마크/리포트 모달 예약
- 각 컴포넌트에 단위 테스트를 신설했고, `AiTaggingServiceTest.completeTagging`은 협력자 위임을 검증하는 단일 케이스로 슬림화했습니다.

## 변경 사항
- [ ] 기능
- [ ] 버그 수정
- [x] 리팩토링
- [ ] 문서
- [ ] 테스트
- [ ] 기타

## 테스트
- [x] 로컬 테스트 완료
- 테스트 방법:
    - `./gradlew spotlessApply check` 통과
    - `StarTagPersisterTest`, `ScrumTitleCommitterTest`, `UserMilestoneTrackerTest` 신규 추가
    - `AiTaggingServiceTest.CompleteTagging`은 위임 verify로 단순화

### 커버리지 (JaCoCo)
- 라인 커버리지: 단위 테스트 신규 추가로 분리 컴포넌트 분기 커버리지 상승
- [x] `./gradlew test` 실행 후 `build/reports/jacoco/index.html` 확인

## 스크린샷/로그 (선택)
- 해당 없음

## 롤백/리스크
- 리스크 포인트:
    - `completeTagging` 호출 흐름은 동일하며 트랜잭션 경계도 변경 없음.
    - 분리된 컴포넌트는 `@Component`로 등록되며 외부 호출 진입점은 기존과 동일합니다.
- 롤백 방법: 해당 PR revert (커밋 3개 단위로 분해되어 있어 부분 revert도 가능)

## 관련 이슈
Closes #168

## 커밋 구성
- `refactor: AI 태깅 star_tags 저장을 StarTagPersister로 분리`
- `refactor: AI 태깅 ScrumTitle 커밋 로직을 ScrumTitleCommitter로 분리`
- `refactor: AI 태깅 사용자 마일스톤 갱신을 UserMilestoneTracker로 분리`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * AI 태깅 기능의 처리 로직을 더욱 세분화된 컴포넌트로 재구성하여 코드 관리성을 개선했습니다.

* **New Features**
  * 사용자의 누적 태깅 횟수에 따라 자동으로 마일스톤 추적 및 피드백 알림을 제공하는 기능이 추가되었습니다.

* **Tests**
  * AI 태깅 검증 및 사용자 마일스톤 추적 기능에 대한 테스트 케이스가 추가되었습니다.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/2026-KUSITMS-GLIT/2026-KUSITMS-GLIT-BACK/pull/174?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->