### PR TITLE
chore: SocialAccount.email HMAC-SHA-256 해시 저장 및 마이그레이션 (#169)

### DIFF
--- a/src/main/java/com/groute/groute_server/auth/service/SocialEmailHashProperties.java
+++ b/src/main/java/com/groute/groute_server/auth/service/SocialEmailHashProperties.java
@@ -1,0 +1,20 @@
+package com.groute.groute_server.auth.service;
+
+import jakarta.validation.constraints.Size;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.validation.annotation.Validated;
+
+/**
+ * SocialAccount.email HMAC 해시 시 사용하는 pepper 설정.
+ *
+ * <p>환경별 값은 SSM Parameter Store의 {@code /groute/{env}/SOCIAL_EMAIL_HASH_PEPPER}에서 주입된다.
+ *
+ * <p>HMAC-SHA-256의 키 강도를 위해 {@code pepper}는 32바이트 이상이어야 하며, 미충족 시 부팅 단계에서 실패한다. 한 번 정해진 pepper는 같은
+ * 이메일을 항상 같은 해시값으로 매핑하므로 운영 중 변경하지 않는다.
+ */
+@Validated
+@ConfigurationProperties(prefix = "social.email-hash")
+public record SocialEmailHashProperties(
+        @Size(min = 32, message = "social.email-hash.pepper는 HMAC-SHA-256 키로 32바이트 이상이어야 한다")
+                String pepper) {}

--- a/src/main/java/com/groute/groute_server/auth/service/SocialEmailHasher.java
+++ b/src/main/java/com/groute/groute_server/auth/service/SocialEmailHasher.java
@@ -1,0 +1,44 @@
+package com.groute.groute_server.auth.service;
+
+import java.nio.charset.StandardCharsets;
+import java.util.HexFormat;
+
+import javax.crypto.Mac;
+import javax.crypto.spec.SecretKeySpec;
+
+import org.springframework.stereotype.Component;
+
+import lombok.RequiredArgsConstructor;
+
+/**
+ * SocialAccount.email을 HMAC-SHA-256으로 단방향 해시한다.
+ *
+ * <p>로그인 식별은 (provider, provider_uid)로 처리되므로 email은 양방향 복호화가 필요 없고, 평문 노출을 피하기 위해 저장 전 해시값으로 치환한다.
+ * 같은 pepper·같은 입력은 항상 같은 hex 문자열로 매핑되며, 마이그레이션 SQL과 동일한 알고리즘으로 처리된다.
+ */
+@Component
+@RequiredArgsConstructor
+public class SocialEmailHasher {
+
+    private static final String ALGORITHM = "HmacSHA256";
+    private static final HexFormat HEX = HexFormat.of();
+
+    private final SocialEmailHashProperties properties;
+
+    /** null·빈 문자열은 null로 반환해 컬럼 nullable 동작을 유지한다. */
+    public String hash(String email) {
+        if (email == null || email.isEmpty()) {
+            return null;
+        }
+        try {
+            Mac mac = Mac.getInstance(ALGORITHM);
+            mac.init(
+                    new SecretKeySpec(
+                            properties.pepper().getBytes(StandardCharsets.UTF_8), ALGORITHM));
+            byte[] digest = mac.doFinal(email.getBytes(StandardCharsets.UTF_8));
+            return HEX.formatHex(digest);
+        } catch (java.security.GeneralSecurityException e) {
+            throw new IllegalStateException("HMAC-SHA-256 hashing failed", e);
+        }
+    }
+}

--- a/src/main/java/com/groute/groute_server/auth/service/SocialLoginService.java
+++ b/src/main/java/com/groute/groute_server/auth/service/SocialLoginService.java
@@ -26,6 +26,7 @@ public class SocialLoginService {
 
     private final UserRepository userRepository;
     private final SocialAccountRepository socialAccountRepository;
+    private final SocialEmailHasher socialEmailHasher;
 
     @Transactional
     public User upsertUser(OAuthAttributes attributes) {
@@ -36,7 +37,7 @@ public class SocialLoginService {
     }
 
     private User updateReturning(SocialAccount existing, OAuthAttributes attributes) {
-        existing.updateEmail(attributes.email());
+        existing.updateEmail(socialEmailHasher.hash(attributes.email()));
         User user = existing.getUser();
         user.recordLogin();
         return user;
@@ -47,7 +48,10 @@ public class SocialLoginService {
         user.recordLogin();
         SocialAccount account =
                 SocialAccount.create(
-                        user, attributes.provider(), attributes.providerUid(), attributes.email());
+                        user,
+                        attributes.provider(),
+                        attributes.providerUid(),
+                        socialEmailHasher.hash(attributes.email()));
         socialAccountRepository.save(account);
         log.info("신규 소셜 유저 생성: userId={}, provider={}", user.getId(), attributes.provider());
         return user;

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -48,6 +48,8 @@ spring:
     baseline-version: 1
     baseline-on-migrate: true
     out-of-order: true
+    placeholders:
+      social_email_hash_pepper: ${SOCIAL_EMAIL_HASH_PEPPER}
 
   security:
     oauth2:
@@ -108,6 +110,13 @@ jwt:
   secret: ${JWT_SECRET}
   access-token-expiration: ${JWT_ACCESS_TOKEN_EXPIRATION:3600000}
   refresh-token-expiration: ${JWT_REFRESH_TOKEN_EXPIRATION:1209600000}
+
+social:
+  email-hash:
+    # stg/prod는 SSM에서 SOCIAL_EMAIL_HASH_PEPPER 주입 필수 — 누락 시 부팅 실패(fail-fast).
+    # 로컬은 하단 local 프로파일에서 개발용 pepper fallback 허용.
+    # 한 번 정한 값은 변경 금지 — 변경 시 기존 row의 해시값과 일치하지 않게 된다.
+    pepper: ${SOCIAL_EMAIL_HASH_PEPPER}
 
 auth:
   refresh-token:
@@ -194,8 +203,16 @@ spring:
       hibernate:
         format_sql: true
 
+  flyway:
+    placeholders:
+      social_email_hash_pepper: ${SOCIAL_EMAIL_HASH_PEPPER:local-dev-pepper-must-be-changed-in-production-env}
+
 jwt:
   secret: ${JWT_SECRET:local-dev-secret-key-must-be-changed-in-production-env}
+
+social:
+  email-hash:
+    pepper: ${SOCIAL_EMAIL_HASH_PEPPER:local-dev-pepper-must-be-changed-in-production-env}
 
 app:
   user:

--- a/src/main/resources/db/migration/V20260528152208__hash_social_account_emails.sql
+++ b/src/main/resources/db/migration/V20260528152208__hash_social_account_emails.sql
@@ -1,0 +1,10 @@
+-- social_accounts.email을 평문에서 HMAC-SHA-256(hex) 단방향 해시로 일괄 전환한다.
+-- pepper는 Flyway placeholder로 주입되며 yaml의 `social.email-hash.pepper`와 동일한 값이다.
+-- 이미 64자 hex 형식이면 이전에 해시된 row로 간주하고 건너뛴다(재실행 안전성).
+CREATE EXTENSION IF NOT EXISTS pgcrypto;
+
+UPDATE social_accounts
+SET email = encode(hmac(email, '${social_email_hash_pepper}', 'sha256'), 'hex')
+WHERE email IS NOT NULL
+  AND email <> ''
+  AND email !~ '^[0-9a-f]{64}$';

--- a/src/test/java/com/groute/groute_server/auth/service/SocialEmailHasherTest.java
+++ b/src/test/java/com/groute/groute_server/auth/service/SocialEmailHasherTest.java
@@ -1,0 +1,84 @@
+package com.groute.groute_server.auth.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+class SocialEmailHasherTest {
+
+    private static final String PEPPER = "test-pepper-must-be-at-least-32-bytes-for-hmac-sha256";
+
+    private final SocialEmailHasher hasher =
+            new SocialEmailHasher(new SocialEmailHashProperties(PEPPER));
+
+    @Nested
+    @DisplayName("HappyPath")
+    class HappyPath {
+
+        @Test
+        @DisplayName("성공 — 같은 입력은 항상 같은 64자 hex 해시로 매핑된다")
+        void returnsDeterministicHexDigest_forSameInput() {
+            // given
+            String email = "user@example.com";
+
+            // when
+            String first = hasher.hash(email);
+            String second = hasher.hash(email);
+
+            // then
+            assertThat(first).isEqualTo(second);
+            assertThat(first).hasSize(64).matches("^[0-9a-f]+$");
+        }
+
+        @Test
+        @DisplayName("성공 — 다른 입력은 다른 해시값으로 매핑된다")
+        void returnsDifferentDigest_forDifferentInput() {
+            // given
+            String a = "user@example.com";
+            String b = "other@example.com";
+
+            // when
+            String hashA = hasher.hash(a);
+            String hashB = hasher.hash(b);
+
+            // then
+            assertThat(hashA).isNotEqualTo(hashB);
+        }
+
+        @Test
+        @DisplayName("성공 — pepper가 다르면 같은 이메일도 다른 해시값으로 매핑된다")
+        void returnsDifferentDigest_whenPepperDiffers() {
+            // given
+            SocialEmailHasher other =
+                    new SocialEmailHasher(
+                            new SocialEmailHashProperties(
+                                    "another-pepper-also-must-be-at-least-32-bytes"));
+
+            // when
+            String hashA = hasher.hash("user@example.com");
+            String hashB = other.hash("user@example.com");
+
+            // then
+            assertThat(hashA).isNotEqualTo(hashB);
+        }
+    }
+
+    @Nested
+    @DisplayName("Edges")
+    class Edges {
+
+        @Test
+        @DisplayName("성공 — null 입력은 null 반환")
+        void returnsNull_whenInputIsNull() {
+            assertThat(hasher.hash(null)).isNull();
+        }
+
+        @Test
+        @DisplayName("성공 — 빈 문자열 입력은 null 반환")
+        void returnsNull_whenInputIsEmpty() {
+            assertThat(hasher.hash("")).isNull();
+        }
+    }
+}

--- a/src/test/java/com/groute/groute_server/auth/service/SocialLoginServiceTest.java
+++ b/src/test/java/com/groute/groute_server/auth/service/SocialLoginServiceTest.java
@@ -33,6 +33,7 @@ class SocialLoginServiceTest {
 
     @Mock UserRepository userRepository;
     @Mock SocialAccountRepository socialAccountRepository;
+    @Mock SocialEmailHasher socialEmailHasher;
 
     @InjectMocks SocialLoginService socialLoginService;
 
@@ -41,7 +42,7 @@ class SocialLoginServiceTest {
     class UpsertUser {
 
         @Test
-        @DisplayName("기존 소셜 계정이 없을 때 User를 먼저 저장하고 SocialAccount를 이어서 저장한 뒤 User를 반환한다")
+        @DisplayName("기존 소셜 계정이 없을 때 User를 먼저 저장하고 SocialAccount에는 해시된 email을 저장한 뒤 User를 반환한다")
         void should_createUserAndSocialAccount_when_socialAccountNotFound() {
             // given
             OAuthAttributes attributes =
@@ -59,6 +60,7 @@ class SocialLoginServiceTest {
                                 ReflectionTestUtils.setField(saved, "id", 42L);
                                 return saved;
                             });
+            given(socialEmailHasher.hash("new@kakao.com")).willReturn("HASHED-NEW");
 
             // when
             User result = socialLoginService.upsertUser(attributes);
@@ -75,19 +77,18 @@ class SocialLoginServiceTest {
             SocialAccount saved = captor.getValue();
             assertThat(saved.getProvider()).isEqualTo(SocialProvider.KAKAO);
             assertThat(saved.getProviderUid()).isEqualTo("9999");
-            assertThat(saved.getEmail()).isEqualTo("new@kakao.com");
+            assertThat(saved.getEmail()).isEqualTo("HASHED-NEW");
             assertThat(saved.getUser()).isSameAs(result);
         }
 
         @Test
-        @DisplayName("기존 소셜 계정이 있을 때 email을 갱신하고 recordLogin만 호출하며 새로 저장하지 않는다")
+        @DisplayName("기존 소셜 계정이 있을 때 email을 해시 값으로 갱신하고 recordLogin만 호출하며 새로 저장하지 않는다")
         void should_updateEmailAndRecordLoginOnly_when_socialAccountExists() {
             // given
             User existingUser = User.createForSocialLogin();
             ReflectionTestUtils.setField(existingUser, "id", 42L);
             SocialAccount existingAccount =
-                    SocialAccount.create(
-                            existingUser, SocialProvider.KAKAO, "9999", "old@kakao.com");
+                    SocialAccount.create(existingUser, SocialProvider.KAKAO, "9999", "HASHED-OLD");
             given(
                             socialAccountRepository.findByProviderAndProviderUid(
                                     SocialProvider.KAKAO, "9999"))
@@ -96,6 +97,7 @@ class SocialLoginServiceTest {
                     OAuthAttributes.from(
                             "kakao",
                             Map.of("id", 9999L, "kakao_account", Map.of("email", "new@kakao.com")));
+            given(socialEmailHasher.hash("new@kakao.com")).willReturn("HASHED-NEW");
 
             // when
             User result = socialLoginService.upsertUser(attributes);
@@ -103,7 +105,7 @@ class SocialLoginServiceTest {
             // then
             assertThat(result).isSameAs(existingUser);
             assertThat(result.getLastLoginAt()).isNotNull();
-            assertThat(existingAccount.getEmail()).isEqualTo("new@kakao.com");
+            assertThat(existingAccount.getEmail()).isEqualTo("HASHED-NEW");
             verify(userRepository, never()).save(any(User.class));
             verify(socialAccountRepository, never()).save(any(SocialAccount.class));
         }

--- a/src/test/resources/application.yaml
+++ b/src/test/resources/application.yaml
@@ -94,6 +94,10 @@ jwt:
   access-token-expiration: 3600000
   refresh-token-expiration: 1209600000
 
+social:
+  email-hash:
+    pepper: test-pepper-must-be-at-least-32-bytes-for-hmac-sha256
+
 auth:
   refresh-token:
     cookie-enabled: false


### PR DESCRIPTION
## 요약
- `SocialAccount.email`을 평문 저장에서 HMAC-SHA-256(hex) 단방향 해시 저장으로 전환했습니다.
- `SocialEmailHasher`를 신설해 신규 가입/재로그인 시 hash로 치환 후 영속화합니다.
- 기존 row는 Flyway 마이그레이션으로 동일 알고리즘 일괄 변환합니다(재실행 시 64자 hex 행은 자동 skip).
- pepper는 `SOCIAL_EMAIL_HASH_PEPPER` 환경변수로 주입하며, `SocialEmailHashProperties`에 `@Validated + @Size(min=32)`로 fail-fast.

## 변경 사항
- [ ] 기능
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 문서
- [ ] 테스트
- [x] 기타 (보안 설정 강화)

## 테스트
- [x] 로컬 테스트 완료
- 테스트 방법:
    - `./gradlew spotlessApply check` 통과
    - `SocialEmailHasherTest` 신규 (deterministic / pepper 격리 / null·빈 입력)
    - `SocialLoginServiceTest`는 hasher mock으로 갱신해 해시값 저장 동작 검증

### 커버리지 (JaCoCo)
- 라인 커버리지: 신규 컴포넌트에 단위 테스트 동반
- [x] `./gradlew test` 실행 후 `build/reports/jacoco/index.html` 확인

## 스크린샷/로그 (선택)
- 해당 없음

## 롤백/리스크
- 리스크 포인트:
    - stg/prod 배포 시 SSM에 `SOCIAL_EMAIL_HASH_PEPPER`(32바이트 이상)가 주입되어 있어야 부팅 가능.
    - pepper는 변경 금지. 변경 시 기존 row 해시값과 일치하지 않게 되어 매칭 불가.
    - Flyway 마이그레이션은 `pgcrypto` 확장을 사용. prod에서 일반적으로 활성화되어 있으나 `CREATE EXTENSION IF NOT EXISTS pgcrypto`로 안전하게 보강함.
- 롤백 방법: 해당 PR revert 가능. 단 이미 해시된 row는 평문으로 되돌릴 수 없으므로 평문 복구가 필요하다면 백업에서 복원 필요.

## 관련 이슈
Closes #169

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 소셜 계정 이메일이 암호화되어 저장되도록 변경되어 사용자 데이터 보안이 강화되었습니다.
  * 기존 소셜 계정 이메일이 자동으로 마이그레이션되었습니다.

* **테스트**
  * 이메일 해싱 기능의 정확성과 보안성을 검증하는 테스트 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->