### PR TITLE
feat: Scrum·StarRecord.create() 멀티테넌시 경계 교차 사용자 검증 추가 (#202)

### DIFF
--- a/src/main/java/com/groute/groute_server/common/exception/ErrorCode.java
+++ b/src/main/java/com/groute/groute_server/common/exception/ErrorCode.java
@@ -60,6 +60,8 @@ public enum ErrorCode {
     STAR_WRITE_LOCKED(HttpStatus.CONFLICT, "RECORD_010", "이미 완료된 심화기록은 수정할 수 없어요."),
     STAR_IMAGE_LIMIT_EXCEEDED(HttpStatus.BAD_REQUEST, "RECORD_011", "이미지는 최대 2장까지 첨부할 수 있어요."),
     STAR_IMAGE_NOT_FOUND(HttpStatus.NOT_FOUND, "RECORD_012", "이미지를 찾을 수 없습니다."),
+    DOMAIN_OWNER_MISMATCH(
+            HttpStatus.INTERNAL_SERVER_ERROR, "RECORD_013", "도메인 객체의 소유자가 일치하지 않습니다."),
 
     // Record - StarRecord
     STAR_RECORD_NOT_FOUND(HttpStatus.NOT_FOUND, "REC_001", "STAR 기록을 찾을 수 없습니다."),

--- a/src/main/java/com/groute/groute_server/common/exception/ErrorCode.java
+++ b/src/main/java/com/groute/groute_server/common/exception/ErrorCode.java
@@ -60,8 +60,7 @@ public enum ErrorCode {
     STAR_WRITE_LOCKED(HttpStatus.CONFLICT, "RECORD_010", "이미 완료된 심화기록은 수정할 수 없어요."),
     STAR_IMAGE_LIMIT_EXCEEDED(HttpStatus.BAD_REQUEST, "RECORD_011", "이미지는 최대 2장까지 첨부할 수 있어요."),
     STAR_IMAGE_NOT_FOUND(HttpStatus.NOT_FOUND, "RECORD_012", "이미지를 찾을 수 없습니다."),
-    DOMAIN_OWNER_MISMATCH(
-            HttpStatus.INTERNAL_SERVER_ERROR, "RECORD_013", "도메인 객체의 소유자가 일치하지 않습니다."),
+    DOMAIN_OWNER_MISMATCH(HttpStatus.FORBIDDEN, "RECORD_013", "도메인 객체의 소유자가 일치하지 않습니다."),
 
     // Record - StarRecord
     STAR_RECORD_NOT_FOUND(HttpStatus.NOT_FOUND, "REC_001", "STAR 기록을 찾을 수 없습니다."),

--- a/src/main/java/com/groute/groute_server/record/domain/Scrum.java
+++ b/src/main/java/com/groute/groute_server/record/domain/Scrum.java
@@ -6,6 +6,8 @@ import java.util.Objects;
 import jakarta.persistence.*;
 
 import com.groute.groute_server.common.entity.SoftDeleteEntity;
+import com.groute.groute_server.common.exception.BusinessException;
+import com.groute.groute_server.common.exception.ErrorCode;
 import com.groute.groute_server.record.domain.enums.CompetencyCategory;
 import com.groute.groute_server.user.entity.User;
 
@@ -59,9 +61,14 @@ public class Scrum extends SoftDeleteEntity {
 
     /** 신규 스크럼 팩토리. {@code hasStar}는 false, {@code selectedCompetency}는 NULL로 초기화한다. */
     public static Scrum create(User user, ScrumTitle title, String content, LocalDate scrumDate) {
+        Objects.requireNonNull(user, "user");
+        Objects.requireNonNull(title, "title");
+        if (!user.getId().equals(title.getUser().getId())) {
+            throw new BusinessException(ErrorCode.DOMAIN_OWNER_MISMATCH);
+        }
         Scrum scrum = new Scrum();
-        scrum.user = Objects.requireNonNull(user, "user");
-        scrum.title = Objects.requireNonNull(title, "title");
+        scrum.user = user;
+        scrum.title = title;
         scrum.content = Objects.requireNonNull(content, "content");
         scrum.scrumDate = Objects.requireNonNull(scrumDate, "scrumDate");
         return scrum;

--- a/src/main/java/com/groute/groute_server/record/domain/Scrum.java
+++ b/src/main/java/com/groute/groute_server/record/domain/Scrum.java
@@ -63,7 +63,11 @@ public class Scrum extends SoftDeleteEntity {
     public static Scrum create(User user, ScrumTitle title, String content, LocalDate scrumDate) {
         Objects.requireNonNull(user, "user");
         Objects.requireNonNull(title, "title");
-        if (!user.getId().equals(title.getUser().getId())) {
+        User titleOwner = title.getUser();
+        if (titleOwner == null
+                || user.getId() == null
+                || titleOwner.getId() == null
+                || !user.getId().equals(titleOwner.getId())) {
             throw new BusinessException(ErrorCode.DOMAIN_OWNER_MISMATCH);
         }
         Scrum scrum = new Scrum();

--- a/src/main/java/com/groute/groute_server/record/domain/StarRecord.java
+++ b/src/main/java/com/groute/groute_server/record/domain/StarRecord.java
@@ -6,6 +6,8 @@ import java.util.Objects;
 import jakarta.persistence.*;
 
 import com.groute.groute_server.common.entity.SoftDeleteEntity;
+import com.groute.groute_server.common.exception.BusinessException;
+import com.groute.groute_server.common.exception.ErrorCode;
 import com.groute.groute_server.record.domain.enums.StarRecordStatus;
 import com.groute.groute_server.record.domain.enums.StarStep;
 import com.groute.groute_server.user.entity.User;
@@ -70,9 +72,14 @@ public class StarRecord extends SoftDeleteEntity {
 
     /** 신규 StarRecord 팩토리. currentStep=ST, status=WRITING으로 초기화된다. */
     public static StarRecord create(User user, Scrum scrum) {
+        Objects.requireNonNull(user, "user");
+        Objects.requireNonNull(scrum, "scrum");
+        if (!user.getId().equals(scrum.getUser().getId())) {
+            throw new BusinessException(ErrorCode.DOMAIN_OWNER_MISMATCH);
+        }
         StarRecord record = new StarRecord();
-        record.user = Objects.requireNonNull(user, "user");
-        record.scrum = Objects.requireNonNull(scrum, "scrum");
+        record.user = user;
+        record.scrum = scrum;
         return record;
     }
 

--- a/src/main/java/com/groute/groute_server/record/domain/StarRecord.java
+++ b/src/main/java/com/groute/groute_server/record/domain/StarRecord.java
@@ -74,7 +74,11 @@ public class StarRecord extends SoftDeleteEntity {
     public static StarRecord create(User user, Scrum scrum) {
         Objects.requireNonNull(user, "user");
         Objects.requireNonNull(scrum, "scrum");
-        if (!user.getId().equals(scrum.getUser().getId())) {
+        User scrumOwner = scrum.getUser();
+        if (scrumOwner == null
+                || user.getId() == null
+                || scrumOwner.getId() == null
+                || !user.getId().equals(scrumOwner.getId())) {
             throw new BusinessException(ErrorCode.DOMAIN_OWNER_MISMATCH);
         }
         StarRecord record = new StarRecord();

--- a/src/test/java/com/groute/groute_server/record/application/service/BulkCreateStarRecordServiceTest.java
+++ b/src/test/java/com/groute/groute_server/record/application/service/BulkCreateStarRecordServiceTest.java
@@ -128,8 +128,9 @@ class BulkCreateStarRecordServiceTest {
             Scrum scrum = scrum(10L);
             given(scrumQueryPort.findAllByIdInAndUserId(List.of(10L), USER_ID))
                     .willReturn(List.of(scrum));
-            given(userReferencePort.getReferenceById(USER_ID))
-                    .willReturn(User.createForSocialLogin());
+            User stubUser = User.createForSocialLogin();
+            ReflectionTestUtils.setField(stubUser, "id", USER_ID);
+            given(userReferencePort.getReferenceById(USER_ID)).willReturn(stubUser);
             given(starRecordWritePort.save(any())).willReturn(starRecord(100L));
 
             BulkCreateStarRecordResult result = service.bulkCreate(command(List.of(10L)));
@@ -145,8 +146,9 @@ class BulkCreateStarRecordServiceTest {
             Scrum scrum20 = scrum(20L);
             given(scrumQueryPort.findAllByIdInAndUserId(List.of(10L, 20L), USER_ID))
                     .willReturn(List.of(scrum10, scrum20));
-            given(userReferencePort.getReferenceById(USER_ID))
-                    .willReturn(User.createForSocialLogin());
+            User stubUser = User.createForSocialLogin();
+            ReflectionTestUtils.setField(stubUser, "id", USER_ID);
+            given(userReferencePort.getReferenceById(USER_ID)).willReturn(stubUser);
             given(starRecordWritePort.save(any()))
                     .willReturn(starRecord(100L))
                     .willReturn(starRecord(101L));
@@ -168,13 +170,21 @@ class BulkCreateStarRecordServiceTest {
     }
 
     private static Scrum scrum(Long id, LocalDate date) {
-        Scrum scrum = Scrum.create(User.createForSocialLogin(), new ScrumTitle(), "내용", date);
+        User user = User.createForSocialLogin();
+        ReflectionTestUtils.setField(user, "id", 1L);
+        ScrumTitle title = new ScrumTitle();
+        ReflectionTestUtils.setField(title, "user", user);
+        Scrum scrum = Scrum.create(user, title, "내용", date);
         ReflectionTestUtils.setField(scrum, "id", id);
         return scrum;
     }
 
     private static StarRecord starRecord(Long id) {
-        StarRecord record = StarRecord.create(User.createForSocialLogin(), new Scrum());
+        User user = User.createForSocialLogin();
+        ReflectionTestUtils.setField(user, "id", 1L);
+        Scrum scrum = new Scrum();
+        ReflectionTestUtils.setField(scrum, "user", user);
+        StarRecord record = StarRecord.create(user, scrum);
         ReflectionTestUtils.setField(record, "id", id);
         return record;
     }

--- a/src/test/java/com/groute/groute_server/record/application/service/CalendarQueryServiceTest.java
+++ b/src/test/java/com/groute/groute_server/record/application/service/CalendarQueryServiceTest.java
@@ -391,7 +391,10 @@ class CalendarQueryServiceTest {
             String content,
             boolean hasStar,
             LocalDate createdLocalDate) {
-        Scrum scrum = Scrum.create(User.createForSocialLogin(), title, content, DATE);
+        User user = User.createForSocialLogin();
+        ReflectionTestUtils.setField(user, "id", USER_ID);
+        ReflectionTestUtils.setField(title, "user", user);
+        Scrum scrum = Scrum.create(user, title, content, DATE);
         ReflectionTestUtils.setField(scrum, "id", id);
         ReflectionTestUtils.setField(scrum, "hasStar", hasStar);
         OffsetDateTime createdAt =

--- a/src/test/java/com/groute/groute_server/record/application/service/ConfirmStarImageServiceTest.java
+++ b/src/test/java/com/groute/groute_server/record/application/service/ConfirmStarImageServiceTest.java
@@ -62,6 +62,7 @@ class ConfirmStarImageServiceTest {
 
         ScrumTitle title = new ScrumTitle();
         ReflectionTestUtils.setField(title, "id", 20L);
+        ReflectionTestUtils.setField(title, "user", owner);
 
         Scrum scrum = Scrum.create(owner, title, "스크럼 내용", LocalDate.of(2026, 5, 12));
         ReflectionTestUtils.setField(scrum, "id", 50L);

--- a/src/test/java/com/groute/groute_server/record/application/service/DeleteScrumServiceTest.java
+++ b/src/test/java/com/groute/groute_server/record/application/service/DeleteScrumServiceTest.java
@@ -161,12 +161,10 @@ class DeleteScrumServiceTest {
     }
 
     private static Scrum scrum(Long id, ScrumTitle title, boolean hasStar) {
-        Scrum scrum =
-                Scrum.create(
-                        User.createForSocialLogin(),
-                        title,
-                        "content",
-                        java.time.LocalDate.of(2026, 5, 4));
+        User user = User.createForSocialLogin();
+        ReflectionTestUtils.setField(user, "id", USER_ID);
+        ReflectionTestUtils.setField(title, "user", user);
+        Scrum scrum = Scrum.create(user, title, "content", java.time.LocalDate.of(2026, 5, 4));
         ReflectionTestUtils.setField(scrum, "id", id);
         ReflectionTestUtils.setField(scrum, "hasStar", hasStar);
         return scrum;

--- a/src/test/java/com/groute/groute_server/record/application/service/DeleteScrumTitleServiceTest.java
+++ b/src/test/java/com/groute/groute_server/record/application/service/DeleteScrumTitleServiceTest.java
@@ -186,9 +186,10 @@ class DeleteScrumTitleServiceTest {
     }
 
     private static Scrum scrum(Long id, ScrumTitle title, boolean hasStar) {
-        Scrum scrum =
-                Scrum.create(
-                        User.createForSocialLogin(), title, "content", LocalDate.of(2026, 5, 23));
+        User user = User.createForSocialLogin();
+        ReflectionTestUtils.setField(user, "id", USER_ID);
+        ReflectionTestUtils.setField(title, "user", user);
+        Scrum scrum = Scrum.create(user, title, "content", LocalDate.of(2026, 5, 23));
         ReflectionTestUtils.setField(scrum, "id", id);
         ReflectionTestUtils.setField(scrum, "hasStar", hasStar);
         return scrum;

--- a/src/test/java/com/groute/groute_server/record/application/service/DeleteStarImageServiceTest.java
+++ b/src/test/java/com/groute/groute_server/record/application/service/DeleteStarImageServiceTest.java
@@ -62,6 +62,7 @@ class DeleteStarImageServiceTest {
 
         ScrumTitle title = new ScrumTitle();
         ReflectionTestUtils.setField(title, "id", 20L);
+        ReflectionTestUtils.setField(title, "user", owner);
 
         Scrum scrum = Scrum.create(owner, title, "스크럼 내용", LocalDate.of(2026, 5, 12));
         ReflectionTestUtils.setField(scrum, "id", 50L);

--- a/src/test/java/com/groute/groute_server/record/application/service/QueryStarImagesServiceTest.java
+++ b/src/test/java/com/groute/groute_server/record/application/service/QueryStarImagesServiceTest.java
@@ -51,6 +51,7 @@ class QueryStarImagesServiceTest {
 
         ScrumTitle title = new ScrumTitle();
         ReflectionTestUtils.setField(title, "id", 20L);
+        ReflectionTestUtils.setField(title, "user", owner);
 
         Scrum scrum = Scrum.create(owner, title, "스크럼 내용", LocalDate.of(2026, 5, 12));
         ReflectionTestUtils.setField(scrum, "id", 50L);

--- a/src/test/java/com/groute/groute_server/record/application/service/ScrumBulkWriteServiceTest.java
+++ b/src/test/java/com/groute/groute_server/record/application/service/ScrumBulkWriteServiceTest.java
@@ -85,8 +85,7 @@ class ScrumBulkWriteServiceTest {
             given(scrumQueryPort.findAllByUserAndDate(USER_ID, DATE)).willReturn(List.of(existing));
             given(projectPort.findByIdAndUserId(100L, USER_ID))
                     .willReturn(Optional.of(project(100L, "프로젝트A")));
-            given(userReferencePort.getReferenceById(USER_ID))
-                    .willReturn(User.createForSocialLogin());
+            given(userReferencePort.getReferenceById(USER_ID)).willReturn(userRef());
             stubSaveTitles();
             stubSaveScrums();
 
@@ -151,8 +150,7 @@ class ScrumBulkWriteServiceTest {
         void should_returnCorrectResult_when_singleGroupSingleScrum() {
             Project project = project(100L, "프로젝트A");
             given(projectPort.findByIdAndUserId(100L, USER_ID)).willReturn(Optional.of(project));
-            given(userReferencePort.getReferenceById(USER_ID))
-                    .willReturn(User.createForSocialLogin());
+            given(userReferencePort.getReferenceById(USER_ID)).willReturn(userRef());
             stubSaveTitles();
             stubSaveScrums();
 
@@ -172,8 +170,7 @@ class ScrumBulkWriteServiceTest {
         void should_saveScrums_when_exactly5Scrums() {
             given(projectPort.findByIdAndUserId(anyLong(), anyLong()))
                     .willReturn(Optional.of(project(100L, "프로젝트A")));
-            given(userReferencePort.getReferenceById(USER_ID))
-                    .willReturn(User.createForSocialLogin());
+            given(userReferencePort.getReferenceById(USER_ID)).willReturn(userRef());
             stubSaveTitles();
             stubSaveScrums();
 
@@ -190,8 +187,7 @@ class ScrumBulkWriteServiceTest {
                     .willReturn(Optional.of(project(100L, "프로젝트A")));
             given(projectPort.findByIdAndUserId(101L, USER_ID))
                     .willReturn(Optional.of(project(101L, "프로젝트B")));
-            given(userReferencePort.getReferenceById(USER_ID))
-                    .willReturn(User.createForSocialLogin());
+            given(userReferencePort.getReferenceById(USER_ID)).willReturn(userRef());
             stubSaveTitles();
             stubSaveScrums();
 
@@ -206,8 +202,7 @@ class ScrumBulkWriteServiceTest {
         void should_incrementTitleCountByTwo_when_sameProjectInTwoGroups() {
             given(projectPort.findByIdAndUserId(anyLong(), anyLong()))
                     .willReturn(Optional.of(project(100L, "프로젝트A")));
-            given(userReferencePort.getReferenceById(USER_ID))
-                    .willReturn(User.createForSocialLogin());
+            given(userReferencePort.getReferenceById(USER_ID)).willReturn(userRef());
             stubSaveTitles();
             stubSaveScrums();
 
@@ -223,8 +218,7 @@ class ScrumBulkWriteServiceTest {
                     .willReturn(Optional.of(project(100L, "P1")));
             given(projectPort.findByIdAndUserId(101L, USER_ID))
                     .willReturn(Optional.of(project(101L, "P2")));
-            given(userReferencePort.getReferenceById(USER_ID))
-                    .willReturn(User.createForSocialLogin());
+            given(userReferencePort.getReferenceById(USER_ID)).willReturn(userRef());
             stubSaveTitles();
             stubSaveScrums();
 
@@ -250,8 +244,7 @@ class ScrumBulkWriteServiceTest {
         void should_recordStreak_when_writeSucceeds() {
             given(projectPort.findByIdAndUserId(100L, USER_ID))
                     .willReturn(Optional.of(project(100L, "프로젝트A")));
-            given(userReferencePort.getReferenceById(USER_ID))
-                    .willReturn(User.createForSocialLogin());
+            given(userReferencePort.getReferenceById(USER_ID)).willReturn(userRef());
             stubSaveTitles();
             stubSaveScrums();
 
@@ -308,6 +301,12 @@ class ScrumBulkWriteServiceTest {
         ReflectionTestUtils.setField(scrum, "id", scrumId);
         ReflectionTestUtils.setField(scrum, "title", title);
         return scrum;
+    }
+
+    private static User userRef() {
+        User user = User.createForSocialLogin();
+        ReflectionTestUtils.setField(user, "id", USER_ID);
+        return user;
     }
 
     private static Project project(Long id, String name) {

--- a/src/test/java/com/groute/groute_server/record/application/service/ScrumCompetencyUpdateServiceTest.java
+++ b/src/test/java/com/groute/groute_server/record/application/service/ScrumCompetencyUpdateServiceTest.java
@@ -183,12 +183,11 @@ class ScrumCompetencyUpdateServiceTest {
     }
 
     private static Scrum scrum(Long id) {
-        Scrum scrum =
-                Scrum.create(
-                        User.createForSocialLogin(),
-                        new ScrumTitle(),
-                        "내용",
-                        LocalDate.of(2026, 5, 9));
+        User user = User.createForSocialLogin();
+        ReflectionTestUtils.setField(user, "id", USER_ID);
+        ScrumTitle title = new ScrumTitle();
+        ReflectionTestUtils.setField(title, "user", user);
+        Scrum scrum = Scrum.create(user, title, "내용", LocalDate.of(2026, 5, 9));
         ReflectionTestUtils.setField(scrum, "id", id);
         return scrum;
     }

--- a/src/test/java/com/groute/groute_server/record/application/service/ScrumSyncServiceTest.java
+++ b/src/test/java/com/groute/groute_server/record/application/service/ScrumSyncServiceTest.java
@@ -161,8 +161,9 @@ class ScrumSyncServiceTest {
             given(scrumQueryPort.findAllByIdInAndUserId(anyCollection(), anyLong()))
                     .willReturn(List.of());
             given(scrumQueryPort.findAllByUserAndDate(USER_ID, DATE)).willReturn(List.of());
-            given(userReferencePort.getReferenceById(USER_ID))
-                    .willReturn(User.createForSocialLogin());
+            User stubUser = User.createForSocialLogin();
+            ReflectionTestUtils.setField(stubUser, "id", USER_ID);
+            given(userReferencePort.getReferenceById(USER_ID)).willReturn(stubUser);
             SyncDailyScrumCommand command = command(group(1L, item(null, "신규")));
 
             // when
@@ -340,8 +341,9 @@ class ScrumSyncServiceTest {
             given(scrumQueryPort.findAllByIdInAndUserId(anyCollection(), anyLong()))
                     .willReturn(List.of(a));
             given(scrumQueryPort.findAllByUserAndDate(USER_ID, DATE)).willReturn(List.of(a, b));
-            given(userReferencePort.getReferenceById(USER_ID))
-                    .willReturn(User.createForSocialLogin());
+            User stubUser = User.createForSocialLogin();
+            ReflectionTestUtils.setField(stubUser, "id", USER_ID);
+            given(userReferencePort.getReferenceById(USER_ID)).willReturn(stubUser);
             SyncDailyScrumCommand command =
                     command(
                             group(1L, item(100L, "A_new")),
@@ -376,8 +378,9 @@ class ScrumSyncServiceTest {
             given(scrumQueryPort.findAllByIdInAndUserId(anyCollection(), anyLong()))
                     .willReturn(List.of());
             given(scrumQueryPort.findAllByUserAndDate(USER_ID, DATE)).willReturn(List.of());
-            given(userReferencePort.getReferenceById(USER_ID))
-                    .willReturn(User.createForSocialLogin());
+            User stubUser = User.createForSocialLogin();
+            ReflectionTestUtils.setField(stubUser, "id", USER_ID);
+            given(userReferencePort.getReferenceById(USER_ID)).willReturn(stubUser);
             SyncDailyScrumCommand command = command(group(1L, item(null, "신규")));
 
             // when
@@ -494,9 +497,12 @@ class ScrumSyncServiceTest {
     }
 
     private static ScrumTitle title(Long id, String projectName, String freeText) {
+        User user = User.createForSocialLogin();
+        ReflectionTestUtils.setField(user, "id", USER_ID);
         Project project = Project.builder().id(1000L + id).name(projectName).build();
         ScrumTitle title = new ScrumTitle();
         ReflectionTestUtils.setField(title, "id", id);
+        ReflectionTestUtils.setField(title, "user", user);
         ReflectionTestUtils.setField(title, "project", project);
         ReflectionTestUtils.setField(title, "freeText", freeText);
         return title;
@@ -508,7 +514,10 @@ class ScrumSyncServiceTest {
             String content,
             boolean hasStar,
             LocalDate createdLocalDate) {
-        Scrum scrum = Scrum.create(User.createForSocialLogin(), title, content, DATE);
+        User user = User.createForSocialLogin();
+        ReflectionTestUtils.setField(user, "id", USER_ID);
+        ReflectionTestUtils.setField(title, "user", user);
+        Scrum scrum = Scrum.create(user, title, content, DATE);
         ReflectionTestUtils.setField(scrum, "id", id);
         ReflectionTestUtils.setField(scrum, "hasStar", hasStar);
         OffsetDateTime createdAt =

--- a/src/test/java/com/groute/groute_server/record/application/service/UpdateStarRecordStepServiceTest.java
+++ b/src/test/java/com/groute/groute_server/record/application/service/UpdateStarRecordStepServiceTest.java
@@ -68,6 +68,7 @@ class UpdateStarRecordStepServiceTest {
 
         ScrumTitle title = new ScrumTitle();
         ReflectionTestUtils.setField(title, "id", 10L);
+        ReflectionTestUtils.setField(title, "user", owner);
 
         scrum = Scrum.create(owner, title, "내용", DATE);
         ReflectionTestUtils.setField(scrum, "id", 50L);
@@ -96,7 +97,10 @@ class UpdateStarRecordStepServiceTest {
         void should_throwForbidden_when_notOwner() {
             User anotherUser = User.createForSocialLogin();
             ReflectionTestUtils.setField(anotherUser, "id", ANOTHER_USER_ID);
-            StarRecord otherRecord = StarRecord.create(anotherUser, scrum);
+            ScrumTitle anotherTitle = new ScrumTitle();
+            ReflectionTestUtils.setField(anotherTitle, "user", anotherUser);
+            Scrum anotherScrum = Scrum.create(anotherUser, anotherTitle, "내용", DATE);
+            StarRecord otherRecord = StarRecord.create(anotherUser, anotherScrum);
             given(starRecordRepositoryPort.findByIdWithScrum(STAR_ID))
                     .willReturn(Optional.of(otherRecord));
 

--- a/src/test/java/com/groute/groute_server/record/application/service/UploadStarImageServiceTest.java
+++ b/src/test/java/com/groute/groute_server/record/application/service/UploadStarImageServiceTest.java
@@ -64,6 +64,7 @@ class UploadStarImageServiceTest {
 
         ScrumTitle title = new ScrumTitle();
         ReflectionTestUtils.setField(title, "id", 20L);
+        ReflectionTestUtils.setField(title, "user", owner);
 
         Scrum scrum = Scrum.create(owner, title, "스크럼 내용", LocalDate.of(2026, 5, 12));
         ReflectionTestUtils.setField(scrum, "id", 50L);

--- a/src/test/java/com/groute/groute_server/record/domain/ScrumTest.java
+++ b/src/test/java/com/groute/groute_server/record/domain/ScrumTest.java
@@ -1,0 +1,48 @@
+package com.groute.groute_server.record.domain;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.time.LocalDate;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import com.groute.groute_server.common.exception.BusinessException;
+import com.groute.groute_server.common.exception.ErrorCode;
+import com.groute.groute_server.user.entity.User;
+
+class ScrumTest {
+
+    @Test
+    @DisplayName("title 소유자가 다른 user이면 DOMAIN_OWNER_MISMATCH 예외가 발생한다")
+    void should_throw_when_title_belongs_to_other_user() {
+        User owner = User.createForSocialLogin();
+        ReflectionTestUtils.setField(owner, "id", 1L);
+
+        User other = User.createForSocialLogin();
+        ReflectionTestUtils.setField(other, "id", 2L);
+
+        ScrumTitle title = new ScrumTitle();
+        ReflectionTestUtils.setField(title, "user", other);
+
+        assertThatThrownBy(() -> Scrum.create(owner, title, "내용", LocalDate.of(2026, 5, 31)))
+                .isInstanceOf(BusinessException.class)
+                .extracting(e -> ((BusinessException) e).getErrorCode())
+                .isEqualTo(ErrorCode.DOMAIN_OWNER_MISMATCH);
+    }
+
+    @Test
+    @DisplayName("title 소유자와 user가 같으면 정상 생성된다")
+    void should_create_when_owner_matches() {
+        User owner = User.createForSocialLogin();
+        ReflectionTestUtils.setField(owner, "id", 1L);
+
+        ScrumTitle title = new ScrumTitle();
+        ReflectionTestUtils.setField(title, "user", owner);
+
+        Scrum scrum = Scrum.create(owner, title, "내용", LocalDate.of(2026, 5, 31));
+
+        assert scrum != null;
+    }
+}

--- a/src/test/java/com/groute/groute_server/record/domain/ScrumTest.java
+++ b/src/test/java/com/groute/groute_server/record/domain/ScrumTest.java
@@ -1,5 +1,6 @@
 package com.groute.groute_server.record.domain;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.time.LocalDate;
@@ -43,6 +44,6 @@ class ScrumTest {
 
         Scrum scrum = Scrum.create(owner, title, "내용", LocalDate.of(2026, 5, 31));
 
-        assert scrum != null;
+        assertThat(scrum).isNotNull();
     }
 }

--- a/src/test/java/com/groute/groute_server/record/domain/StarRecordTest.java
+++ b/src/test/java/com/groute/groute_server/record/domain/StarRecordTest.java
@@ -1,5 +1,6 @@
 package com.groute.groute_server.record.domain;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import org.junit.jupiter.api.DisplayName;
@@ -41,6 +42,6 @@ class StarRecordTest {
 
         StarRecord record = StarRecord.create(owner, scrum);
 
-        assert record != null;
+        assertThat(record).isNotNull();
     }
 }

--- a/src/test/java/com/groute/groute_server/record/domain/StarRecordTest.java
+++ b/src/test/java/com/groute/groute_server/record/domain/StarRecordTest.java
@@ -1,0 +1,46 @@
+package com.groute.groute_server.record.domain;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import com.groute.groute_server.common.exception.BusinessException;
+import com.groute.groute_server.common.exception.ErrorCode;
+import com.groute.groute_server.user.entity.User;
+
+class StarRecordTest {
+
+    @Test
+    @DisplayName("scrum 소유자가 다른 user이면 DOMAIN_OWNER_MISMATCH 예외가 발생한다")
+    void should_throw_when_scrum_belongs_to_other_user() {
+        User owner = User.createForSocialLogin();
+        ReflectionTestUtils.setField(owner, "id", 1L);
+
+        User other = User.createForSocialLogin();
+        ReflectionTestUtils.setField(other, "id", 2L);
+
+        Scrum scrum = new Scrum();
+        ReflectionTestUtils.setField(scrum, "user", other);
+
+        assertThatThrownBy(() -> StarRecord.create(owner, scrum))
+                .isInstanceOf(BusinessException.class)
+                .extracting(e -> ((BusinessException) e).getErrorCode())
+                .isEqualTo(ErrorCode.DOMAIN_OWNER_MISMATCH);
+    }
+
+    @Test
+    @DisplayName("scrum 소유자와 user가 같으면 정상 생성된다")
+    void should_create_when_owner_matches() {
+        User owner = User.createForSocialLogin();
+        ReflectionTestUtils.setField(owner, "id", 1L);
+
+        Scrum scrum = new Scrum();
+        ReflectionTestUtils.setField(scrum, "user", owner);
+
+        StarRecord record = StarRecord.create(owner, scrum);
+
+        assert record != null;
+    }
+}


### PR DESCRIPTION
## 요약
- Scrum.create() / StarRecord.create() 팩토리에 교차 사용자 소유권 검증을 추가하여 멀티테넌시 경계 침해를 방지한다.

## 변경 사항
- [x] 기능
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 문서
- [x] 테스트
- [ ] 기타

## 테스트
- [x] 로컬 테스트 완료
- 테스트 방법:
    -  ./gradlew test

### 커버리지 (JaCoCo)
- 라인 커버리지: 67%  (기준: 60% 이상)
- [x] `./gradlew test` 실행 후 `build/reports/jacoco/index.html`에서 수치 확인

## 롤백/리스크
- 리스크 포인트: 없음 (서버 사이드 프로그래밍 오류에 해당하며, 정상 플로우에서는 절대 발생하지 않는 경로)
- 롤백 방법: 두 커밋 revert

## 관련 이슈
Closes #202 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 스크럼 및 스타 레코드 생성 시 소유자 검증 로직을 강화하여, 권한이 없는 사용자의 작업을 방지합니다.

* **테스트**
  * 소유자 검증 시나리오에 대한 테스트를 추가하여 데이터 무결성을 보장합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->