### PR TITLE
master ← dev sync

### DIFF
--- a/src/main/java/com/groute/groute_server/auth/service/AuthService.java
+++ b/src/main/java/com/groute/groute_server/auth/service/AuthService.java
@@ -19,8 +19,10 @@ import lombok.extern.slf4j.Slf4j;
  * <p>검증·매칭 실패는 전부 {@link ErrorCode#INVALID_REFRESH_TOKEN} (401)로 일원화. 토큰 자체 누락은 그보다 앞 단계에서 {@link
  * ErrorCode#REFRESH_TOKEN_REQUIRED} (400)로 분리해, 클라이언트 버그(누락)와 실제 인증 실패를 구분.
  *
- * <p>재발급 성공 시 refresh 토큰을 rotate — {@link RefreshTokenRepository#rotate(Long, String, String)}가 Lua
- * 스크립트로 "이전 값 일치 확인 + 새 값 저장"을 원자 실행한다. 동시 요청이 들어와도 한 건만 성공하고 나머지는 401로 거절되어 일회성 회전 보장이 유지된다.
+ * <p>재발급 성공 시 refresh 토큰을 rotate 한다. {@link RefreshTokenRepository#rotate(Long, String, String)}가
+ * Lua 스크립트로 "이전 값 일치 확인 + 새 값 저장"을 원자 실행하므로, 동시 요청이 들어와도 한 건만 성공하고 나머지는 401로 거절되어 일회성 회전 보장이 유지된다.
+ * 단 CAS 실패 시 저장값을 삭제하지는 않는다. 정상적인 동시 reissue 경합에서 패배한 요청까지 키를 지우면 회전에 성공한 세션이 끊기기 때문이며, 회전 불가 자체가
+ * 일회성 보장을 담당한다.
  *
  * <p>로그아웃은 rotate의 대칭쌍으로 {@link RefreshTokenRepository#deleteByUserId(Long)}만 수행 — userId 하나로 해당
  * 유저의 refresh를 통째로 무효화한다(탈취된 refresh 포함). 브라우저 쿠키 제거는 Controller 계층이 {@code
@@ -49,8 +51,11 @@ public class AuthService {
         String newAccessToken = jwtTokenProvider.createAccessToken(userId);
         String newRefreshToken = jwtTokenProvider.createRefreshToken(userId);
 
+        // CAS 실패 시 저장값을 삭제하지 않는다. 앱 콜드 로드처럼 같은 refresh로 동시에 여러 reissue가
+        // 들어오면 한 건만 회전에 성공하고 나머지는 직전 토큰으로 CAS가 불일치하는데, 여기서 키를 지우면
+        // 회전에 성공한 멀쩡한 세션까지 끊긴다. 일회성 회전은 CAS 자체로 이미 보장되므로(불일치 토큰은
+        // 회전 불가) 패배한 요청은 401만 받고 키는 보존한다.
         if (!refreshTokenRepository.rotate(userId, refreshToken, newRefreshToken)) {
-            refreshTokenRepository.deleteByUserId(userId);
             throw new BusinessException(ErrorCode.INVALID_REFRESH_TOKEN);
         }
 

--- a/src/main/java/com/groute/groute_server/common/config/SecurityConfig.java
+++ b/src/main/java/com/groute/groute_server/common/config/SecurityConfig.java
@@ -66,6 +66,13 @@ public class SecurityConfig {
                         ex ->
                                 ex.authenticationEntryPoint(jwtAuthenticationEntryPoint)
                                         .accessDeniedHandler(jwtAccessDeniedHandler))
+                .headers(
+                        h ->
+                                h.httpStrictTransportSecurity(
+                                        hsts ->
+                                                hsts.includeSubDomains(true)
+                                                        .maxAgeInSeconds(31536000)
+                                                        .preload(true)))
                 .addFilterBefore(
                         jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
 

--- a/src/main/java/com/groute/groute_server/common/jwt/JwtProperties.java
+++ b/src/main/java/com/groute/groute_server/common/jwt/JwtProperties.java
@@ -1,14 +1,20 @@
 package com.groute.groute_server.common.jwt;
 
+import jakarta.validation.constraints.Size;
+
 import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.validation.annotation.Validated;
 
 /**
  * JWT 서명 키 및 토큰 만료 시간 설정.
  *
  * <p>환경별 값은 SSM Parameter Store의 {@code /groute/{env}/JWT_SECRET}에서 주입된다.
  *
- * <p>만료 시간 단위는 밀리초(ms). HS256 서명을 위해 {@code secret}은 32바이트(UTF-8) 이상이어야 한다.
+ * <p>만료 시간 단위는 밀리초(ms). HS256 서명을 위해 {@code secret}은 32바이트(UTF-8) 이상이어야 하며, 미충족 시 부팅 단계에서 실패한다.
  */
+@Validated
 @ConfigurationProperties(prefix = "jwt")
 public record JwtProperties(
-        String secret, long accessTokenExpiration, long refreshTokenExpiration) {}
+        @Size(min = 32, message = "jwt.secret은 HS256 서명을 위해 32바이트 이상이어야 한다") String secret,
+        long accessTokenExpiration,
+        long refreshTokenExpiration) {}

--- a/src/main/java/com/groute/groute_server/common/util/DateTimeFormatters.java
+++ b/src/main/java/com/groute/groute_server/common/util/DateTimeFormatters.java
@@ -2,36 +2,9 @@ package com.groute.groute_server.common.util;
 
 import java.time.ZoneId;
 
-/**
- * 사람이 읽는 시간 문자열 포맷을 한 곳에서 관리하는 유틸리티.
- *
- * <h2>포지셔닝</h2>
- *
- * <ul>
- *   <li>엔티티/DB에 저장되는 시간은 {@link java.time.OffsetDateTime} UTC를 기준으로 한다.
- *   <li>응답 DTO에 <b>raw {@code OffsetDateTime}</b> 필드를 노출하는 경우, 직렬화는 {@link
- *       com.groute.groute_server.common.config.JacksonConfig}가 ISO-8601 UTC로 처리한다. (예: 클라이언트가 직접
- *       상대시간("2시간 전")을 계산하는 케이스)
- *   <li>응답 DTO에 <b>사람이 읽는 문자열</b>(예: "2026.04.18", "04.18 15:45")을 내려야 하는 경우, 서비스/어셈블러 레이어에서 본 클래스의
- *       포맷터/헬퍼를 사용해 {@code String}으로 채운다.
- * </ul>
- *
- * <h2>사용 위치</h2>
- *
- * 서비스 레이어 또는 DTO 어셈블러에서만 호출한다. 엔티티와 컨트롤러는 시간 포맷팅에 관여하지 않는다.
- *
- * <h2>타임존 변환 책임</h2>
- *
- * UTC로 저장된 시간을 KST 표현으로 변환하는 로직은 본 클래스 내부에서 처리한다. 호출부는 UTC/KST 변환을 신경 쓰지 않고 "어떤 포맷으로 보여줄지"만 결정한다.
- *
- * <h2>현재 상태</h2>
- *
- * 응답 DTO 작업 전이므로 실제 포맷터 상수/메서드는 비어 있다. 클라이언트 요구 패턴이 확정되는 대로 이곳에 상수와 헬퍼 메서드를 추가한다. (예: {@code
- * KST_DATE_DOT}, {@code KST_DATE_TIME_DOT}, {@code toKstDate(OffsetDateTime)} 등)
- */
+/** KST 타임존 단일 출처. UTC로 저장된 시간을 한국 표시 기준으로 변환할 때 공통으로 참조한다. */
 public final class DateTimeFormatters {
 
-    /** 한국 서비스 기준 표시용 타임존. UTC로 저장된 시간을 KST로 환산할 때 모든 포맷터/헬퍼가 공통으로 사용한다. */
     public static final ZoneId ZONE_KST = ZoneId.of("Asia/Seoul");
 
     private DateTimeFormatters() {}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -241,6 +241,21 @@ spring:
   flyway:
     baseline-on-migrate: false
 
+  lifecycle:
+    timeout-per-shutdown-phase: 30s
+
+  datasource:
+    hikari:
+      leak-detection-threshold: 30000
+
+server:
+  forward-headers-strategy: framework
+  compression:
+    enabled: true
+    mime-types: application/json,application/xml,text/html,text/plain
+    min-response-size: 1024
+  shutdown: graceful
+
 app:
   swagger:
     server-url: https://stg-api.glit.today
@@ -274,6 +289,21 @@ spring:
 
   flyway:
     baseline-on-migrate: false
+
+  lifecycle:
+    timeout-per-shutdown-phase: 30s
+
+  datasource:
+    hikari:
+      leak-detection-threshold: 30000
+
+server:
+  forward-headers-strategy: framework
+  compression:
+    enabled: true
+    mime-types: application/json,application/xml,text/html,text/plain
+    min-response-size: 1024
+  shutdown: graceful
 
 springdoc:
   swagger-ui:

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -13,9 +13,11 @@ spring:
       password: ${REDIS_PASSWORD:}
 
   datasource:
+    # stg/prod는 SSM에서 SPRING_DATASOURCE_USERNAME/PASSWORD 주입 필수 — 누락 시 부팅 실패(fail-fast).
+    # 로컬은 하단 local 프로파일에서 postgres/postgres fallback 허용.
     url: ${SPRING_DATASOURCE_URL:jdbc:postgresql://localhost:5432/groute_local}
-    username: ${SPRING_DATASOURCE_USERNAME:postgres}
-    password: ${SPRING_DATASOURCE_PASSWORD:postgres}
+    username: ${SPRING_DATASOURCE_USERNAME}
+    password: ${SPRING_DATASOURCE_PASSWORD}
     driver-class-name: org.postgresql.Driver
     hikari:
       maximum-pool-size: 10
@@ -92,7 +94,9 @@ server:
   port: 8080
 
 jwt:
-  secret: ${JWT_SECRET:local-dev-secret-key-must-be-changed-in-production-env}
+  # stg/prod는 SSM에서 JWT_SECRET 주입 필수 — 누락 시 부팅 실패(fail-fast).
+  # 로컬은 하단 local 프로파일에서 개발용 시크릿 fallback 허용.
+  secret: ${JWT_SECRET}
   access-token-expiration: ${JWT_ACCESS_TOKEN_EXPIRATION:3600000}
   refresh-token-expiration: ${JWT_REFRESH_TOKEN_EXPIRATION:1209600000}
 
@@ -171,11 +175,18 @@ spring:
     activate:
       on-profile: local
 
+  datasource:
+    username: ${SPRING_DATASOURCE_USERNAME:postgres}
+    password: ${SPRING_DATASOURCE_PASSWORD:postgres}
+
   jpa:
     show-sql: true
     properties:
       hibernate:
         format_sql: true
+
+jwt:
+  secret: ${JWT_SECRET:local-dev-secret-key-must-be-changed-in-production-env}
 
 app:
   user:

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -23,6 +23,9 @@ spring:
       maximum-pool-size: 10
       minimum-idle: 5
       connection-timeout: 30000
+      # 커넥션이 반납되지 않고 점유된 채로 임계치(ms)를 넘기면 WARN 로그로 누수 의심 스택을 남긴다.
+      # 운영 정상 쿼리는 1초 이내라 10s 임계로 잡아도 false positive가 적다.
+      leak-detection-threshold: 10000
 
   jpa:
     hibernate:
@@ -31,6 +34,12 @@ spring:
       hibernate:
         dialect: org.hibernate.dialect.PostgreSQLDialect
         jdbc.time_zone: UTC
+        # 같은 트랜잭션 안의 INSERT/UPDATE를 묶어 단일 round-trip으로 전송한다.
+        jdbc.batch_size: 50
+        order_inserts: true
+        order_updates: true
+        # N+1을 완화하기 위해 연관 엔티티 lazy 로딩 시 IN 쿼리로 일괄 fetch한다.
+        default_batch_fetch_size: 50
     open-in-view: false
 
   flyway:

--- a/src/test/java/com/groute/groute_server/auth/service/AuthServiceTest.java
+++ b/src/test/java/com/groute/groute_server/auth/service/AuthServiceTest.java
@@ -111,8 +111,8 @@ class AuthServiceTest {
         }
 
         @Test
-        @DisplayName("rotate에 실패했을 때 저장값을 삭제하고 INVALID_REFRESH_TOKEN을 던진다")
-        void should_deleteStoredAndThrowInvalidRefreshToken_when_rotateFails() {
+        @DisplayName("rotate에 실패했을 때 저장값을 삭제하지 않고 INVALID_REFRESH_TOKEN을 던진다")
+        void should_throwInvalidRefreshTokenAndKeepStored_when_rotateFails() {
             // given
             String oldRefresh = "old-refresh";
             String newRefresh = "new-refresh";
@@ -129,7 +129,7 @@ class AuthServiceTest {
                     .isInstanceOf(BusinessException.class)
                     .extracting("errorCode")
                     .isEqualTo(ErrorCode.INVALID_REFRESH_TOKEN);
-            verify(refreshTokenRepository).deleteByUserId(userId);
+            verify(refreshTokenRepository, never()).deleteByUserId(anyLong());
         }
     }
 


### PR DESCRIPTION
## 요약
- dev에 누적된 변경을 master로 반영하는 릴리즈 동기화 PR.

## 포함 변경 (5 commits)
### 버그 수정
- reissue rotate(CAS) 실패 시 refresh 키 삭제를 제거해 동시 요청으로 세션이 끊기던 문제 수정 (#193)

### 설정/인프라
- 서버 보안·성능·안정성 설정 추가 (HSTS, 압축, Graceful Shutdown, HikariCP) (#187)
- Hibernate batch 및 HikariCP connection leak detection 설정 추가 (#171)
- prod 프로파일 jwt.secret 및 DB 자격증명 fail-fast (#164)

### 리팩토링
- DateTimeFormatters placeholder Javadoc 정리 (#162)

## 변경 파일
- auth/service/AuthService.java, auth/service/AuthServiceTest.java
- common/config/SecurityConfig.java
- common/jwt/JwtProperties.java
- common/util/DateTimeFormatters.java
- resources/application.yaml

## 테스트
- [x] dev 브랜치 기준 로컬 테스트 통과
- 테스트 방법:
    - ./gradlew test

## 롤백/리스크
- 리스크 포인트: prod 설정(application.yaml) 변경이 포함되므로 배포 후 기동·헬스체크 확인 필요.
  reissue 변경은 refresh reuse detection의 세션 전체 무효화 동작이 약화된다(상세는 #193).
- 롤백 방법: 본 머지 revert 또는 직전 master 커밋으로 복귀.

## 관련 이슈
- #193 #187 #171 #164 #162
