### PR TITLE
chore: projects UNIQUE 인덱스를 부분 인덱스(WHERE is_deleted=false)로 전환 (#222)

### DIFF
--- a/src/main/resources/db/migration/V20260604041057__fix_projects_unique_index_partial.sql
+++ b/src/main/resources/db/migration/V20260604041057__fix_projects_unique_index_partial.sql
@@ -1,5 +1,11 @@
 -- (user_id, name, is_deleted) 전체를 unique key로 잡던 기존 인덱스를
 -- 활성 row(is_deleted=false)만 unique를 보장하는 부분 인덱스로 전환한다.
+--
+-- 롤백 방법:
+--   DROP INDEX uq_projects_user_name_active;
+--   CREATE UNIQUE INDEX uq_projects_user_name_is_deleted ON projects (user_id, name, is_deleted);
+--
+-- 주의: projects 테이블이 크다면 트래픽이 적은 시간대에 배포 권장 (SHARE 락 획득).
 
 DROP INDEX uq_projects_user_name_is_deleted;
 

--- a/src/main/resources/db/migration/V20260604041057__fix_projects_unique_index_partial.sql
+++ b/src/main/resources/db/migration/V20260604041057__fix_projects_unique_index_partial.sql
@@ -1,0 +1,8 @@
+-- (user_id, name, is_deleted) 전체를 unique key로 잡던 기존 인덱스를
+-- 활성 row(is_deleted=false)만 unique를 보장하는 부분 인덱스로 전환한다.
+
+DROP INDEX uq_projects_user_name_is_deleted;
+
+CREATE UNIQUE INDEX uq_projects_user_name_active
+    ON projects (user_id, name)
+    WHERE is_deleted = FALSE;


### PR DESCRIPTION
## 요약
- (user_id, name, is_deleted) 전체 unique 인덱스를 활성 row(is_deleted=false)만 unique를 보장하는 부분 인덱스로 교체한다.

## 변경 사항
- [ ] 기능
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 문서
- [ ] 테스트
- [x] 기타

## 테스트
- [x] 로컬 테스트 완료
- 테스트 방법:
   - 앱 실행 후 Flyway 마이그레이션 정상 적용 확인
   - 같은 이름의 활성 프로젝트 중복 생성 시 unique 위반 발생 확인
   - 논리 삭제 후 동일 이름으로 재생성 시 정상 생성 확인

### 커버리지 (JaCoCo)
- 라인 커버리지: 변동 없음.

## 롤백/리스크
- 리스크 포인트: 없음 (기존 데이터 변경 없이 인덱스만 교체)
- 롤백 방법: `CREATE UNIQUE INDEX uq_projects_user_name_is_deleted ON projects (user_id, name, is_deleted);`

## 관련 이슈
Closes #222 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Projects 테이블의 유니크 인덱스를 부분 인덱스로 변경했습니다. 이제 활성 상태의 레코드에 대해서만 사용자 및 프로젝트 이름 조합의 유니크 제약을 적용합니다. 소프트 삭제된 레코드는 이 제약의 대상에서 제외됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->