### PR TITLE
refactor: NotificationScheduler FCM 호출 트랜잭션 밖으로 분리 (#172)

### DIFF
--- a/src/main/java/com/groute/groute_server/notification/scheduler/NotificationDispatchWriter.java
+++ b/src/main/java/com/groute/groute_server/notification/scheduler/NotificationDispatchWriter.java
@@ -1,0 +1,46 @@
+package com.groute.groute_server.notification.scheduler;
+
+import java.util.Collection;
+import java.util.Set;
+
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.groute.groute_server.auth.repository.DeviceTokenRepository;
+import com.groute.groute_server.user.entity.User;
+import com.groute.groute_server.user.repository.UserRepository;
+
+import lombok.RequiredArgsConstructor;
+
+/**
+ * 알림 발송 사이클의 DB 변경분을 단일 트랜잭션으로 반영한다.
+ *
+ * <p>스케줄러 본체는 FCM 호출과 분리되어 트랜잭션 없이 동작하고, 본 컴포넌트가 invalid 토큰 비활성화와 user 카피 인덱스 advance를 한 번의 트랜잭션으로
+ * 처리한다.
+ */
+@Component
+@RequiredArgsConstructor
+public class NotificationDispatchWriter {
+
+    private final UserRepository userRepository;
+    private final DeviceTokenRepository deviceTokenRepository;
+
+    /**
+     * @param processedUserIds 카피 인덱스를 advance할 user id 집합
+     * @param copyPoolSize 카피 풀 크기 (mod 정규화에 사용)
+     * @param invalidTokens FCM 응답이 token-invalid로 돌아온 push token 목록
+     */
+    @Transactional
+    public void apply(
+            Set<Long> processedUserIds, int copyPoolSize, Collection<String> invalidTokens) {
+        for (String token : invalidTokens) {
+            deviceTokenRepository.deactivateByPushToken(token);
+        }
+        if (processedUserIds.isEmpty() || copyPoolSize <= 0) {
+            return;
+        }
+        for (User user : userRepository.findAllById(processedUserIds)) {
+            user.advanceCopyIndex(copyPoolSize);
+        }
+    }
+}

--- a/src/main/java/com/groute/groute_server/notification/scheduler/NotificationScheduler.java
+++ b/src/main/java/com/groute/groute_server/notification/scheduler/NotificationScheduler.java
@@ -6,6 +6,7 @@ import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.time.ZoneId;
 import java.time.temporal.ChronoUnit;
+import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -14,7 +15,6 @@ import java.util.stream.Collectors;
 
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
-import org.springframework.transaction.annotation.Transactional;
 
 import com.groute.groute_server.auth.entity.DeviceToken;
 import com.groute.groute_server.auth.repository.DeviceTokenRepository;
@@ -38,8 +38,8 @@ import lombok.extern.slf4j.Slf4j;
  *
  * <p>매시 0/30분(KST) 트리거. 매칭 활성 슬롯 → 작성자 제외 → user별 카피 라운드로빈 발송 → invalid 토큰 비활성화.
  *
- * <p>FCM 호출이 트랜잭션 안에서 일어나 DB 커넥션이 잠시 점유된다. MVP 볼륨(수백 건 이하)에서는 허용 가능하며, 트래픽이 커지면 send와 deactivate를
- * 분리해 트랜잭션을 좁히는 리팩토링이 필요하다.
+ * <p>FCM 호출은 트랜잭션 밖에서 수행하고, invalid 토큰 비활성화·카피 인덱스 advance는 {@link NotificationDispatchWriter}가 단일
+ * 트랜잭션으로 일괄 반영한다.
  *
  * <p>단일 인스턴스 가정. 다중 인스턴스 배포 시 동일 시각에 모든 인스턴스가 동시에 발사돼 N배 발송이 발생하므로 ShedLock 등 분산 락이 필요하다(별도 이슈).
  */
@@ -58,16 +58,17 @@ public class NotificationScheduler {
     private final NotificationCopy notificationCopy;
     private final NotificationCopyProperties notificationCopyProperties;
     private final ScrumDailyQueryService scrumDailyQueryService;
+    private final NotificationDispatchWriter dispatchWriter;
     private final Clock clock;
 
     /**
      * 30분 단위 발송 사이클. KST 매시 0분/30분에 트리거된다.
      *
      * <p>흐름: 1) 현재 (요일, 시각, 날짜) 추출 2) 매칭 활성 슬롯 → user 모음 3) 카피 풀 비어 있으면 스킵 4) 당일 작성자 제외 5) 남은 user
-     * 엔티티/토큰 일괄 조회 6) user별 카피 1개 선택 + {닉네임} 치환 + 토큰별 발송 7) 발송 후 카피 인덱스 advance 8) 사이클 결과 INFO 로그.
+     * 엔티티/토큰 일괄 조회 6) user별 카피 1개 선택 + {닉네임} 치환 + 토큰별 FCM 발송(트랜잭션 밖) 7) 비활성화·인덱스 advance를 {@link
+     * NotificationDispatchWriter}로 위임 8) 사이클 결과 INFO 로그.
      */
     @Scheduled(cron = "0 0,30 * * * *", zone = "Asia/Seoul")
-    @Transactional
     public void dispatch() {
         // 1. KST 현재 (요일, 시각, 날짜) 추출 — DB의 notify_time은 분 단위라 초·나노 truncate
         LocalDateTime now = LocalDateTime.now(clock.withZone(KST));
@@ -111,11 +112,11 @@ public class NotificationScheduler {
                 deviceTokenRepository.findAllByUser_IdInAndIsActiveTrue(candidateUserIds).stream()
                         .collect(Collectors.groupingBy(t -> t.getUser().getId()));
 
-        // 6. user별 발송 + 인덱스 advance
+        // 6. user별 FCM 발송 — 트랜잭션 밖에서 실행
         String link = notificationCopyProperties.deepLinkUrl();
+        Set<Long> processedUserIds = new HashSet<>();
+        List<String> invalidTokens = new ArrayList<>();
         int sent = 0;
-        int deactivated = 0;
-        int processed = 0;
         for (Long userId : candidateUserIds) {
             User user = usersById.get(userId);
             List<DeviceToken> userTokens = tokensByUserId.get(userId);
@@ -123,7 +124,6 @@ public class NotificationScheduler {
                 continue;
             }
 
-            // 카피 선택 + 닉네임 치환 (mod로 인덱스 정규화 — 풀 크기 축소 케이스 대비)
             int idx = Math.floorMod(user.getNotificationCopyIndex(), copies.size());
             NotificationCopy.Item template = copies.get(idx);
             FcmPayload payload =
@@ -132,21 +132,20 @@ public class NotificationScheduler {
                             replaceNickname(template.body(), user.getNickname()),
                             link);
 
-            // 토큰별 발송 + invalid 토큰 비활성화
             for (DeviceToken token : userTokens) {
                 SendResult result = fcmPushClient.send(token.getPushToken(), payload);
                 if (result.success()) {
                     sent++;
                 } else if (result.tokenInvalid()) {
-                    deviceTokenRepository.deactivateByPushToken(token.getPushToken());
-                    deactivated++;
+                    invalidTokens.add(token.getPushToken());
                 }
             }
 
-            // 7. 발송 후 카피 인덱스 advance (트랜잭션 dirty checking으로 UPDATE 발행)
-            user.advanceCopyIndex(copies.size());
-            processed++;
+            processedUserIds.add(userId);
         }
+
+        // 7. 비활성화·인덱스 advance 트랜잭션 위임
+        dispatchWriter.apply(processedUserIds, copies.size(), invalidTokens);
 
         // 8. 사이클 결과 로그
         log.info(
@@ -155,9 +154,9 @@ public class NotificationScheduler {
                 time,
                 slots.size(),
                 writers.size(),
-                processed,
+                processedUserIds.size(),
                 sent,
-                deactivated);
+                invalidTokens.size());
     }
 
     /**

--- a/src/main/java/com/groute/groute_server/record/application/service/ScrumBulkWriteService.java
+++ b/src/main/java/com/groute/groute_server/record/application/service/ScrumBulkWriteService.java
@@ -19,6 +19,7 @@ import com.groute.groute_server.record.application.port.out.scrum.ScrumWritePort
 import com.groute.groute_server.record.application.port.out.scrumtitle.ScrumTitleRepositoryPort;
 import com.groute.groute_server.record.application.port.out.star.StarRecordRepositoryPort;
 import com.groute.groute_server.record.application.port.out.user.UserReferencePort;
+import com.groute.groute_server.record.application.port.out.user.UserStreakPort;
 import com.groute.groute_server.record.domain.Project;
 import com.groute.groute_server.record.domain.Scrum;
 import com.groute.groute_server.record.domain.ScrumTitle;
@@ -46,6 +47,7 @@ public class ScrumBulkWriteService implements BulkWriteScrumUseCase {
     private final StarRecordRepositoryPort starRecordRepositoryPort;
     private final StarImageCascadeCleaner starImageCascadeCleaner;
     private final UserReferencePort userReferencePort;
+    private final UserStreakPort userStreakPort;
 
     @Override
     public BulkWriteScrumResult bulkWrite(BulkWriteScrumCommand command) {
@@ -108,7 +110,10 @@ public class ScrumBulkWriteService implements BulkWriteScrumUseCase {
         }
         List<Scrum> savedScrums = scrumWritePort.saveAll(scrums);
 
-        // 6. Project.titleCount 증감 (동일 projectId 중복 시 count만큼)
+        // 6. user streak 갱신 (REC-001) — 같은 날 재작성은 entity 단에서 멱등 처리
+        userStreakPort.recordOnDate(command.userId(), command.date());
+
+        // 7. Project.titleCount 증감 (동일 projectId 중복 시 count만큼)
         groups.stream()
                 .collect(
                         Collectors.groupingBy(
@@ -118,7 +123,7 @@ public class ScrumBulkWriteService implements BulkWriteScrumUseCase {
                         (projectId, count) ->
                                 projectPort.applyTitleCountIncrement(projectId, count.intValue()));
 
-        // 7. 결과 조립 (저장 순서 보장)
+        // 8. 결과 조립 (저장 순서 보장)
         List<BulkWriteScrumResult.GroupResult> results = new ArrayList<>();
         int scrumIdx = 0;
         for (int i = 0; i < savedTitles.size(); i++) {

--- a/src/test/java/com/groute/groute_server/notification/scheduler/NotificationDispatchWriterTest.java
+++ b/src/test/java/com/groute/groute_server/notification/scheduler/NotificationDispatchWriterTest.java
@@ -1,0 +1,106 @@
+package com.groute.groute_server.notification.scheduler;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+import java.lang.reflect.Constructor;
+import java.util.List;
+import java.util.Set;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import com.groute.groute_server.auth.repository.DeviceTokenRepository;
+import com.groute.groute_server.user.entity.User;
+import com.groute.groute_server.user.repository.UserRepository;
+
+@ExtendWith(MockitoExtension.class)
+class NotificationDispatchWriterTest {
+
+    @Mock UserRepository userRepository;
+    @Mock DeviceTokenRepository deviceTokenRepository;
+
+    @InjectMocks NotificationDispatchWriter writer;
+
+    private static User user(Long id, short copyIndex) {
+        try {
+            Constructor<User> ctor = User.class.getDeclaredConstructor();
+            ctor.setAccessible(true);
+            User user = ctor.newInstance();
+            ReflectionTestUtils.setField(user, "id", id);
+            ReflectionTestUtils.setField(user, "notificationCopyIndex", copyIndex);
+            return user;
+        } catch (ReflectiveOperationException e) {
+            throw new IllegalStateException(e);
+        }
+    }
+
+    @Nested
+    @DisplayName("HappyPath")
+    class HappyPath {
+
+        @Test
+        @DisplayName("성공 — 처리된 user는 copyPoolSize로 advance하고 invalid 토큰은 비활성화한다")
+        void advancesUserIndexAndDeactivatesTokens() {
+            // given
+            User u1 = user(1L, (short) 0);
+            User u2 = user(2L, (short) 2);
+            given(userRepository.findAllById(Set.of(1L, 2L))).willReturn(List.of(u1, u2));
+
+            // when
+            writer.apply(Set.of(1L, 2L), 3, List.of("bad-1", "bad-2"));
+
+            // then
+            verify(deviceTokenRepository).deactivateByPushToken("bad-1");
+            verify(deviceTokenRepository).deactivateByPushToken("bad-2");
+            assertThat(u1.getNotificationCopyIndex()).isEqualTo((short) 1);
+            assertThat(u2.getNotificationCopyIndex()).isEqualTo((short) 0); // 2+1 = 3 mod 3 = 0
+        }
+
+        @Test
+        @DisplayName("성공 — invalid 토큰만 있고 처리된 user가 없으면 비활성화만 수행한다")
+        void onlyDeactivates_whenNoProcessedUsers() {
+            // when
+            writer.apply(Set.of(), 3, List.of("bad-1"));
+
+            // then
+            verify(deviceTokenRepository).deactivateByPushToken("bad-1");
+            verify(userRepository, never()).findAllById(any());
+        }
+    }
+
+    @Nested
+    @DisplayName("Skips")
+    class Skips {
+
+        @Test
+        @DisplayName("스킵 — copyPoolSize가 0이면 advance를 수행하지 않는다")
+        void skipsAdvance_whenCopyPoolSizeIsZero() {
+            // when
+            writer.apply(Set.of(1L), 0, List.of());
+
+            // then
+            verify(userRepository, never()).findAllById(any());
+        }
+
+        @Test
+        @DisplayName("스킵 — invalid 토큰이 없고 처리된 user도 없으면 아무 일도 안 한다")
+        void noop_whenAllInputsEmpty() {
+            // when
+            writer.apply(Set.of(), 3, List.of());
+
+            // then
+            verify(userRepository, never()).findAllById(any());
+            verify(deviceTokenRepository, never()).deactivateByPushToken(any());
+        }
+    }
+}

--- a/src/test/java/com/groute/groute_server/notification/scheduler/NotificationSchedulerTest.java
+++ b/src/test/java/com/groute/groute_server/notification/scheduler/NotificationSchedulerTest.java
@@ -15,6 +15,7 @@ import java.time.LocalTime;
 import java.time.ZoneId;
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -63,6 +64,7 @@ class NotificationSchedulerTest {
     @Mock UserRepository userRepository;
     @Mock FcmPushClient fcmPushClient;
     @Mock ScrumDailyQueryService scrumDailyQueryService;
+    @Mock NotificationDispatchWriter dispatchWriter;
 
     NotificationScheduler scheduler;
     NotificationCopy notificationCopy;
@@ -90,6 +92,7 @@ class NotificationSchedulerTest {
                         notificationCopy,
                         properties,
                         scrumDailyQueryService,
+                        dispatchWriter,
                         FIXED_CLOCK);
     }
 
@@ -98,8 +101,8 @@ class NotificationSchedulerTest {
     class HappyPath {
 
         @Test
-        @DisplayName("KST 09:00 화요일 매칭 시 카피를 닉네임 치환·딥링크와 함께 발송하고 카피 인덱스를 advance한다")
-        void should_sendWithNicknameAndLinkAndAdvanceIndex_when_matchedSlot() {
+        @DisplayName("KST 09:00 화요일 매칭 시 카피를 닉네임 치환·딥링크와 함께 발송하고 dispatchWriter에 user id를 전달한다")
+        void should_sendWithNicknameAndLinkAndDelegateToWriter_when_matchedSlot() {
             // given
             User user = user(1L, "겨레", (short) 0);
             given(
@@ -126,12 +129,12 @@ class NotificationSchedulerTest {
             assertThat(payload.title()).isEqualTo("A 겨레");
             assertThat(payload.body()).isEqualTo("본문 A");
             assertThat(payload.link()).isEqualTo(DEEP_LINK);
-            assertThat(user.getNotificationCopyIndex()).isEqualTo((short) 1);
+            verify(dispatchWriter).apply(Set.of(1L), 3, List.of());
         }
 
         @Test
-        @DisplayName("user별 카피 인덱스에 따라 라운드로빈으로 카피를 선택하고 mod로 advance한다 (0→1, 1→2, 2→0)")
-        void should_pickCopyByIndexAndAdvanceWithMod_when_multipleUsers() {
+        @DisplayName("user별 카피 인덱스에 따라 라운드로빈으로 카피를 선택하고 모든 user id가 dispatchWriter에 전달된다")
+        void should_pickCopyByIndexAndDelegateAllUserIds_when_multipleUsers() {
             // given — copy_index 0/1/2인 3 users
             User u1 = user(1L, "유저1", (short) 0);
             User u2 = user(2L, "유저2", (short) 1);
@@ -160,15 +163,12 @@ class NotificationSchedulerTest {
             assertThat(sent.get("t1").title()).isEqualTo("A 유저1"); // idx=0 → 카피 A
             assertThat(sent.get("t2").title()).isEqualTo("B 유저2"); // idx=1 → 카피 B
             assertThat(sent.get("t3").title()).isEqualTo("C 유저3"); // idx=2 → 카피 C
-            // mod 동작: 0+1=1, 1+1=2, 2+1=3 mod 3 = 0
-            assertThat(u1.getNotificationCopyIndex()).isEqualTo((short) 1);
-            assertThat(u2.getNotificationCopyIndex()).isEqualTo((short) 2);
-            assertThat(u3.getNotificationCopyIndex()).isEqualTo((short) 0);
+            verify(dispatchWriter).apply(Set.of(1L, 2L, 3L), 3, List.of());
         }
 
         @Test
-        @DisplayName("한 user에 토큰 N개면 모두 발송하지만 카피 인덱스는 1번만 advance한다")
-        void should_sendToAllTokensButAdvanceIndexOnce_when_userHasMultipleTokens() {
+        @DisplayName("한 user에 토큰 N개면 모두 발송하지만 dispatchWriter에는 user id가 한 번만 전달된다")
+        void should_sendToAllTokensButDelegateUserIdOnce_when_userHasMultipleTokens() {
             // given
             User user = user(1L, "겨레", (short) 0);
             given(
@@ -188,7 +188,7 @@ class NotificationSchedulerTest {
             verify(fcmPushClient).send(eq("t1"), any());
             verify(fcmPushClient).send(eq("t2"), any());
             verify(fcmPushClient).send(eq("t3"), any());
-            assertThat(user.getNotificationCopyIndex()).isEqualTo((short) 1);
+            verify(dispatchWriter).apply(Set.of(1L), 3, List.of());
         }
     }
 
@@ -197,16 +197,15 @@ class NotificationSchedulerTest {
     class Filtering {
 
         @Test
-        @DisplayName("당일 작성자(user 2)는 발송에서 제외되고 카피 인덱스도 변하지 않는다")
+        @DisplayName("당일 작성자(user 2)는 발송에서 제외되고 dispatchWriter에도 전달되지 않는다")
         void should_skipWriters_when_someUsersAlreadyWrote() {
             // given — 후보 {1,2,3}, 작성자 {2}
             User u1 = user(1L, "U1", (short) 0);
-            User u2 = user(2L, "U2", (short) 0);
             User u3 = user(3L, "U3", (short) 0);
             given(
                             notificationSettingRepository
                                     .findAllByDayOfWeekAndNotifyTimeAndIsActiveTrue(any(), any()))
-                    .willReturn(List.of(slot(u1), slot(u2), slot(u3)));
+                    .willReturn(List.of(slot(u1), slot(user(2L, "U2", (short) 0)), slot(u3)));
             given(scrumDailyQueryService.findUserIdsWithScrumOn(any(), any()))
                     .willReturn(Set.of(2L));
             // 서비스가 candidate에서 작성자 제외 후 user/토큰 조회 (u2 빠짐)
@@ -222,12 +221,12 @@ class NotificationSchedulerTest {
             verify(fcmPushClient).send(eq("t1"), any());
             verify(fcmPushClient).send(eq("t3"), any());
             verify(fcmPushClient, never()).send(eq("t2"), any());
-            assertThat(u2.getNotificationCopyIndex()).isEqualTo((short) 0);
+            verify(dispatchWriter).apply(Set.of(1L, 3L), 3, List.of());
         }
 
         @Test
-        @DisplayName("invalid 응답을 받은 토큰만 deactivateByPushToken으로 비활성화된다")
-        void should_deactivateOnlyInvalidTokens_when_fcmReturnsTokenInvalid() {
+        @DisplayName("invalid 응답을 받은 토큰만 dispatchWriter.apply의 invalidTokens 인자에 포함된다")
+        void should_collectOnlyInvalidTokens_when_fcmReturnsTokenInvalid() {
             // given
             User user = user(1L, "겨레", (short) 0);
             DeviceToken good = token(user, "t-good");
@@ -247,8 +246,10 @@ class NotificationSchedulerTest {
             scheduler.dispatch();
 
             // then
-            verify(deviceTokenRepository).deactivateByPushToken("t-bad");
-            verify(deviceTokenRepository, never()).deactivateByPushToken("t-good");
+            ArgumentCaptor<Collection<String>> invalidCap =
+                    ArgumentCaptor.forClass(Collection.class);
+            verify(dispatchWriter).apply(eq(Set.of(1L)), eq(3), invalidCap.capture());
+            assertThat(invalidCap.getValue()).containsExactly("t-bad");
         }
     }
 

--- a/src/test/java/com/groute/groute_server/record/application/service/ScrumBulkWriteServiceTest.java
+++ b/src/test/java/com/groute/groute_server/record/application/service/ScrumBulkWriteServiceTest.java
@@ -2,6 +2,7 @@ package com.groute.groute_server.record.application.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyCollection;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.anyLong;
@@ -33,6 +34,7 @@ import com.groute.groute_server.record.application.port.out.scrum.ScrumWritePort
 import com.groute.groute_server.record.application.port.out.scrumtitle.ScrumTitleRepositoryPort;
 import com.groute.groute_server.record.application.port.out.star.StarRecordRepositoryPort;
 import com.groute.groute_server.record.application.port.out.user.UserReferencePort;
+import com.groute.groute_server.record.application.port.out.user.UserStreakPort;
 import com.groute.groute_server.record.domain.Project;
 import com.groute.groute_server.record.domain.Scrum;
 import com.groute.groute_server.record.domain.ScrumTitle;
@@ -52,6 +54,7 @@ class ScrumBulkWriteServiceTest {
     @Mock StarRecordRepositoryPort starRecordRepositoryPort;
     @Mock StarImageCascadeCleaner starImageCascadeCleaner;
     @Mock UserReferencePort userReferencePort;
+    @Mock UserStreakPort userStreakPort;
 
     @InjectMocks ScrumBulkWriteService service;
 
@@ -235,6 +238,51 @@ class ScrumBulkWriteServiceTest {
             assertThat(result.groups().get(0).scrums().get(1).content()).isEqualTo("B");
             assertThat(result.groups().get(1).scrums()).hasSize(1);
             assertThat(result.groups().get(1).scrums().get(0).content()).isEqualTo("C");
+        }
+    }
+
+    @Nested
+    @DisplayName("streak 갱신")
+    class Streak {
+
+        @Test
+        @DisplayName("저장 성공 시 user streak를 userId·date로 갱신한다")
+        void should_recordStreak_when_writeSucceeds() {
+            given(projectPort.findByIdAndUserId(100L, USER_ID))
+                    .willReturn(Optional.of(project(100L, "프로젝트A")));
+            given(userReferencePort.getReferenceById(USER_ID))
+                    .willReturn(User.createForSocialLogin());
+            stubSaveTitles();
+            stubSaveScrums();
+
+            service.bulkWrite(command(group(100L, "제목", "스크럼1")));
+
+            verify(userStreakPort).recordOnDate(USER_ID, DATE);
+        }
+
+        @Test
+        @DisplayName("COMMITTED 충돌로 실패하면 streak를 갱신하지 않는다")
+        void should_notRecordStreak_when_committedConflict() {
+            given(scrumQueryPort.findAllByUserAndDate(USER_ID, DATE))
+                    .willReturn(
+                            List.of(scrumWithTitle(50L, 10L, ScrumTitleStatus.COMMITTED, 100L)));
+
+            assertThatThrownBy(() -> service.bulkWrite(command(group(100L, "제목", "스크럼1"))))
+                    .isInstanceOf(BusinessException.class);
+
+            verify(userStreakPort, never()).recordOnDate(anyLong(), any(LocalDate.class));
+        }
+
+        @Test
+        @DisplayName("스크럼 개수 초과로 실패하면 streak를 갱신하지 않는다")
+        void should_notRecordStreak_when_dateLimitExceeded() {
+            BulkWriteScrumCommand command =
+                    command(group(100L, "제목", "a", "b", "c", "d", "e", "f"));
+
+            assertThatThrownBy(() -> service.bulkWrite(command))
+                    .isInstanceOf(BusinessException.class);
+
+            verify(userStreakPort, never()).recordOnDate(anyLong(), any(LocalDate.class));
         }
     }
 


### PR DESCRIPTION
## 요약
- `NotificationScheduler.dispatch`에서 `@Transactional`을 제거하고 FCM 호출을 트랜잭션 밖에서 수행하도록 분리했습니다.
- 결과로 모이는 DB 변경분(invalid 토큰 비활성화, user 카피 인덱스 advance)은 새로 만든 `NotificationDispatchWriter.apply(...)`가 단일 트랜잭션으로 일괄 처리합니다.
- 기존 `NotificationSchedulerTest`는 writer 위임 verify 기준으로 재정렬했고, `NotificationDispatchWriterTest`를 신설했습니다.

## 변경 사항
- [ ] 기능
- [ ] 버그 수정
- [x] 리팩토링
- [ ] 문서
- [ ] 테스트
- [ ] 기타

## 테스트
- [x] 로컬 테스트 완료
- 테스트 방법:
    - `./gradlew spotlessApply check` 통과
    - `NotificationSchedulerTest` 케이스 갱신, `NotificationDispatchWriterTest` 신규

### 커버리지 (JaCoCo)
- 라인 커버리지: writer 분리에 따른 단위 테스트 신규 추가로 분기 커버 상승
- [x] `./gradlew test` 실행 후 `build/reports/jacoco/index.html` 확인

## 스크린샷/로그 (선택)
- 해당 없음

## 롤백/리스크
- 리스크 포인트:
    - FCM 호출은 더 이상 DB 트랜잭션 안에서 일어나지 않으므로 발송 도중 DB 커넥션을 점유하지 않습니다.
    - writer가 user를 재조회하므로 카피 인덱스 advance가 발송 직후 한 트랜잭션 안에서 안전하게 반영됩니다.
    - 다중 인스턴스 배포 시 분산 락이 필요한 점은 기존과 동일합니다(별도 이슈).
- 롤백 방법: 해당 PR revert

## 관련 이슈
Closes #172