### PR TITLE
refactor: ReportService AI 호출 try/catch 헬퍼 추출 및 readOnly 트랜잭션 일원화 (#170)

### DIFF
--- a/src/main/java/com/groute/groute_server/record/application/service/ScrumBulkWriteService.java
+++ b/src/main/java/com/groute/groute_server/record/application/service/ScrumBulkWriteService.java
@@ -19,6 +19,7 @@ import com.groute.groute_server.record.application.port.out.scrum.ScrumWritePort
 import com.groute.groute_server.record.application.port.out.scrumtitle.ScrumTitleRepositoryPort;
 import com.groute.groute_server.record.application.port.out.star.StarRecordRepositoryPort;
 import com.groute.groute_server.record.application.port.out.user.UserReferencePort;
+import com.groute.groute_server.record.application.port.out.user.UserStreakPort;
 import com.groute.groute_server.record.domain.Project;
 import com.groute.groute_server.record.domain.Scrum;
 import com.groute.groute_server.record.domain.ScrumTitle;
@@ -46,6 +47,7 @@ public class ScrumBulkWriteService implements BulkWriteScrumUseCase {
     private final StarRecordRepositoryPort starRecordRepositoryPort;
     private final StarImageCascadeCleaner starImageCascadeCleaner;
     private final UserReferencePort userReferencePort;
+    private final UserStreakPort userStreakPort;
 
     @Override
     public BulkWriteScrumResult bulkWrite(BulkWriteScrumCommand command) {
@@ -108,7 +110,10 @@ public class ScrumBulkWriteService implements BulkWriteScrumUseCase {
         }
         List<Scrum> savedScrums = scrumWritePort.saveAll(scrums);
 
-        // 6. Project.titleCount 증감 (동일 projectId 중복 시 count만큼)
+        // 6. user streak 갱신 (REC-001) — 같은 날 재작성은 entity 단에서 멱등 처리
+        userStreakPort.recordOnDate(command.userId(), command.date());
+
+        // 7. Project.titleCount 증감 (동일 projectId 중복 시 count만큼)
         groups.stream()
                 .collect(
                         Collectors.groupingBy(
@@ -118,7 +123,7 @@ public class ScrumBulkWriteService implements BulkWriteScrumUseCase {
                         (projectId, count) ->
                                 projectPort.applyTitleCountIncrement(projectId, count.intValue()));
 
-        // 7. 결과 조립 (저장 순서 보장)
+        // 8. 결과 조립 (저장 순서 보장)
         List<BulkWriteScrumResult.GroupResult> results = new ArrayList<>();
         int scrumIdx = 0;
         for (int i = 0; i < savedTitles.size(); i++) {

--- a/src/main/java/com/groute/groute_server/report/application/service/ReportService.java
+++ b/src/main/java/com/groute/groute_server/report/application/service/ReportService.java
@@ -5,6 +5,7 @@ import java.util.List;
 import java.util.Objects;
 
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.groute.groute_server.common.exception.BusinessException;
@@ -41,6 +42,7 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 @Service
 @RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class ReportService
         implements GetSelectableInfoUseCase,
                 CreateReportUseCase,
@@ -66,7 +68,6 @@ public class ReportService
      * <p>미니 발행 이력이 없으면 MINI, 있으면 CAREER 타입으로 결정한다.
      */
     @Override
-    @Transactional(readOnly = true)
     public SelectableInfoView getSelectableInfo(Long userId) {
         boolean hasMini = loadReportPort.existsMiniReportByUserId(userId);
         ReportType reportType = hasMini ? ReportType.CAREER : ReportType.MINI;
@@ -103,9 +104,11 @@ public class ReportService
     /**
      * 유저가 선택한 심화기록을 검증하고 리포트 row를 생성한 뒤 AI 서버에 생성을 요청한다.
      *
-     * <p>DB 저장은 {@link ReportTransactionalService#saveReportTx}에 위임하여 트랜잭션 커밋 후 AI 호출이 실행된다.
+     * <p>DB 저장은 {@link ReportTransactionalService#saveReportTx}에 위임하여 트랜잭션 커밋 후 AI 호출이 실행된다. 본 메서드는
+     * {@link Propagation#NEVER}로 외부 트랜잭션 안에서 호출되는 것을 명시적으로 금지해 AI I/O가 DB 커넥션을 점유하지 않게 한다.
      */
     @Override
+    @Transactional(propagation = Propagation.NEVER)
     public Long createReport(CreateReportCommand command) {
         // 1~7. 검증 + DB 저장 (트랜잭션 커밋까지 완료)
         ReportTransactionalService.CreateReportResult result =
@@ -116,20 +119,7 @@ public class ReportService
                 loadReportPort
                         .findById(result.reportId())
                         .orElseThrow(() -> new BusinessException(ErrorCode.REPORT_NOT_FOUND));
-        try {
-            AiReportResult aiResult =
-                    requestAiReportPort.requestReportGeneration(
-                            result.reportId(), result.starRecords(), result.scrums());
-            report.complete(aiResult.title(), aiResult.contentJson());
-        } catch (Exception e) {
-            log.error(
-                    "[AI Report] 생성 실패 — reportId={}, error={}",
-                    result.reportId(),
-                    e.getMessage(),
-                    e);
-            report.fail();
-        }
-        saveReportPort.save(report);
+        invokeAiAndPersist(report, result.reportId(), result.starRecords(), result.scrums(), "생성");
 
         return result.reportId();
     }
@@ -144,7 +134,6 @@ public class ReportService
      * <p>FAILED 상태이고 재시도가 가능한 경우 retryAvailable=true를 함께 반환한다.
      */
     @Override
-    @Transactional(readOnly = true)
     public ReportStatusView getReportStatus(Long userId, Long reportId) {
         Report report =
                 loadReportPort
@@ -165,9 +154,11 @@ public class ReportService
     /**
      * FAILED 상태인 리포트를 GENERATING으로 되돌리고 AI 서버에 재호출한다.
      *
-     * <p>DB 상태 변경은 {@link ReportTransactionalService#retryReportTx}에 위임하여 트랜잭션 커밋 후 AI 호출이 실행된다.
+     * <p>DB 상태 변경은 {@link ReportTransactionalService#retryReportTx}에 위임하여 트랜잭션 커밋 후 AI 호출이 실행된다. 본
+     * 메서드는 {@link Propagation#NEVER}로 외부 트랜잭션 안에서 호출되는 것을 명시적으로 금지해 AI I/O가 DB 커넥션을 점유하지 않게 한다.
      */
     @Override
+    @Transactional(propagation = Propagation.NEVER)
     public Long retryReport(Long userId, Long reportId) {
         // DB 상태 변경 (트랜잭션 커밋까지 완료)
         reportTransactionalService.retryReportTx(userId, reportId);
@@ -195,15 +186,7 @@ public class ReportService
             return reportId;
         }
 
-        try {
-            AiReportResult aiResult =
-                    requestAiReportPort.requestReportGeneration(reportId, starRecords, scrums);
-            report.complete(aiResult.title(), aiResult.contentJson());
-        } catch (Exception e) {
-            log.error("[AI Report] 재시도 실패 — reportId={}, error={}", reportId, e.getMessage(), e);
-            report.fail();
-        }
-        saveReportPort.save(report);
+        invokeAiAndPersist(report, reportId, starRecords, scrums, "재시도");
 
         return reportId;
     }
@@ -216,5 +199,32 @@ public class ReportService
         if (!Objects.equals(report.getUser().getId(), userId)) {
             throw new BusinessException(ErrorCode.FORBIDDEN);
         }
+    }
+
+    /**
+     * AI 호출 결과에 따라 Report 상태를 갱신하고 영속화한다. 트랜잭션 밖에서 호출되며, 예외 시 FAILED로 전환해 재시도 경로로 보낸다.
+     *
+     * @param stageLabel 로그 식별용 단계 표기(예: "생성", "재시도")
+     */
+    private void invokeAiAndPersist(
+            Report report,
+            Long reportId,
+            List<StarRecord> starRecords,
+            List<Scrum> scrums,
+            String stageLabel) {
+        try {
+            AiReportResult aiResult =
+                    requestAiReportPort.requestReportGeneration(reportId, starRecords, scrums);
+            report.complete(aiResult.title(), aiResult.contentJson());
+        } catch (Exception e) {
+            log.error(
+                    "[AI Report] {} 실패 — reportId={}, error={}",
+                    stageLabel,
+                    reportId,
+                    e.getMessage(),
+                    e);
+            report.fail();
+        }
+        saveReportPort.save(report);
     }
 }

--- a/src/test/java/com/groute/groute_server/record/application/service/ScrumBulkWriteServiceTest.java
+++ b/src/test/java/com/groute/groute_server/record/application/service/ScrumBulkWriteServiceTest.java
@@ -2,6 +2,7 @@ package com.groute.groute_server.record.application.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyCollection;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.anyLong;
@@ -33,6 +34,7 @@ import com.groute.groute_server.record.application.port.out.scrum.ScrumWritePort
 import com.groute.groute_server.record.application.port.out.scrumtitle.ScrumTitleRepositoryPort;
 import com.groute.groute_server.record.application.port.out.star.StarRecordRepositoryPort;
 import com.groute.groute_server.record.application.port.out.user.UserReferencePort;
+import com.groute.groute_server.record.application.port.out.user.UserStreakPort;
 import com.groute.groute_server.record.domain.Project;
 import com.groute.groute_server.record.domain.Scrum;
 import com.groute.groute_server.record.domain.ScrumTitle;
@@ -52,6 +54,7 @@ class ScrumBulkWriteServiceTest {
     @Mock StarRecordRepositoryPort starRecordRepositoryPort;
     @Mock StarImageCascadeCleaner starImageCascadeCleaner;
     @Mock UserReferencePort userReferencePort;
+    @Mock UserStreakPort userStreakPort;
 
     @InjectMocks ScrumBulkWriteService service;
 
@@ -235,6 +238,51 @@ class ScrumBulkWriteServiceTest {
             assertThat(result.groups().get(0).scrums().get(1).content()).isEqualTo("B");
             assertThat(result.groups().get(1).scrums()).hasSize(1);
             assertThat(result.groups().get(1).scrums().get(0).content()).isEqualTo("C");
+        }
+    }
+
+    @Nested
+    @DisplayName("streak 갱신")
+    class Streak {
+
+        @Test
+        @DisplayName("저장 성공 시 user streak를 userId·date로 갱신한다")
+        void should_recordStreak_when_writeSucceeds() {
+            given(projectPort.findByIdAndUserId(100L, USER_ID))
+                    .willReturn(Optional.of(project(100L, "프로젝트A")));
+            given(userReferencePort.getReferenceById(USER_ID))
+                    .willReturn(User.createForSocialLogin());
+            stubSaveTitles();
+            stubSaveScrums();
+
+            service.bulkWrite(command(group(100L, "제목", "스크럼1")));
+
+            verify(userStreakPort).recordOnDate(USER_ID, DATE);
+        }
+
+        @Test
+        @DisplayName("COMMITTED 충돌로 실패하면 streak를 갱신하지 않는다")
+        void should_notRecordStreak_when_committedConflict() {
+            given(scrumQueryPort.findAllByUserAndDate(USER_ID, DATE))
+                    .willReturn(
+                            List.of(scrumWithTitle(50L, 10L, ScrumTitleStatus.COMMITTED, 100L)));
+
+            assertThatThrownBy(() -> service.bulkWrite(command(group(100L, "제목", "스크럼1"))))
+                    .isInstanceOf(BusinessException.class);
+
+            verify(userStreakPort, never()).recordOnDate(anyLong(), any(LocalDate.class));
+        }
+
+        @Test
+        @DisplayName("스크럼 개수 초과로 실패하면 streak를 갱신하지 않는다")
+        void should_notRecordStreak_when_dateLimitExceeded() {
+            BulkWriteScrumCommand command =
+                    command(group(100L, "제목", "a", "b", "c", "d", "e", "f"));
+
+            assertThatThrownBy(() -> service.bulkWrite(command))
+                    .isInstanceOf(BusinessException.class);
+
+            verify(userStreakPort, never()).recordOnDate(anyLong(), any(LocalDate.class));
         }
     }
 


### PR DESCRIPTION
## 요약
- `ReportService`를 클래스 단위 `@Transactional(readOnly = true)`로 묶고, 조회 메서드의 메서드 단위 어노테이션을 제거했습니다.
- 쓰기 메서드(`createReport`, `retryReport`)는 `@Transactional(propagation = Propagation.NEVER)`로 명시해 AI I/O가 트랜잭션 안으로 들어가지 않도록 강제했습니다. DB 변경은 기존대로 `ReportTransactionalService`에서 분리된 트랜잭션으로 처리됩니다.
- 두 곳에 중복돼 있던 `try/catch + save` 블록을 `invokeAiAndPersist` 헬퍼로 추출했습니다.

## 변경 사항
- [ ] 기능
- [ ] 버그 수정
- [x] 리팩토링
- [ ] 문서
- [ ] 테스트
- [ ] 기타

## 테스트
- [x] 로컬 테스트 완료
- 테스트 방법:
    - `./gradlew spotlessApply check` 통과
    - 기존 `ReportServiceTest` 케이스 전부 통과 (트랜잭션 어노테이션 변경은 단위 테스트에서 무관)

### 커버리지 (JaCoCo)
- 라인 커버리지: 헬퍼 추출로 분기 수 동일, 변동 없음
- [x] `./gradlew test` 실행 후 `build/reports/jacoco/index.html` 확인

## 스크린샷/로그 (선택)
- 해당 없음

## 롤백/리스크
- 리스크 포인트:
    - `createReport`, `retryReport`는 외부에서 트랜잭션 안에 호출되면 `IllegalTransactionStateException`을 발생시킵니다. 현재 호출 경로는 Controller에서만 진입하므로 영향이 없으며, 향후 다른 서비스가 호출할 경우 트랜잭션 밖에서 호출해야 합니다.
- 롤백 방법: 해당 PR revert

## 관련 이슈
Closes #170