### PR TITLE
chore: AiTaggingJob 페이로드 Javadoc에 JSON 키 명세 추가 (#218)

### DIFF
--- a/src/main/java/com/groute/groute_server/record/domain/AiTaggingJob.java
+++ b/src/main/java/com/groute/groute_server/record/domain/AiTaggingJob.java
@@ -42,12 +42,37 @@ public class AiTaggingJob extends BaseTimeEntity {
     @Column(name = "retry_count", nullable = false)
     private Short retryCount = 0;
 
-    /** 요청 페이로드 JSON: 직군 + 선택 역량 + S-T-A-R 텍스트(REC006). */
+    /**
+     * 요청 페이로드 JSON: 직군 + 선택 역량 + S-T-A-R 텍스트(REC006).
+     *
+     * <pre>
+     * {
+     *   "jobRole"            : String  — JobRole.name(),
+     *   "selectedCompetency" : String  — CompetencyCategory.name(), 미선택 시 빈 문자열,
+     *   "situationTask"      : String  — 상황/과제 텍스트,
+     *   "action"             : String  — 행동 텍스트,
+     *   "result"             : String  — 결과 텍스트
+     * }
+     * </pre>
+     *
+     * {@link com.groute.groute_server.record.adapter.out.ai.dto.AiTaggingRequest} 필드와 1:1 대응.
+     */
     @JdbcTypeCode(SqlTypes.JSON)
     @Column(name = "request_payload", columnDefinition = "jsonb")
     private Map<String, Object> requestPayload;
 
-    /** AI 응답 원문. {primary_category, detail_tags[]} JSON. 디버깅 및 모델 교체 대비용 원본 보관. */
+    /**
+     * AI 응답 페이로드 JSON. 디버깅 및 모델 교체 대비용 원본 보관(REC006).
+     *
+     * <pre>
+     * {
+     *   "primaryCategory" : String       — CompetencyCategory.name(),
+     *   "detailTags"      : List&lt;String&gt; — 세부 태그 목록
+     * }
+     * </pre>
+     *
+     * {@link com.groute.groute_server.record.adapter.out.ai.dto.AiTaggingResponse} 필드와 1:1 대응.
+     */
     @JdbcTypeCode(SqlTypes.JSON)
     @Column(name = "response_payload", columnDefinition = "jsonb")
     private Map<String, Object> responsePayload;


### PR DESCRIPTION
## 요약
- AiTaggingJob requestPayload·responsePayload Javadoc에 실제 JSON 키·타입을 명세하고, responsePayload의 snake_case 오기를 수정한다.

## 변경 사항
- [ ] 기능
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 문서
- [ ] 테스트
- [x] 기타

### 커버리지 (JaCoCo)
  - 라인 커버리지: 변동 없음 (Javadoc only)

## 롤백/리스크
- 리스크 포인트: 없음.
- 롤백 방법: 브랜치 삭제

## 관련 이슈
Closes #218 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 문서

* **Documentation**
  * AI 태깅 작업의 요청 및 응답 페이로드에 대한 문서화를 개선했습니다. JSON 구조와 필드 매핑에 대한 상세한 설명을 추가하여 개발자의 이해도를 높였습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->