### PR TITLE
fix: 리포트 생성 시 Scrum·User fetch join 누락으로 FAILED 되는 버그 수정

### DIFF
--- a/src/main/java/com/groute/groute_server/report/adapter/out/persistence/StarRecordForReportJpaRepository.java
+++ b/src/main/java/com/groute/groute_server/report/adapter/out/persistence/StarRecordForReportJpaRepository.java
@@ -54,6 +54,7 @@ public interface StarRecordForReportJpaRepository extends JpaRepository<StarReco
     /** 심화기록 ID 목록으로 심화기록을 조회한다. userId로 소유권을 함께 검증한다. */
     @Query(
             "SELECT sr FROM StarRecord sr "
+                    + "JOIN FETCH sr.scrum s "
                     + "WHERE sr.user.id = :userId "
                     + "AND sr.id IN :ids "
                     + "AND sr.isDeleted = false")

--- a/src/main/java/com/groute/groute_server/report/adapter/out/persistence/StarRecordForReportJpaRepository.java
+++ b/src/main/java/com/groute/groute_server/report/adapter/out/persistence/StarRecordForReportJpaRepository.java
@@ -55,6 +55,7 @@ public interface StarRecordForReportJpaRepository extends JpaRepository<StarReco
     @Query(
             "SELECT sr FROM StarRecord sr "
                     + "JOIN FETCH sr.scrum s "
+                    + "JOIN FETCH sr.user u "
                     + "WHERE sr.user.id = :userId "
                     + "AND sr.id IN :ids "
                     + "AND sr.isDeleted = false")


### PR DESCRIPTION
## 요약
- findAllByIds 쿼리에 JOIN FETCH sr.scrum, JOIN FETCH sr.user 누락으로 트랜잭션 커밋 후 AI 요청 데이터 구성 중 LazyInitializationException 발생 → prod에서 리포트 생성/재시도 모두 FAILED

## 상세내용
prod 서버 로그에서 원인 확인. 트랜잭션 커밋 후 AI 호출 시점에 Scrum, User가 lazy proxy 상태로 남아있어 scrum.getSelectedCompetency(), user.getNickname() 등 접근 시 에러 발생

## 변경 사항
- [ ] 기능
- [x] 버그 수정
- [ ] 리팩토링
- [ ] 문서
- [ ] 테스트
- [ ] 기타

## 테스트
- [x] 로컬 테스트 완료
- 테스트 방법:
    - 예) ./gradlew check

### 커버리지 (JaCoCo)


## 스크린샷/로그 (선택)
- 필요한 경우 첨부

## 롤백/리스크
- 리스크 포인트:
- 롤백 방법:

## 관련 이슈
Closes #209 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **최적화**
  * 별표 기록 조회 시 데이터베이스 쿼리 성능을 개선했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->