### PR TITLE
chore: 서버 보안·성능·안정성 설정 추가

### DIFF
--- a/src/main/java/com/groute/groute_server/common/config/SecurityConfig.java
+++ b/src/main/java/com/groute/groute_server/common/config/SecurityConfig.java
@@ -66,6 +66,13 @@ public class SecurityConfig {
                         ex ->
                                 ex.authenticationEntryPoint(jwtAuthenticationEntryPoint)
                                         .accessDeniedHandler(jwtAccessDeniedHandler))
+                .headers(
+                        h ->
+                                h.httpStrictTransportSecurity(
+                                        hsts ->
+                                                hsts.includeSubDomains(true)
+                                                        .maxAgeInSeconds(31536000)
+                                                        .preload(true)))
                 .addFilterBefore(
                         jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
 

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -221,6 +221,21 @@ spring:
   flyway:
     baseline-on-migrate: false
 
+  lifecycle:
+    timeout-per-shutdown-phase: 30s
+
+  datasource:
+    hikari:
+      leak-detection-threshold: 30000
+
+server:
+  forward-headers-strategy: framework
+  compression:
+    enabled: true
+    mime-types: application/json,application/xml,text/html,text/plain
+    min-response-size: 1024
+  shutdown: graceful
+
 app:
   swagger:
     server-url: https://stg-api.glit.today
@@ -254,6 +269,21 @@ spring:
 
   flyway:
     baseline-on-migrate: false
+
+  lifecycle:
+    timeout-per-shutdown-phase: 30s
+
+  datasource:
+    hikari:
+      leak-detection-threshold: 30000
+
+server:
+  forward-headers-strategy: framework
+  compression:
+    enabled: true
+    mime-types: application/json,application/xml,text/html,text/plain
+    min-response-size: 1024
+  shutdown: graceful
 
 springdoc:
   swagger-ui:


### PR DESCRIPTION
## 요약
- stg/prod 프로파일에 HSTS, GZIP 압축, Graceful Shutdown, HikariCP leak-detection, forward-headers-strategy 설정 추가

## 상세내용
- server.forward-headers-strategy: framework → ALB 뒤에서 클라이언트 실제 IP/프로토콜 인식
- server.compression: GZIP 압축으로 JSON 응답 크기 절감
- server.shutdown: graceful + lifecycle timeout 30s → 배포 시 진행 중인 요청 안전하게 처리 후 종료
- HikariCP leak-detection-threshold: 30000 → 커넥션 30초 미반환 시 WARN 로그
- SecurityConfig HSTS 헤더 추가 → HTTPS 강제, MITM 공격 차단

## 변경 사항
- [ ] 기능
- [ ] 버그 수정
- [ ] 리팩토링
- [x] 문서
- [ ] 테스트
- [x] 기타

## 테스트
- [ ] 로컬 테스트 완료
- 테스트 방법:
    - stg 배포 이후
    - HSTS: `curl -I https://stg-api.glit.today/...` → Strict-Transport-Security 헤더 확인
    - GZIP: `curl -H "Accept-Encoding: gzip" -I https://stg-api.glit.today/...` → Content-Encoding: gzip 확인
    - Graceful Shutdown: 배포 시 로그에서 "Waiting for active requests to complete" 확인

### 커버리지 (JaCoCo)
- 라인 커버리지: __%  (기준: 60% 이상)
- [ ] `./gradlew test` 실행 후 `build/reports/jacoco/index.html`에서 수치 확인

## 스크린샷/로그 (선택)
- 필요한 경우 첨부

## 롤백/리스크
- 리스크 포인트:
- 롤백 방법:

## 관련 이슈
Closes #186 