### PR TITLE
test: WebMvcTest 시범 도입 — AuthController·ReportController 인증·DTO validation 검증 (#224)

### DIFF
--- a/src/test/java/com/groute/groute_server/auth/controller/AuthControllerTest.java
+++ b/src/test/java/com/groute/groute_server/auth/controller/AuthControllerTest.java
@@ -1,0 +1,86 @@
+package com.groute.groute_server.auth.controller;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import jakarta.servlet.http.HttpServletResponse;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+
+import com.groute.groute_server.auth.dto.TokenResponse;
+import com.groute.groute_server.auth.service.AuthService;
+import com.groute.groute_server.auth.service.TokenDeliveryService;
+import com.groute.groute_server.support.WebMvcTestBase;
+
+@WebMvcTest(AuthController.class)
+class AuthControllerTest extends WebMvcTestBase {
+
+    @MockitoBean private AuthService authService;
+    @MockitoBean private TokenDeliveryService tokenDeliveryService;
+
+    private static final String REISSUE_URL = "/api/auth/reissue";
+    private static final String LOGOUT_URL = "/api/auth/logout";
+
+    @Nested
+    @DisplayName("POST /api/auth/reissue")
+    class Reissue {
+
+        @Test
+        @DisplayName("유효한 refreshToken 전달 시 200 반환")
+        void should_return200_when_validRefreshToken() throws Exception {
+            given(authService.reissue(anyString()))
+                    .willReturn(new TokenResponse("access-token", "refresh-token"));
+            given(tokenDeliveryService.deliver(
+                            any(HttpServletResponse.class), anyString(), anyString()))
+                    .willReturn(new TokenResponse("access-token", null));
+
+            mockMvc.perform(
+                            post(REISSUE_URL)
+                                    .contentType(MediaType.APPLICATION_JSON)
+                                    .content("{\"refreshToken\":\"valid-refresh-token\"}"))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.success").value(true));
+        }
+
+        @Test
+        @DisplayName("빈 refreshToken 전달 시 400 반환")
+        void should_return400_when_blankRefreshToken() throws Exception {
+            mockMvc.perform(
+                            post(REISSUE_URL)
+                                    .contentType(MediaType.APPLICATION_JSON)
+                                    .content("{\"refreshToken\":\"   \"}"))
+                    .andExpect(status().isBadRequest());
+        }
+    }
+
+    @Nested
+    @DisplayName("POST /api/auth/logout")
+    class Logout {
+
+        @Test
+        @DisplayName("인증된 사용자 로그아웃 시 200 반환")
+        void should_return200_when_authenticated() throws Exception {
+            mockMvc.perform(post(LOGOUT_URL).with(auth(1L)))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.success").value(true));
+
+            then(authService).should().logout(1L);
+        }
+
+        @Test
+        @DisplayName("미인증 요청 시 401 반환")
+        void should_return401_when_unauthenticated() throws Exception {
+            mockMvc.perform(post(LOGOUT_URL)).andExpect(status().isUnauthorized());
+        }
+    }
+}

--- a/src/test/java/com/groute/groute_server/auth/controller/AuthControllerTest.java
+++ b/src/test/java/com/groute/groute_server/auth/controller/AuthControllerTest.java
@@ -2,6 +2,7 @@ package com.groute.groute_server.auth.controller;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
@@ -51,6 +52,14 @@ class AuthControllerTest extends WebMvcTestBase {
                                     .content("{\"refreshToken\":\"valid-refresh-token\"}"))
                     .andExpect(status().isOk())
                     .andExpect(jsonPath("$.success").value(true));
+
+            then(authService).should().reissue("valid-refresh-token");
+            then(tokenDeliveryService)
+                    .should()
+                    .deliver(
+                            any(HttpServletResponse.class),
+                            eq("access-token"),
+                            eq("refresh-token"));
         }
 
         @Test

--- a/src/test/java/com/groute/groute_server/auth/controller/AuthControllerTest.java
+++ b/src/test/java/com/groute/groute_server/auth/controller/AuthControllerTest.java
@@ -40,8 +40,9 @@ class AuthControllerTest extends WebMvcTestBase {
         void should_return200_when_validRefreshToken() throws Exception {
             given(authService.reissue(anyString()))
                     .willReturn(new TokenResponse("access-token", "refresh-token"));
-            given(tokenDeliveryService.deliver(
-                            any(HttpServletResponse.class), anyString(), anyString()))
+            given(
+                            tokenDeliveryService.deliver(
+                                    any(HttpServletResponse.class), anyString(), anyString()))
                     .willReturn(new TokenResponse("access-token", null));
 
             mockMvc.perform(

--- a/src/test/java/com/groute/groute_server/report/adapter/in/web/ReportControllerTest.java
+++ b/src/test/java/com/groute/groute_server/report/adapter/in/web/ReportControllerTest.java
@@ -2,7 +2,9 @@ package com.groute.groute_server.report.adapter.in.web;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -17,6 +19,7 @@ import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
+import com.groute.groute_server.report.application.port.in.CreateReportCommand;
 import com.groute.groute_server.report.application.port.in.CreateReportUseCase;
 import com.groute.groute_server.report.application.port.in.GetReportDetailUseCase;
 import com.groute.groute_server.report.application.port.in.GetReportGaugeUseCase;
@@ -26,6 +29,7 @@ import com.groute.groute_server.report.application.port.in.GetSelectableInfoUseC
 import com.groute.groute_server.report.application.port.in.RetryReportUseCase;
 import com.groute.groute_server.report.application.port.in.dto.ReportGaugeView;
 import com.groute.groute_server.report.application.port.in.dto.ReportListView;
+import com.groute.groute_server.report.domain.enums.ReportType;
 import com.groute.groute_server.support.WebMvcTestBase;
 
 @WebMvcTest(ReportController.class)
@@ -98,6 +102,16 @@ class ReportControllerTest extends WebMvcTestBase {
                     .andExpect(status().isOk())
                     .andExpect(jsonPath("$.success").value(true))
                     .andExpect(jsonPath("$.data.reportId").value(42));
+
+            then(createReportUseCase)
+                    .should()
+                    .createReport(
+                            argThat(
+                                    (CreateReportCommand cmd) ->
+                                            cmd.userId().equals(1L)
+                                                    && cmd.reportType() == ReportType.MINI
+                                                    && cmd.starRecordIds()
+                                                            .equals(List.of(1L, 2L, 3L))));
         }
 
         @Test

--- a/src/test/java/com/groute/groute_server/report/adapter/in/web/ReportControllerTest.java
+++ b/src/test/java/com/groute/groute_server/report/adapter/in/web/ReportControllerTest.java
@@ -1,0 +1,127 @@
+package com.groute.groute_server.report.adapter.in.web;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+
+import com.groute.groute_server.report.application.port.in.CreateReportUseCase;
+import com.groute.groute_server.report.application.port.in.GetReportDetailUseCase;
+import com.groute.groute_server.report.application.port.in.GetReportGaugeUseCase;
+import com.groute.groute_server.report.application.port.in.GetReportListUseCase;
+import com.groute.groute_server.report.application.port.in.GetReportStatusUseCase;
+import com.groute.groute_server.report.application.port.in.GetSelectableInfoUseCase;
+import com.groute.groute_server.report.application.port.in.RetryReportUseCase;
+import com.groute.groute_server.report.application.port.in.dto.ReportGaugeView;
+import com.groute.groute_server.report.application.port.in.dto.ReportListView;
+import com.groute.groute_server.support.WebMvcTestBase;
+
+@WebMvcTest(ReportController.class)
+class ReportControllerTest extends WebMvcTestBase {
+
+    @MockitoBean private GetReportGaugeUseCase getReportGaugeUseCase;
+    @MockitoBean private GetReportListUseCase getReportListUseCase;
+    @MockitoBean private GetReportDetailUseCase getReportDetailUseCase;
+    @MockitoBean private GetSelectableInfoUseCase getSelectableInfoUseCase;
+    @MockitoBean private CreateReportUseCase createReportUseCase;
+    @MockitoBean private GetReportStatusUseCase getReportStatusUseCase;
+    @MockitoBean private RetryReportUseCase retryReportUseCase;
+
+    private static final String BASE_URL = "/api/reports";
+
+    @Nested
+    @DisplayName("GET /api/reports/gauge")
+    class GetGauge {
+
+        @Test
+        @DisplayName("인증된 사용자 요청 시 200 반환")
+        void should_return200_when_authenticated() throws Exception {
+            given(getReportGaugeUseCase.getGauge(anyLong()))
+                    .willReturn(ReportGaugeView.of(7, 10));
+
+            mockMvc.perform(get(BASE_URL + "/gauge").with(auth(1L)))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.success").value(true))
+                    .andExpect(jsonPath("$.data.currentCount").value(7))
+                    .andExpect(jsonPath("$.data.nextThreshold").value(10));
+        }
+
+        @Test
+        @DisplayName("미인증 요청 시 401 반환")
+        void should_return401_when_unauthenticated() throws Exception {
+            mockMvc.perform(get(BASE_URL + "/gauge")).andExpect(status().isUnauthorized());
+        }
+    }
+
+    @Nested
+    @DisplayName("GET /api/reports")
+    class GetList {
+
+        @Test
+        @DisplayName("인증된 사용자 요청 시 200 반환")
+        void should_return200_when_authenticated() throws Exception {
+            given(getReportListUseCase.getList(anyLong()))
+                    .willReturn(new ReportListView(List.of()));
+
+            mockMvc.perform(get(BASE_URL).with(auth(1L)))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.success").value(true))
+                    .andExpect(jsonPath("$.data.reports").isArray());
+        }
+    }
+
+    @Nested
+    @DisplayName("POST /api/reports")
+    class CreateReport {
+
+        @Test
+        @DisplayName("유효한 요청 시 200 반환")
+        void should_return200_when_validRequest() throws Exception {
+            given(createReportUseCase.createReport(any())).willReturn(42L);
+
+            mockMvc.perform(
+                            post(BASE_URL)
+                                    .with(auth(1L))
+                                    .contentType(MediaType.APPLICATION_JSON)
+                                    .content(
+                                            "{\"reportType\":\"MINI\",\"starRecordIds\":[1,2,3]}"))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.success").value(true))
+                    .andExpect(jsonPath("$.data.reportId").value(42));
+        }
+
+        @Test
+        @DisplayName("reportType 누락 시 400 반환")
+        void should_return400_when_reportTypeIsNull() throws Exception {
+            mockMvc.perform(
+                            post(BASE_URL)
+                                    .with(auth(1L))
+                                    .contentType(MediaType.APPLICATION_JSON)
+                                    .content("{\"starRecordIds\":[1,2,3]}"))
+                    .andExpect(status().isBadRequest());
+        }
+
+        @Test
+        @DisplayName("starRecordIds 빈 배열 시 400 반환")
+        void should_return400_when_starRecordIdsIsEmpty() throws Exception {
+            mockMvc.perform(
+                            post(BASE_URL)
+                                    .with(auth(1L))
+                                    .contentType(MediaType.APPLICATION_JSON)
+                                    .content("{\"reportType\":\"MINI\",\"starRecordIds\":[]}"))
+                    .andExpect(status().isBadRequest());
+        }
+    }
+}

--- a/src/test/java/com/groute/groute_server/report/adapter/in/web/ReportControllerTest.java
+++ b/src/test/java/com/groute/groute_server/report/adapter/in/web/ReportControllerTest.java
@@ -48,8 +48,7 @@ class ReportControllerTest extends WebMvcTestBase {
         @Test
         @DisplayName("인증된 사용자 요청 시 200 반환")
         void should_return200_when_authenticated() throws Exception {
-            given(getReportGaugeUseCase.getGauge(anyLong()))
-                    .willReturn(ReportGaugeView.of(7, 10));
+            given(getReportGaugeUseCase.getGauge(anyLong())).willReturn(ReportGaugeView.of(7, 10));
 
             mockMvc.perform(get(BASE_URL + "/gauge").with(auth(1L)))
                     .andExpect(status().isOk())
@@ -95,8 +94,7 @@ class ReportControllerTest extends WebMvcTestBase {
                             post(BASE_URL)
                                     .with(auth(1L))
                                     .contentType(MediaType.APPLICATION_JSON)
-                                    .content(
-                                            "{\"reportType\":\"MINI\",\"starRecordIds\":[1,2,3]}"))
+                                    .content("{\"reportType\":\"MINI\",\"starRecordIds\":[1,2,3]}"))
                     .andExpect(status().isOk())
                     .andExpect(jsonPath("$.success").value(true))
                     .andExpect(jsonPath("$.data.reportId").value(42));

--- a/src/test/java/com/groute/groute_server/support/WebMvcTestBase.java
+++ b/src/test/java/com/groute/groute_server/support/WebMvcTestBase.java
@@ -1,0 +1,55 @@
+package com.groute.groute_server.support;
+
+import java.util.List;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Import;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.RequestPostProcessor;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.groute.groute_server.common.config.SecurityConfig;
+import com.groute.groute_server.common.config.WebMvcConfig;
+import com.groute.groute_server.common.filter.JwtAuthenticationFilter;
+import com.groute.groute_server.common.handler.JwtAccessDeniedHandler;
+import com.groute.groute_server.common.handler.JwtAuthenticationEntryPoint;
+import com.groute.groute_server.common.jwt.JwtTokenProvider;
+import com.groute.groute_server.common.resolver.CurrentUserArgumentResolver;
+
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
+
+/**
+ * {@code @WebMvcTest} 슬라이스 공통 베이스.
+ *
+ * <p>실제 {@link SecurityConfig}·{@link JwtAuthenticationFilter}를 로드하되, {@link JwtTokenProvider}만
+ * 모킹해 필터가 실행되더라도 SecurityContext를 비운 채로 둔다. 인증이 필요한 테스트는 {@link #auth(Long)}로 {@code
+ * Authentication}을 직접 주입한다.
+ *
+ * <p>{@link OAuth2SecurityConfig}는 임포트하지 않는다 — OAuth2 체인은 {@code /oauth2/**}에만 적용되며 해당 의존 빈
+ * (CustomOAuth2UserService 등)을 모킹하면 복잡도가 증가한다.
+ */
+@Import({
+    SecurityConfig.class,
+    WebMvcConfig.class,
+    CurrentUserArgumentResolver.class,
+    JwtAuthenticationFilter.class,
+    JwtAuthenticationEntryPoint.class,
+    JwtAccessDeniedHandler.class
+})
+public abstract class WebMvcTestBase {
+
+    @MockitoBean protected JwtTokenProvider jwtTokenProvider;
+
+    @Autowired protected MockMvc mockMvc;
+
+    @Autowired protected ObjectMapper objectMapper;
+
+    protected static RequestPostProcessor auth(Long userId) {
+        return authentication(
+                new UsernamePasswordAuthenticationToken(
+                        userId, null, List.of(new SimpleGrantedAuthority("ROLE_USER"))));
+    }
+}

--- a/src/test/java/com/groute/groute_server/support/WebMvcTestBase.java
+++ b/src/test/java/com/groute/groute_server/support/WebMvcTestBase.java
@@ -1,9 +1,15 @@
 package com.groute.groute_server.support;
 
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
+
 import java.util.List;
 
+import org.junit.jupiter.api.BeforeEach;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Import;
+import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
@@ -11,6 +17,7 @@ import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.RequestPostProcessor;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.groute.groute_server.common.config.OffsetDateTimeProvider;
 import com.groute.groute_server.common.config.SecurityConfig;
 import com.groute.groute_server.common.config.WebMvcConfig;
 import com.groute.groute_server.common.filter.JwtAuthenticationFilter;
@@ -18,20 +25,21 @@ import com.groute.groute_server.common.handler.JwtAccessDeniedHandler;
 import com.groute.groute_server.common.handler.JwtAuthenticationEntryPoint;
 import com.groute.groute_server.common.jwt.JwtTokenProvider;
 import com.groute.groute_server.common.resolver.CurrentUserArgumentResolver;
-
-import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
+import com.groute.groute_server.common.webhook.ErrorWebhookNotifier;
+import com.groute.groute_server.user.service.UserService;
 
 /**
  * {@code @WebMvcTest} 슬라이스 공통 베이스.
  *
- * <p>실제 {@link SecurityConfig}·{@link JwtAuthenticationFilter}를 로드하되, {@link JwtTokenProvider}만
- * 모킹해 필터가 실행되더라도 SecurityContext를 비운 채로 둔다. 인증이 필요한 테스트는 {@link #auth(Long)}로 {@code
- * Authentication}을 직접 주입한다.
+ * <p>실제 {@link SecurityConfig}·{@link JwtAuthenticationFilter}를 로드하되, {@link JwtTokenProvider}만 모킹해
+ * 필터가 실행되더라도 SecurityContext를 비운 채로 둔다. 인증이 필요한 테스트는 {@link #auth(Long)}로 {@code Authentication}을
+ * 직접 주입한다.
  *
  * <p>{@link OAuth2SecurityConfig}는 임포트하지 않는다 — OAuth2 체인은 {@code /oauth2/**}에만 적용되며 해당 의존 빈
  * (CustomOAuth2UserService 등)을 모킹하면 복잡도가 증가한다.
  */
 @Import({
+    OffsetDateTimeProvider.class,
     SecurityConfig.class,
     WebMvcConfig.class,
     CurrentUserArgumentResolver.class,
@@ -42,8 +50,16 @@ import static org.springframework.security.test.web.servlet.request.SecurityMock
 public abstract class WebMvcTestBase {
 
     @MockitoBean protected JwtTokenProvider jwtTokenProvider;
+    @MockitoBean protected JpaMetamodelMappingContext jpaMetamodelMappingContext;
+    @MockitoBean protected ErrorWebhookNotifier errorWebhookNotifier;
+    @MockitoBean protected UserService userService;
 
     @Autowired protected MockMvc mockMvc;
+
+    @BeforeEach
+    void setUpOnboardingDefault() {
+        given(userService.isOnboardingCompleted(anyLong())).willReturn(true);
+    }
 
     @Autowired protected ObjectMapper objectMapper;
 


### PR DESCRIPTION
## 요약
 - @WebMvcTest 슬라이스 테스트를 도입해 AuthController·ReportController의 HTTP 상태코드·인증·DTO validation을 검증한다.

## 변경 사항
- [ ] 기능
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 문서
- [x] 테스트
- [ ] 기타

## 테스트
- [x] 로컬 테스트 완료
- 테스트 방법:
    - ./gradlew test

### 커버리지 (JaCoCo)
- 라인 커버리지: 69%  (기준: 60% 이상)
- [x] `./gradlew test` 실행 후 `build/reports/jacoco/index.html`에서 수치 확인

## 롤백/리스크
- 리스크 포인트: 없음 (테스트 전용 변경, 프로덕션 코드 미변경)
- 롤백 방법: 브랜치 삭제 또는 테스트 파일 제거

## 관련 이슈
Closes #224 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

이번 업데이트는 내부 테스트 인프라 개선으로 구성되어 있습니다. 사용자에게 직접적인 기능 변화는 없습니다.

* **Tests**
  * 인증 및 리포트 엔드포인트에 대한 통합 테스트 추가
  * 웹 MVC 테스트를 위한 공유 기본 클래스 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->