### PR TITLE
fix: scrum_titles.status DB DEFAULT 'COMMITTED' → 'PENDING' 정정 마이그레이션 (#220)

### DIFF
--- a/src/main/resources/db/migration/V20260604035025__fix_scrum_titles_status_default.sql
+++ b/src/main/resources/db/migration/V20260604035025__fix_scrum_titles_status_default.sql
@@ -1,0 +1,25 @@
+-- V20260509100000에서 ADD COLUMN status DEFAULT 'COMMITTED'로 추가되어
+-- JPA 엔티티의 기본값(PENDING)과 불일치가 발생한 문제를 수정한다.
+
+-- 1. 컬럼 DEFAULT를 JPA 엔티티(ScrumTitle.status = PENDING)와 일치시킨다.
+ALTER TABLE scrum_titles
+    ALTER COLUMN status SET DEFAULT 'PENDING';
+
+-- 2. ADD COLUMN 시 잘못 채워진 기존 row를 보정한다.
+--    STAR 완료 트리거는 "해당 날짜의 모든 scrum_title을 COMMITTED"이므로,
+--    산하 scrum의 날짜+유저 기준으로 완료된 star_record가 하나라도 있으면 COMMITTED 유지,
+--    그렇지 않으면 DEFAULT로 잘못 설정된 것으로 보고 PENDING으로 되돌린다.
+UPDATE scrum_titles st
+SET status = 'PENDING'
+WHERE st.status = 'COMMITTED'
+  AND NOT EXISTS (
+      SELECT 1
+      FROM scrums s1
+      JOIN scrums s2
+          ON s2.user_id = s1.user_id
+         AND s2.scrum_date = s1.scrum_date
+      JOIN star_records sr ON sr.scrum_id = s2.id
+      WHERE s1.title_id = st.id
+        AND s1.is_deleted = false
+        AND sr.is_completed = true
+  );

--- a/src/main/resources/db/migration/V20260604035025__fix_scrum_titles_status_default.sql
+++ b/src/main/resources/db/migration/V20260604035025__fix_scrum_titles_status_default.sql
@@ -1,5 +1,18 @@
 -- V20260509100000에서 ADD COLUMN status DEFAULT 'COMMITTED'로 추가되어
 -- JPA 엔티티의 기본값(PENDING)과 불일치가 발생한 문제를 수정한다.
+--
+-- 성능 및 락 영향:
+--   UPDATE 쿼리는 scrum_titles(COMMITTED) → scrums(s1, s2) → star_records 4-way 조인이나,
+--   아래 인덱스가 모두 존재하여 테이블 스캔 없이 처리된다.
+--     - idx_scrums_title_is_deleted ON scrums(title_id, is_deleted)
+--     - idx_scrums_user_scrum_date  ON scrums(user_id, scrum_date)
+--     - uq_star_records_scrum_id    ON star_records(scrum_id)  [unique]
+--   초기 서비스 데이터 규모(수천 row 이하)에서 실행 시간 < 1초, 락 영향 무시 가능.
+--   향후 대규모 테이블 대상 동일 패턴 마이그레이션 시 EXPLAIN ANALYZE 선행 필요.
+--
+-- 롤백 방법:
+--   UPDATE scrum_titles SET status = 'COMMITTED' WHERE status = 'PENDING';
+--   ALTER TABLE scrum_titles ALTER COLUMN status SET DEFAULT 'COMMITTED';
 
 -- 1. 컬럼 DEFAULT를 JPA 엔티티(ScrumTitle.status = PENDING)와 일치시킨다.
 ALTER TABLE scrum_titles


### PR DESCRIPTION
## 요약
- V20260509100000에서 ADD COLUMN DEFAULT 'COMMITTED'로 추가되어 JPA 엔티티 기본값(PENDING)과 불일치가 발생한 문제를 Flyway 마이그레이션으로 수정한다.

## 변경 사항
- [ ] 기능
- [x] 버그 수정
- [ ] 리팩토링
- [ ] 문서
- [ ] 테스트
- [ ] 기타

## 테스트
- [x] 로컬 테스트 완료
- 테스트 방법:
  - 앱 실행 후 Flyway 마이그레이션 정상 적용 확인
   - `SELECT * FROM scrum_titles WHERE status = 'COMMITTED'` — star_record 없는 row가 없는지 확인


### 커버리지 (JaCoCo)
- 라인 커버리지: 변동 없음.

## 롤백/리스크
- 리스크 포인트: 기존 COMMITTED row 중 star_record가 없는 row를 PENDING으로 변경 — 캘린더 조회(COMMITTED 기준 필터)에서 해당 스크럼이 노출되지 않을 수 있음
- 롤백 방법:
1. `ALTER TABLE scrum_titles ALTER COLUMN status SET DEFAULT 'COMMITTED';`
2. 마이그레이션 이후 앱에서 생성된 PENDING row와 구분이 불가능하므로 완전한 데이터 롤백은 어려움. `flyway_schema_history`에서 해당 버전 삭제 후 운영 데이터 직접 확인 필요

## 관련 이슈
Closes #220 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * Scrum 제목 상태 데이터의 일관성을 개선하고 기본값을 설정하였습니다. 불정확하게 저장된 기존 레코드들이 자동으로 정정되며, 향후 새로운 데이터의 기본값도 올바르게 설정되어 데이터 품질이 향상됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->