### PR TITLE
docs: 보호 엔드포인트 누락 401 @ApiResponse 보강 (#200)

### DIFF
--- a/src/main/java/com/groute/groute_server/record/adapter/in/web/ProjectController.java
+++ b/src/main/java/com/groute/groute_server/record/adapter/in/web/ProjectController.java
@@ -49,6 +49,9 @@ public class ProjectController {
                 responseCode = "400",
                 description = "유효하지 않은 입력값"),
         @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                responseCode = "401",
+                description = "미인증 또는 만료된 액세스 토큰"),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(
                 responseCode = "409",
                 description = "이미 존재하는 태그 이름")
     })
@@ -67,7 +70,10 @@ public class ProjectController {
                 description = "조회 성공"),
         @io.swagger.v3.oas.annotations.responses.ApiResponse(
                 responseCode = "400",
-                description = "유효하지 않은 page/size 입력값")
+                description = "유효하지 않은 page/size 입력값"),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                responseCode = "401",
+                description = "미인증 또는 만료된 액세스 토큰")
     })
     @GetMapping
     public ApiResponse<ProjectsResponse> getProjects(
@@ -86,6 +92,9 @@ public class ProjectController {
         @io.swagger.v3.oas.annotations.responses.ApiResponse(
                 responseCode = "400",
                 description = "유효하지 않은 입력값"),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                responseCode = "401",
+                description = "미인증 또는 만료된 액세스 토큰"),
         @io.swagger.v3.oas.annotations.responses.ApiResponse(
                 responseCode = "404",
                 description = "프로젝트 태그를 찾을 수 없음"),
@@ -107,6 +116,9 @@ public class ProjectController {
         @io.swagger.v3.oas.annotations.responses.ApiResponse(
                 responseCode = "200",
                 description = "삭제 성공"),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                responseCode = "401",
+                description = "미인증 또는 만료된 액세스 토큰"),
         @io.swagger.v3.oas.annotations.responses.ApiResponse(
                 responseCode = "404",
                 description = "프로젝트 태그를 찾을 수 없음"),

--- a/src/main/java/com/groute/groute_server/record/adapter/in/web/StarRecordController.java
+++ b/src/main/java/com/groute/groute_server/record/adapter/in/web/StarRecordController.java
@@ -80,6 +80,9 @@ public class StarRecordController {
                 responseCode = "400",
                 description = "중복 scrumId 또는 빈 목록"),
         @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                responseCode = "401",
+                description = "미인증 또는 만료된 액세스 토큰"),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(
                 responseCode = "404",
                 description = "스크럼을 찾을 수 없음 (미존재 또는 타인 소유)"),
         @io.swagger.v3.oas.annotations.responses.ApiResponse(

--- a/src/main/java/com/groute/groute_server/user/controller/OnboardingController.java
+++ b/src/main/java/com/groute/groute_server/user/controller/OnboardingController.java
@@ -36,9 +36,14 @@ public class OnboardingController {
     private final UserProperties userProperties;
 
     @Operation(summary = "온보딩 완료 여부 조회", description = "로그인한 유저의 온보딩 완료 여부를 반환한다.")
-    @io.swagger.v3.oas.annotations.responses.ApiResponse(
-            responseCode = "200",
-            description = "조회 성공")
+    @ApiResponses({
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                responseCode = "200",
+                description = "조회 성공"),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                responseCode = "401",
+                description = "미인증 또는 만료된 액세스 토큰")
+    })
     @GetMapping("/status")
     public ApiResponse<OnboardingStatusResponse> getOnboardingStatus(@CurrentUser Long userId) {
         return ApiResponse.ok(


### PR DESCRIPTION
## 요약
- grep으로 전체 컨트롤러 현황 파악 후 인증 필요 엔드포인트에 누락된 401 응답 코드를 일괄 보강

## 변경 사항
- [ ] 기능
- [ ] 버그 수정
- [ ] 리팩토링
- [x] 문서
- [ ] 테스트
- [ ] 기타

## 롤백/리스크
- 리스크 포인트: Swagger 문서 변경만이므로 런타임 리스크 없음
- 롤백 방법: 브랜치 revert

## 관련 이슈
Closes #200 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Documentation**
  * API 엔드포인트 문서에 미인증 또는 만료된 액세스 토큰에 대한 401 응답 코드가 추가되어 API 문서의 명확성이 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->