### PR TITLE
fix: reissue rotate 실패 시 refresh 키 삭제를 제거해 동시 요청 세션 끊김 방지

### DIFF
--- a/src/main/java/com/groute/groute_server/auth/service/AuthService.java
+++ b/src/main/java/com/groute/groute_server/auth/service/AuthService.java
@@ -19,8 +19,10 @@ import lombok.extern.slf4j.Slf4j;
  * <p>검증·매칭 실패는 전부 {@link ErrorCode#INVALID_REFRESH_TOKEN} (401)로 일원화. 토큰 자체 누락은 그보다 앞 단계에서 {@link
  * ErrorCode#REFRESH_TOKEN_REQUIRED} (400)로 분리해, 클라이언트 버그(누락)와 실제 인증 실패를 구분.
  *
- * <p>재발급 성공 시 refresh 토큰을 rotate — {@link RefreshTokenRepository#rotate(Long, String, String)}가 Lua
- * 스크립트로 "이전 값 일치 확인 + 새 값 저장"을 원자 실행한다. 동시 요청이 들어와도 한 건만 성공하고 나머지는 401로 거절되어 일회성 회전 보장이 유지된다.
+ * <p>재발급 성공 시 refresh 토큰을 rotate 한다. {@link RefreshTokenRepository#rotate(Long, String, String)}가
+ * Lua 스크립트로 "이전 값 일치 확인 + 새 값 저장"을 원자 실행하므로, 동시 요청이 들어와도 한 건만 성공하고 나머지는 401로 거절되어 일회성 회전 보장이 유지된다.
+ * 단 CAS 실패 시 저장값을 삭제하지는 않는다. 정상적인 동시 reissue 경합에서 패배한 요청까지 키를 지우면 회전에 성공한 세션이 끊기기 때문이며, 회전 불가 자체가
+ * 일회성 보장을 담당한다.
  *
  * <p>로그아웃은 rotate의 대칭쌍으로 {@link RefreshTokenRepository#deleteByUserId(Long)}만 수행 — userId 하나로 해당
  * 유저의 refresh를 통째로 무효화한다(탈취된 refresh 포함). 브라우저 쿠키 제거는 Controller 계층이 {@code
@@ -49,8 +51,11 @@ public class AuthService {
         String newAccessToken = jwtTokenProvider.createAccessToken(userId);
         String newRefreshToken = jwtTokenProvider.createRefreshToken(userId);
 
+        // CAS 실패 시 저장값을 삭제하지 않는다. 앱 콜드 로드처럼 같은 refresh로 동시에 여러 reissue가
+        // 들어오면 한 건만 회전에 성공하고 나머지는 직전 토큰으로 CAS가 불일치하는데, 여기서 키를 지우면
+        // 회전에 성공한 멀쩡한 세션까지 끊긴다. 일회성 회전은 CAS 자체로 이미 보장되므로(불일치 토큰은
+        // 회전 불가) 패배한 요청은 401만 받고 키는 보존한다.
         if (!refreshTokenRepository.rotate(userId, refreshToken, newRefreshToken)) {
-            refreshTokenRepository.deleteByUserId(userId);
             throw new BusinessException(ErrorCode.INVALID_REFRESH_TOKEN);
         }
 

--- a/src/test/java/com/groute/groute_server/auth/service/AuthServiceTest.java
+++ b/src/test/java/com/groute/groute_server/auth/service/AuthServiceTest.java
@@ -111,8 +111,8 @@ class AuthServiceTest {
         }
 
         @Test
-        @DisplayName("rotate에 실패했을 때 저장값을 삭제하고 INVALID_REFRESH_TOKEN을 던진다")
-        void should_deleteStoredAndThrowInvalidRefreshToken_when_rotateFails() {
+        @DisplayName("rotate에 실패했을 때 저장값을 삭제하지 않고 INVALID_REFRESH_TOKEN을 던진다")
+        void should_throwInvalidRefreshTokenAndKeepStored_when_rotateFails() {
             // given
             String oldRefresh = "old-refresh";
             String newRefresh = "new-refresh";
@@ -129,7 +129,7 @@ class AuthServiceTest {
                     .isInstanceOf(BusinessException.class)
                     .extracting("errorCode")
                     .isEqualTo(ErrorCode.INVALID_REFRESH_TOKEN);
-            verify(refreshTokenRepository).deleteByUserId(userId);
+            verify(refreshTokenRepository, never()).deleteByUserId(anyLong());
         }
     }
 


### PR DESCRIPTION
## 요약
- reissue 동시 호출 시 CAS 실패가 refresh 키를 통째로 삭제해 멀쩡한 세션이 끊기던 문제를 수정한다.

## 변경 사항
- [ ] 기능
- [x] 버그 수정
- [ ] 리팩토링
- [ ] 문서
- [x] 테스트
- [ ] 기타

`AuthService.reissue`는 rotate(Redis CAS) 실패 시 `deleteByUserId`로 유저의 refresh 키를 삭제했다.
access(TTL 1시간) 만료 후 앱 콜드 로드 시점에 같은 refresh로 reissue가 병렬 발생하면, 한 건만 회전에
성공하고 나머지는 직전 토큰으로 CAS가 불일치하는데 그때 키가 삭제되어 이후 모든 재발급이 401(AUTH_004)로
영구 실패했다.

- CAS 실패 시 `deleteByUserId` 호출을 제거한다. 일회성 회전은 CAS 자체로 보장되므로(불일치 토큰은 회전 불가)
  패배한 요청은 401만 받고 저장값은 보존한다.
- 관련 Javadoc·주석을 변경된 동작으로 갱신한다.
- 테스트: rotate 실패 시 `never().deleteByUserId` 를 검증하도록 수정한다.

## 테스트
- [x] 로컬 테스트 완료
- 테스트 방법:
    - ./gradlew test --tests "com.groute.groute_server.auth.service.AuthServiceTest"

### 커버리지 (JaCoCo)
- 라인 커버리지: __%  (기준: 60% 이상)
- [ ] `./gradlew test` 실행 후 `build/reports/jacoco/index.html`에서 수치 확인

## 스크린샷/로그 (선택)
- Redis 진단: `TTL refresh:{userId}` = -2(키 없음), `evicted_keys` 0(eviction 아님)으로 삭제가 원인임을 확인.

## 롤백/리스크
- 리스크 포인트: refresh 토큰 재사용 감지(reuse detection)의 "재사용 시 세션 전체 무효화" 동작이 약화된다.
  탈취된 토큰은 CAS로 회전 자체가 불가하나, 재사용 시도를 능동적으로 감지해 강제 로그아웃하지는 않는다.
  완전한 대응은 프론트 single-flight(동시 reissue 합치기)와 grace 윈도우 기반 reuse detection으로 별도 진행 권장.
- 롤백 방법: 본 커밋 revert 시 직전 동작(CAS 실패 시 삭제)으로 즉시 복귀.

## 관련 이슈
Closes #193


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Bug Fixes**
  * 토큰 재발급 실패 시 세션 데이터 보존 로직으로 변경되어 연결이 끊기지 않도록 개선되었습니다.

* **Documentation**
  * 토큰 재발급 관련 설명이 동시성 보장과 안정성 측면으로 확대되었습니다.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/2026-KUSITMS-GLIT/2026-KUSITMS-GLIT-BACK/pull/194?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->