### PR TITLE
fix: 일자별 스크럼 sync streak 갱신 누락 및 TZ 일관성 (#182)

### DIFF
--- a/src/main/java/com/groute/groute_server/record/application/service/ScrumSyncService.java
+++ b/src/main/java/com/groute/groute_server/record/application/service/ScrumSyncService.java
@@ -23,6 +23,7 @@ import com.groute.groute_server.record.application.port.out.scrum.ScrumWritePort
 import com.groute.groute_server.record.application.port.out.scrumtitle.ScrumTitleRepositoryPort;
 import com.groute.groute_server.record.application.port.out.star.StarRecordCascadePort;
 import com.groute.groute_server.record.application.port.out.user.UserReferencePort;
+import com.groute.groute_server.record.application.port.out.user.UserStreakPort;
 import com.groute.groute_server.record.domain.Scrum;
 import com.groute.groute_server.record.domain.ScrumTitle;
 import com.groute.groute_server.user.entity.User;
@@ -49,6 +50,7 @@ public class ScrumSyncService implements SyncDailyScrumUseCase {
     private final StarRecordCascadePort starRecordCascadePort;
     private final StarImageCascadeCleaner starImageCascadeCleaner;
     private final UserReferencePort userReferencePort;
+    private final UserStreakPort userStreakPort;
 
     /**
      * 일자별 스크럼을 요청 payload 상태로 동기화.
@@ -159,6 +161,13 @@ public class ScrumSyncService implements SyncDailyScrumUseCase {
         // 8. 비정규화 카운터 갱신
         for (Map.Entry<Long, Integer> entry : titleDeltas.entrySet()) {
             scrumTitleRepositoryPort.applyScrumCountIncrement(entry.getKey(), entry.getValue());
+        }
+
+        // 9. user streak 갱신 (REC-001) — 동기화 후 해당 일자에 잔존 스크럼이 1개 이상일 때만 호출. 전부 삭제된 경우는
+        // lastRecordDate가 잘못 갱신되지 않도록 skip. 엔티티에서 같은 날/과거 일자는 멱등 처리됨.
+        int survivingCount = currentScrums.size() - toDelete.size() + toCreate.size();
+        if (survivingCount > 0) {
+            userStreakPort.recordOnDate(command.userId(), command.date());
         }
     }
 

--- a/src/main/java/com/groute/groute_server/record/application/service/ScrumSyncService.java
+++ b/src/main/java/com/groute/groute_server/record/application/service/ScrumSyncService.java
@@ -15,6 +15,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import com.groute.groute_server.common.exception.BusinessException;
 import com.groute.groute_server.common.exception.ErrorCode;
+import com.groute.groute_server.common.util.DateTimeFormatters;
 import com.groute.groute_server.record.application.port.in.scrum.SyncDailyScrumCommand;
 import com.groute.groute_server.record.application.port.in.scrum.SyncDailyScrumUseCase;
 import com.groute.groute_server.record.application.port.out.scrum.ScrumQueryPort;
@@ -99,8 +100,8 @@ public class ScrumSyncService implements SyncDailyScrumUseCase {
             throw new BusinessException(ErrorCode.SCRUM_NOT_FOUND);
         }
 
-        // 5. 변경 분류 + 14일·STAR 검증 (변경 대상에 한해)
-        ZoneId zone = ZoneId.systemDefault();
+        // 5. 변경 분류 + 14일·STAR 검증 (변경 대상에 한해) — JVM TZ에 의존하지 않도록 KST 고정.
+        ZoneId zone = DateTimeFormatters.ZONE_KST;
         LocalDate today = LocalDate.now(zone);
         List<UpdateOp> updates = new ArrayList<>();
         Map<Long, Integer> titleDeltas = new HashMap<>();

--- a/src/test/java/com/groute/groute_server/record/application/service/ScrumSyncServiceTest.java
+++ b/src/test/java/com/groute/groute_server/record/application/service/ScrumSyncServiceTest.java
@@ -38,6 +38,7 @@ import com.groute.groute_server.record.application.port.out.scrum.ScrumWritePort
 import com.groute.groute_server.record.application.port.out.scrumtitle.ScrumTitleRepositoryPort;
 import com.groute.groute_server.record.application.port.out.star.StarRecordCascadePort;
 import com.groute.groute_server.record.application.port.out.user.UserReferencePort;
+import com.groute.groute_server.record.application.port.out.user.UserStreakPort;
 import com.groute.groute_server.record.domain.Project;
 import com.groute.groute_server.record.domain.Scrum;
 import com.groute.groute_server.record.domain.ScrumTitle;
@@ -56,6 +57,7 @@ class ScrumSyncServiceTest {
     @Mock StarRecordCascadePort starRecordCascadePort;
     @Mock StarImageCascadeCleaner starImageCascadeCleaner;
     @Mock UserReferencePort userReferencePort;
+    @Mock UserStreakPort userStreakPort;
 
     @InjectMocks ScrumSyncService service;
 
@@ -357,6 +359,93 @@ class ScrumSyncServiceTest {
             assertThat(captor.getValue()).hasSize(2);
             verify(scrumTitleRepositoryPort).applyScrumCountIncrement(2L, 2);
             verify(scrumTitleRepositoryPort).applyScrumCountIncrement(1L, -1);
+        }
+    }
+
+    @Nested
+    @DisplayName("streak 갱신")
+    class Streak {
+
+        @Test
+        @DisplayName("신규 생성으로 잔존 스크럼이 1개 이상이면 recordOnDate를 호출한다")
+        void should_recordStreak_when_newScrumCreated() {
+            // given
+            ScrumTitle title = title(1L, "P", "F");
+            given(scrumTitleRepositoryPort.findAllByIdInAndUserId(anyCollection(), anyLong()))
+                    .willReturn(List.of(title));
+            given(scrumQueryPort.findAllByIdInAndUserId(anyCollection(), anyLong()))
+                    .willReturn(List.of());
+            given(scrumQueryPort.findAllByUserAndDate(USER_ID, DATE)).willReturn(List.of());
+            given(userReferencePort.getReferenceById(USER_ID))
+                    .willReturn(User.createForSocialLogin());
+            SyncDailyScrumCommand command = command(group(1L, item(null, "신규")));
+
+            // when
+            service.syncDailyScrum(command);
+
+            // then
+            verify(userStreakPort).recordOnDate(USER_ID, DATE);
+        }
+
+        @Test
+        @DisplayName("수정만 일어나고 기존 스크럼이 잔존하면 recordOnDate를 호출한다")
+        void should_recordStreak_when_onlyUpdated() {
+            // given
+            ScrumTitle title = title(1L, "P", "F");
+            Scrum existing = scrum(10L, title, "old", false, YESTERDAY);
+            given(scrumTitleRepositoryPort.findAllByIdInAndUserId(anyCollection(), anyLong()))
+                    .willReturn(List.of(title));
+            given(scrumQueryPort.findAllByIdInAndUserId(anyCollection(), anyLong()))
+                    .willReturn(List.of(existing));
+            given(scrumQueryPort.findAllByUserAndDate(USER_ID, DATE)).willReturn(List.of(existing));
+            SyncDailyScrumCommand command = command(group(1L, item(10L, "new")));
+
+            // when
+            service.syncDailyScrum(command);
+
+            // then
+            verify(userStreakPort).recordOnDate(USER_ID, DATE);
+        }
+
+        @Test
+        @DisplayName("기존 스크럼이 전부 삭제되어 잔존 0이면 recordOnDate를 호출하지 않는다")
+        void should_notRecordStreak_when_allDeleted() {
+            // given — DB에 1건, 요청은 빈 items → survivingCount=0
+            ScrumTitle title = title(1L, "P", "F");
+            Scrum existing = scrum(10L, title, "x", false, YESTERDAY);
+            given(scrumTitleRepositoryPort.findAllByIdInAndUserId(anyCollection(), anyLong()))
+                    .willReturn(List.of(title));
+            given(scrumQueryPort.findAllByIdInAndUserId(anyCollection(), anyLong()))
+                    .willReturn(List.of());
+            given(scrumQueryPort.findAllByUserAndDate(USER_ID, DATE)).willReturn(List.of(existing));
+            SyncDailyScrumCommand command = command(group(1L));
+
+            // when
+            service.syncDailyScrum(command);
+
+            // then
+            verify(userStreakPort, never()).recordOnDate(anyLong(), any(LocalDate.class));
+        }
+
+        @Test
+        @DisplayName("validation 단계에서 실패하면 recordOnDate를 호출하지 않는다")
+        void should_notRecordStreak_when_validationFails() {
+            // given — 5개 제한 초과
+            SyncDailyScrumCommand command =
+                    command(
+                            group(
+                                    1L,
+                                    item(null, "a"),
+                                    item(null, "b"),
+                                    item(null, "c"),
+                                    item(null, "d"),
+                                    item(null, "e"),
+                                    item(null, "f")));
+
+            // when & then
+            assertThatThrownBy(() -> service.syncDailyScrum(command))
+                    .isInstanceOf(BusinessException.class);
+            verify(userStreakPort, never()).recordOnDate(anyLong(), any(LocalDate.class));
         }
     }
 


### PR DESCRIPTION
## 요약
- `PUT /api/scrums/daily`에서도 user streak가 갱신되도록 호출을 추가하고, 14일 편집 윈도우 판정 타임존을 KST로 고정한다.

## 변경 사항
- [ ] 기능
- [x] 버그 수정
- [ ] 리팩토링
- [ ] 문서
- [x] 테스트
- [ ] 기타

세부 내역
- `ScrumSyncService.syncDailyScrum`이 동기화 후 해당 일자에 잔존 스크럼이 1개 이상이면 `userStreakPort.recordOnDate(userId, command.date())`를 호출. 전부 삭제된 경우(survivingCount = 0)에는 호출하지 않아 `lastRecordDate`가 잘못 갱신되지 않도록 한다.
- 14일 편집 윈도우 판정에 쓰던 `ZoneId.systemDefault()`를 `DateTimeFormatters.ZONE_KST`로 교체. JVM TZ에 의존하지 않도록 한다.

## 테스트
- [x] 로컬 테스트 완료
- 테스트 방법:
    - `./gradlew spotlessApply check` 통과
    - `ScrumSyncServiceTest > Streak` 신규 케이스
        - 신규 생성으로 잔존 시 recordOnDate 호출
        - 수정만 일어나 기존이 잔존하면 recordOnDate 호출
        - 전부 삭제되어 잔존 0이면 recordOnDate 미호출
        - validation 실패 시 recordOnDate 미호출

### 커버리지 (JaCoCo)
- 라인 커버리지: __% (기준: 60% 이상)
- [x] `./gradlew test` 실행 후 `build/reports/jacoco/index.html`에서 수치 확인 예정
- (선택) 리포트 스크린샷 또는 60% 미달/특이사항 공유:

## 스크린샷/로그 (선택)
- 디스코드 시연 영상 촬영 대비 트래킹: 옥민지님 계정 오늘자 기록 존재, `consecutiveRecordDays = 0` 응답을 정상화하기 위한 핫픽스.

## 롤백/리스크
- 리스크 포인트:
    - 본 픽스는 향후 갱신만 정상화한다. 픽스 이전에 기록한 일자의 `currentStreak`·`lastRecordDate`는 복원되지 않으므로, 운영상 실제 연속 기록 회복은 별도 백필 작업이 필요(범위 외).
    - sync 종료 시점의 단일 추가 쓰기(`UPDATE users`)가 트랜잭션에 포함되어 약간의 부하 증가. 동일 일자 재요청은 엔티티 단에서 멱등 처리됨.
- 롤백 방법:
    - 본 PR revert로 즉시 이전 동작 복귀. DDL 변경 없음.

## 관련 이슈
Closes #182

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 스크럼 동기화 후 생존하는 항목이 존재할 때만 사용자 스트릭이 기록되도록 개선되었습니다.

* **Bug Fixes**
  * 시간대 처리가 KST로 통일되었습니다.

* **Tests**
  * 스트릭 기록 조건 검증을 포함한 테스트 케이스가 추가되었습니다.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/2026-KUSITMS-GLIT/2026-KUSITMS-GLIT-BACK/pull/183?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->