### PR TITLE
fix: 리포트 생성/재시도 시 Scrum fetch join 누락으로 FAILED 되는 버그 수정

### DIFF
--- a/src/main/java/com/groute/groute_server/report/adapter/out/persistence/StarRecordForReportJpaRepository.java
+++ b/src/main/java/com/groute/groute_server/report/adapter/out/persistence/StarRecordForReportJpaRepository.java
@@ -54,6 +54,7 @@ public interface StarRecordForReportJpaRepository extends JpaRepository<StarReco
     /** 심화기록 ID 목록으로 심화기록을 조회한다. userId로 소유권을 함께 검증한다. */
     @Query(
             "SELECT sr FROM StarRecord sr "
+                    + "JOIN FETCH sr.scrum s "
                     + "WHERE sr.user.id = :userId "
                     + "AND sr.id IN :ids "
                     + "AND sr.isDeleted = false")


### PR DESCRIPTION
## 요약
- findAllByIds 쿼리에 JOIN FETCH sr.scrum이 없어서 StarRecord 조회 시 Scrum이 lazy 상태로 로드됨. 트랜잭션 커밋 후 AI 호출 시점에 세션이 끊겨 scrum.getSelectedCompetency() 접근 시 에러 발생 → 리포트 생성/재시도 모두 FAILED.

## 상세내용
리포트 생성(createReport)과 재시도(retryReport) 모두 findAllByIds를 사용하는데, 해당 쿼리에 Scrum fetch join이 없었음. AI 요청 객체 빌드 중 toStarRecordItem에서 scrum.getSelectedCompetency() 접근 시 LazyInitializationException 발생.

## 변경 사항
- [ ] 기능
- [x] 버그 수정
- [ ] 리팩토링
- [ ] 문서
- [ ] 테스트
- [ ] 기타

## 테스트
- [x] 로컬 테스트 완료
- 테스트 방법:
    - ./gradlew check

### 커버리지 (JaCoCo)


## 스크린샷/로그 (선택)
- 필요한 경우 첨부

## 롤백/리스크
- 리스크 포인트:
- 롤백 방법:

## 관련 이슈
Closes #206 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **성능 개선**
  * 데이터 조회 성능을 최적화하여 시스템 응답 속도가 향상되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->