### PR TITLE
chore: Prometheus 메트릭 수집 설정 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -97,6 +97,8 @@ tasks.named('jacocoTestReport') {
 
 tasks.named('jacocoTestCoverageVerification') {
 	dependsOn tasks.named('test')
+	dependsOn tasks.named('compileJava')
+	dependsOn tasks.named('processResources')
 	classDirectories.setFrom(
 		files(classDirectories.files.collect {
 			fileTree(dir: it, exclude: jacocoExcludes)

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -99,7 +99,15 @@ management:
   endpoints:
     web:
       exposure:
-        include: health
+        include: health,prometheus
+  metrics:
+    tags:
+      application: ${spring.application.name}
+    distribution:
+      percentiles-histogram:
+        http.server.requests: true
+      slo:
+        http.server.requests: 100ms,300ms,500ms,1s,3s
 
 server:
   port: 8080
@@ -238,15 +246,6 @@ firebase:
 notification:
   copy-json: ${NOTIFICATION_COPY_JSON:}
   deep-link-url: ${NOTIFICATION_DEEP_LINK_URL:}
-
-management:
-  endpoints:
-    web:
-      exposure:
-        include: health,prometheus
-  metrics:
-    tags:
-      application: ${spring.application.name}
 
 logging:
   level:


### PR DESCRIPTION
## 요약
- Prometheus 메트릭 수집 엔드포인트 및 SLO 버킷 설정 추가

## 상세 내용
- micrometer-registry-prometheus 의존성 추가
- /actuator/prometheus 엔드포인트 노출
- metrics.tags.application으로 앱 이름 태그 추가
- http.server.requests 히스토그램 및 SLO 버킷(100ms/300ms/500ms/1s/3s) 설정

## 변경 사항
- [ ] 기능
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 문서
- [ ] 테스트
- [x] 기타

## 테스트
- [x] 로컬 테스트 완료
- 테스트 방법:
    - 앱 실행 후 curl http://localhost:8080/actuator/prometheus 응답 확인

### 커버리지 (JaCoCo)
- 라인 커버리지: __%  (기준: 60% 이상)
- [ ] `./gradlew test` 실행 후 `build/reports/jacoco/index.html`에서 수치 확인
- (선택) 리포트 스크린샷 또는 60% 미달/특이사항 공유:

## 스크린샷/로그 (선택)
- 필요한 경우 첨부

## 롤백/리스크
- 리스크 포인트:
- 롤백 방법:

## 관련 이슈
Closes #198 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * Prometheus 메트릭 엔드포인트 노출 활성화
  * 애플리케이션 메트릭 모니터링 구성 추가 (SLO 포함 HTTP 요청 추적)

* **Chores**
  * 빌드 프로세스 의존성 최적화

<!-- end of auto-generated comment: release notes by coderabbit.ai -->