### PR TITLE
chore: Gitleaks 시크릿 스캔 워크플로 추가

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Gitleaks 시크릿 스캔
+        run: |
+          curl -sSL https://github.com/gitleaks/gitleaks/releases/download/v8.27.2/gitleaks_8.27.2_linux_x64.tar.gz | tar -xz gitleaks
+          ./gitleaks detect --source . --redact --log-opts="HEAD~1..HEAD"
+
       - name: Set up JDK 21
         uses: actions/setup-java@v4
         with:


### PR DESCRIPTION
## 요약
- push/PR 시 Gitleaks로 하드코딩된 시크릿 자동 탐지, 발견 시 CI fail 처리

## 상세 내용
- Gitleaks step을 빌드 전 가장 앞에 추가 (시크릿 있으면 빌드 전에 차단)
- gitleaks-action 대신 바이너리 직접 실행 (organization 레포 라이선스 불필요)
- 최신 커밋만 스캔 (--log-opts="HEAD~1..HEAD")

## 변경 사항
- [ ] 기능
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 문서
- [ ] 테스트
- [x] 기타

## 테스트
- [ ] 로컬 테스트 완료
- 테스트 방법:
    - PR 올린 후 GitHub Actions에서 Gitleaks step 통과 확인

### 커버리지 (JaCoCo)

## 스크린샷/로그 (선택)

## 롤백/리스크
- 리스크 포인트:
- 롤백 방법:

## 관련 이슈
Closes #195 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Chores**
  * CI/CD 파이프라인에서 소스 코드 전체 히스토리 스캔 활성화
  * 빌드 프로세스에 자동화된 보안 검증 단계 추가

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/2026-KUSITMS-GLIT/2026-KUSITMS-GLIT-BACK/pull/197?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->