### PR TITLE
feat: 프로필 수정 API에 닉네임 필드 추가 (#179)

### DIFF
--- a/src/main/java/com/groute/groute_server/user/controller/UserController.java
+++ b/src/main/java/com/groute/groute_server/user/controller/UserController.java
@@ -65,7 +65,8 @@ public class UserController {
 
     @Operation(
             summary = "프로필 수정",
-            description = "닉네임·직군·상태를 덮어쓴다. 변경 사항이 없어도 세 필드 모두 포함해 요청한다. 닉네임은 외부 노출이 없어 변경 횟수·기간 제한 없이 자유 수정 가능.")
+            description =
+                    "닉네임·직군·상태를 덮어쓴다. 변경 사항이 없어도 세 필드 모두 포함해 요청한다. 닉네임은 외부 노출이 없어 변경 횟수·기간 제한 없이 자유 수정 가능.")
     @ApiResponses({
         @io.swagger.v3.oas.annotations.responses.ApiResponse(
                 responseCode = "200",

--- a/src/main/java/com/groute/groute_server/user/controller/UserController.java
+++ b/src/main/java/com/groute/groute_server/user/controller/UserController.java
@@ -63,14 +63,16 @@ public class UserController {
                         user.streakSnapshotAsOf(kstToday)));
     }
 
-    @Operation(summary = "프로필 수정", description = "직군·상태를 덮어쓴다. 변경 사항이 없어도 두 필드 모두 한글 라벨로 포함해 요청한다.")
+    @Operation(
+            summary = "프로필 수정",
+            description = "닉네임·직군·상태를 덮어쓴다. 변경 사항이 없어도 세 필드 모두 포함해 요청한다. 닉네임은 외부 노출이 없어 변경 횟수·기간 제한 없이 자유 수정 가능.")
     @ApiResponses({
         @io.swagger.v3.oas.annotations.responses.ApiResponse(
                 responseCode = "200",
                 description = "수정 성공 — 업데이트된 프로필 반환"),
         @io.swagger.v3.oas.annotations.responses.ApiResponse(
                 responseCode = "400",
-                description = "필수 필드 누락 또는 지원하지 않는 라벨"),
+                description = "필수 필드 누락, 지원하지 않는 라벨, 또는 닉네임 형식 위반(2~12자 한글·영문·숫자)"),
         @io.swagger.v3.oas.annotations.responses.ApiResponse(
                 responseCode = "401",
                 description = "미인증 또는 만료된 액세스 토큰"),
@@ -81,7 +83,9 @@ public class UserController {
     @PatchMapping("/me")
     public ApiResponse<ProfileResponse> updateMyProfile(
             @CurrentUser Long userId, @Valid @RequestBody ProfileUpdateRequest request) {
-        User user = userService.updateMyProfile(userId, request.jobRole(), request.userStatus());
+        User user =
+                userService.updateMyProfile(
+                        userId, request.nickname(), request.jobRole(), request.userStatus());
         LocalDate kstToday = LocalDate.now(DateTimeFormatters.ZONE_KST);
         return ApiResponse.ok(
                 ProfileResponse.from(

--- a/src/main/java/com/groute/groute_server/user/dto/ProfileUpdateRequest.java
+++ b/src/main/java/com/groute/groute_server/user/dto/ProfileUpdateRequest.java
@@ -1,16 +1,23 @@
 package com.groute.groute_server.user.dto;
 
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 
 /**
  * 마이페이지 프로필 수정(MYP002) 요청 DTO.
  *
- * <p>요청 바디는 항상 두 필드를 모두 포함한다(스펙). 값은 한글 라벨 문자열로 받아 서비스 계층에서 {@code JobRole.fromLabel} / {@code
- * UserStatus.fromLabel}로 enum 변환한다.
+ * <p>요청 바디는 항상 세 필드를 모두 포함한다(스펙). 직군·상태 라벨은 한글 문자열로 받아 서비스 계층에서 {@code JobRole.fromLabel} / {@code
+ * UserStatus.fromLabel}로 enum 변환한다. 닉네임은 ONB003과 동일한 제약(2~12자, 한글·영문·숫자)을 따른다.
  */
 public record ProfileUpdateRequest(
+        @NotBlank(message = "닉네임은 필수입니다.")
+                @Size(min = 2, max = 12, message = "닉네임은 2자 이상 12자 이하여야 합니다.")
+                @Pattern(regexp = "^[가-힣a-zA-Z0-9]+$", message = "닉네임은 한글, 영문, 숫자만 사용할 수 있습니다.")
+                @Schema(description = "닉네임 (2~12자, 한글·영문·숫자)", example = "겨레")
+                String nickname,
         @NotBlank(message = "직군은 필수입니다.")
                 @Schema(description = "유저 직군 (기획자 | 개발자 | 디자이너)", example = "개발자")
                 String jobRole,

--- a/src/main/java/com/groute/groute_server/user/entity/User.java
+++ b/src/main/java/com/groute/groute_server/user/entity/User.java
@@ -118,11 +118,17 @@ public class User extends SoftDeleteEntity {
     }
 
     /**
-     * 마이페이지 프로필 수정(MYP002). 직군·상태를 덮어쓴다.
+     * 마이페이지 프로필 수정(MYP002). 닉네임·직군·상태를 덮어쓴다.
      *
-     * <p>요청 바디가 항상 두 필드를 모두 포함한다는 전제(부분 수정 아님). 엔티티 invariant 유지를 위해 호출부와 관계없이 null을 거부한다
+     * <p>요청 바디가 항상 세 필드를 모두 포함한다는 전제(부분 수정 아님). 엔티티 invariant 유지를 위해 호출부와 관계없이 null·blank 닉네임을
+     * 거부한다. 닉네임 형식·길이 검증은 DTO 단계에서 끝났다는 가정.
      */
-    public void updateProfile(JobRole jobRole, UserStatus userStatus) {
+    public void updateProfile(String nickname, JobRole jobRole, UserStatus userStatus) {
+        Objects.requireNonNull(nickname, "nickname");
+        if (nickname.isBlank()) {
+            throw new IllegalArgumentException("nickname must not be blank");
+        }
+        this.nickname = nickname;
         this.jobRole = Objects.requireNonNull(jobRole, "jobRole");
         this.userStatus = Objects.requireNonNull(userStatus, "userStatus");
     }

--- a/src/main/java/com/groute/groute_server/user/service/UserService.java
+++ b/src/main/java/com/groute/groute_server/user/service/UserService.java
@@ -48,21 +48,23 @@ public class UserService {
     }
 
     /**
-     * 프로필 수정 — 한글 라벨을 enum으로 변환해 엔티티에 덮어쓴다.
+     * 프로필 수정 — 한글 라벨을 enum으로 변환해 엔티티에 덮어쓴다. 닉네임도 함께 갱신한다.
      *
      * <p>라벨 파싱 실패는 필드별로 구분된 400 응답을 반환한다 — 직군은 {@link ErrorCode#INVALID_JOB_ROLE}, 상태는 {@link
      * ErrorCode#INVALID_USER_STATUS}. enum에서 던지는 {@link IllegalArgumentException}을 {@link
-     * BusinessException}으로 래핑해 일관된 에러 포맷을 유지한다.
+     * BusinessException}으로 래핑해 일관된 에러 포맷을 유지한다. 닉네임 형식·길이 검증은 DTO bean validation 단계에서 끝났다는
+     * 가정으로, 본 메서드는 도메인 invariant(null·blank 거부)만 책임진다. 닉네임은 외부에 노출되지 않으므로 변경 횟수·기간 제한 없이 자유 갱신.
      */
     @Transactional
-    public User updateMyProfile(Long userId, String jobRoleLabel, String userStatusLabel) {
+    public User updateMyProfile(
+            Long userId, String nickname, String jobRoleLabel, String userStatusLabel) {
         JobRole jobRole = parseJobRole(jobRoleLabel);
         UserStatus userStatus = parseUserStatus(userStatusLabel);
         User user =
                 userRepository
                         .findById(userId)
                         .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
-        user.updateProfile(jobRole, userStatus);
+        user.updateProfile(nickname, jobRole, userStatus);
         return user;
     }
 

--- a/src/main/java/com/groute/groute_server/user/service/UserService.java
+++ b/src/main/java/com/groute/groute_server/user/service/UserService.java
@@ -52,8 +52,8 @@ public class UserService {
      *
      * <p>라벨 파싱 실패는 필드별로 구분된 400 응답을 반환한다 — 직군은 {@link ErrorCode#INVALID_JOB_ROLE}, 상태는 {@link
      * ErrorCode#INVALID_USER_STATUS}. enum에서 던지는 {@link IllegalArgumentException}을 {@link
-     * BusinessException}으로 래핑해 일관된 에러 포맷을 유지한다. 닉네임 형식·길이 검증은 DTO bean validation 단계에서 끝났다는
-     * 가정으로, 본 메서드는 도메인 invariant(null·blank 거부)만 책임진다. 닉네임은 외부에 노출되지 않으므로 변경 횟수·기간 제한 없이 자유 갱신.
+     * BusinessException}으로 래핑해 일관된 에러 포맷을 유지한다. 닉네임 형식·길이 검증은 DTO bean validation 단계에서 끝났다는 가정으로, 본
+     * 메서드는 도메인 invariant(null·blank 거부)만 책임진다. 닉네임은 외부에 노출되지 않으므로 변경 횟수·기간 제한 없이 자유 갱신.
      */
     @Transactional
     public User updateMyProfile(

--- a/src/test/java/com/groute/groute_server/user/service/UserServiceTest.java
+++ b/src/test/java/com/groute/groute_server/user/service/UserServiceTest.java
@@ -184,22 +184,36 @@ class UserServiceTest {
     class UpdateMyProfile {
 
         @Test
-        @DisplayName("성공 — 라벨을 enum으로 변환해 엔티티에 반영")
+        @DisplayName("성공 — 라벨을 enum으로 변환해 엔티티에 반영하고 닉네임도 덮어씀")
         void updatesEntity_whenLabelsValid() {
             User user = User.createForSocialLogin();
+            ReflectionTestUtils.setField(user, "nickname", "이전닉네임");
             given(userRepository.findById(USER_ID)).willReturn(Optional.of(user));
 
-            User result = userService.updateMyProfile(USER_ID, "개발자", "재학 중");
+            User result = userService.updateMyProfile(USER_ID, "새닉네임", "개발자", "재학 중");
 
             assertThat(result).isSameAs(user);
+            assertThat(result.getNickname()).isEqualTo("새닉네임");
             assertThat(result.getJobRole()).isEqualTo(JobRole.DEVELOPER);
             assertThat(result.getUserStatus()).isEqualTo(UserStatus.STUDENT);
         }
 
         @Test
+        @DisplayName("성공 — 동일 닉네임 재요청도 무제한 갱신 정책에 따라 그대로 반영")
+        void overwritesSameNickname_whenRepeated() {
+            User user = User.createForSocialLogin();
+            ReflectionTestUtils.setField(user, "nickname", "겨레");
+            given(userRepository.findById(USER_ID)).willReturn(Optional.of(user));
+
+            User result = userService.updateMyProfile(USER_ID, "겨레", "개발자", "재학 중");
+
+            assertThat(result.getNickname()).isEqualTo("겨레");
+        }
+
+        @Test
         @DisplayName("실패 — 직군 라벨 이상 시 INVALID_JOB_ROLE, 유저 조회 스킵")
         void throwsInvalidJobRole_whenJobRoleUnknown() {
-            assertThatThrownBy(() -> userService.updateMyProfile(USER_ID, "몰라요", "재학 중"))
+            assertThatThrownBy(() -> userService.updateMyProfile(USER_ID, "겨레", "몰라요", "재학 중"))
                     .asInstanceOf(InstanceOfAssertFactories.type(BusinessException.class))
                     .extracting(BusinessException::getErrorCode)
                     .isEqualTo(ErrorCode.INVALID_JOB_ROLE);
@@ -210,7 +224,7 @@ class UserServiceTest {
         @Test
         @DisplayName("실패 — 상태 라벨 이상 시 INVALID_USER_STATUS, 유저 조회 스킵")
         void throwsInvalidUserStatus_whenStatusUnknown() {
-            assertThatThrownBy(() -> userService.updateMyProfile(USER_ID, "개발자", "백수"))
+            assertThatThrownBy(() -> userService.updateMyProfile(USER_ID, "겨레", "개발자", "백수"))
                     .asInstanceOf(InstanceOfAssertFactories.type(BusinessException.class))
                     .extracting(BusinessException::getErrorCode)
                     .isEqualTo(ErrorCode.INVALID_USER_STATUS);
@@ -223,10 +237,21 @@ class UserServiceTest {
         void throwsUserNotFound_whenUserMissing() {
             given(userRepository.findById(USER_ID)).willReturn(Optional.empty());
 
-            assertThatThrownBy(() -> userService.updateMyProfile(USER_ID, "개발자", "재학 중"))
+            assertThatThrownBy(() -> userService.updateMyProfile(USER_ID, "겨레", "개발자", "재학 중"))
                     .asInstanceOf(InstanceOfAssertFactories.type(BusinessException.class))
                     .extracting(BusinessException::getErrorCode)
                     .isEqualTo(ErrorCode.USER_NOT_FOUND);
+        }
+
+        @Test
+        @DisplayName("실패 — 닉네임이 blank면 도메인 invariant 위반으로 IllegalArgumentException")
+        void throwsIllegalArgument_whenNicknameBlank() {
+            User user = User.createForSocialLogin();
+            ReflectionTestUtils.setField(user, "nickname", "겨레");
+            given(userRepository.findById(USER_ID)).willReturn(Optional.of(user));
+
+            assertThatThrownBy(() -> userService.updateMyProfile(USER_ID, "  ", "개발자", "재학 중"))
+                    .isInstanceOf(IllegalArgumentException.class);
         }
     }
 


### PR DESCRIPTION
## 요약
- 마이페이지 프로필 수정 API에 닉네임 필드를 추가해 직군·상태와 같은 요청으로 변경 가능하도록 한다.

## 변경 사항
- [x] 기능
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 문서
- [x] 테스트
- [ ] 기타

세부 내역
- `ProfileUpdateRequest`에 `nickname` 필드 추가 (ONB003과 동일한 2~12자·한글/영문/숫자 제약)
- `User.updateProfile` 시그니처를 `(nickname, jobRole, userStatus)`로 확장. 도메인 invariant로 null·blank 닉네임 거부
- `UserService.updateMyProfile`, `UserController PATCH /me`에 닉네임 전달
- Swagger 응답 코드 400 설명에 닉네임 형식 위반 케이스 명시
- 닉네임은 외부에 노출되지 않아 변경 횟수·기간 제한 없이 자유 갱신 정책 (기획 결정)

## 테스트
- [x] 로컬 테스트 완료
- 테스트 방법:
    - `./gradlew spotlessApply check` 통과
    - `UserServiceTest > UpdateMyProfile` 신규 케이스
        - 라벨 정상 + 닉네임 갱신
        - 동일 닉네임 재요청 시에도 무제한 갱신 정책으로 그대로 반영
        - 닉네임 blank 시 `IllegalArgumentException`
        - 기존 직군/상태 라벨 이상·USER_NOT_FOUND 케이스 유지

### 커버리지 (JaCoCo)
- 라인 커버리지: __% (기준: 60% 이상)
- [x] `./gradlew test` 실행 후 `build/reports/jacoco/index.html`에서 수치 확인 예정
- (선택) 리포트 스크린샷 또는 60% 미달/특이사항 공유:

## 스크린샷/로그 (선택)
- Swagger `PATCH /api/users/me` 요청 바디 예시

```json
{
  "nickname": "겨레",
  "jobRole": "개발자",
  "userStatus": "재학 중"
}
```

## 롤백/리스크
- 리스크 포인트:
    - 클라이언트가 기존 2-필드 바디로 요청 시 `nickname` `@NotBlank` 검증에서 400 발생. 프론트 동시 배포 필요.
    - 닉네임 중복 검사 미적용 정책이므로 동일 닉네임 다수 발생 가능.
- 롤백 방법:
    - 본 PR revert로 즉시 이전 동작 복귀 (DDL 변경 없음, 기존 컬럼 그대로 사용).

## 관련 이슈
Closes #179

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 프로필 수정 API에서 닉네임 업데이트 기능이 추가되었습니다.
  * 닉네임 유효성 검증이 적용되었습니다(2~12자, 한글/영문/숫자만 허용).
  * API 문서가 닉네임 필드 및 검증 규칙을 포함하도록 업데이트되었습니다.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/2026-KUSITMS-GLIT/2026-KUSITMS-GLIT-BACK/pull/180?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->