### PR TITLE
chore: Prometheus + Grafana 로컬 모니터링 스택 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,6 +21,7 @@ repositories {
 
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-actuator'
+	runtimeOnly 'io.micrometer:micrometer-registry-prometheus'
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 	implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'

--- a/monitoring/README.md
+++ b/monitoring/README.md
@@ -1,0 +1,38 @@
+# Local Monitoring Stack
+
+Prometheus + Grafana 로컬 모니터링 스택.
+
+## 사전 조건
+
+- Spring 서버가 `local` 프로파일로 실행 중이어야 함 (`http://localhost:8080`)
+- Docker Desktop 실행 중
+
+## 실행
+
+```bash
+cd monitoring
+docker compose up -d
+```
+
+| 서비스     | URL                    | 계정           |
+|-----------|------------------------|---------------|
+| Prometheus | http://localhost:9090  | -             |
+| Grafana    | http://localhost:3001  | admin / admin |
+
+## 4701 대시보드 import
+
+1. Grafana 접속 → 좌측 메뉴 **Dashboards → Import**
+2. **Import via grafana.com** 입력란에 `4701` 입력 → **Load**
+3. Datasource를 `Prometheus` 선택 → **Import**
+
+## 종료
+
+```bash
+docker compose down
+```
+
+볼륨까지 삭제하려면:
+
+```bash
+docker compose down -v
+```

--- a/monitoring/docker-compose.yml
+++ b/monitoring/docker-compose.yml
@@ -1,0 +1,34 @@
+services:
+  prometheus:
+    image: prom/prometheus:v2.52.0
+    container_name: groute-prometheus
+    ports:
+      - "9090:9090"
+    volumes:
+      - ./prometheus.yml:/etc/prometheus/prometheus.yml
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+    networks:
+      - monitoring
+
+  grafana:
+    image: grafana/grafana:10.4.3
+    container_name: groute-grafana
+    ports:
+      - "3001:3000"
+    environment:
+      - GF_SECURITY_ADMIN_USER=admin
+      - GF_SECURITY_ADMIN_PASSWORD=admin
+      - GF_USERS_ALLOW_SIGN_UP=false
+    volumes:
+      - grafana-data:/var/lib/grafana
+      - ./grafana/provisioning:/etc/grafana/provisioning
+    networks:
+      - monitoring
+
+networks:
+  monitoring:
+    driver: bridge
+
+volumes:
+  grafana-data:

--- a/monitoring/grafana/provisioning/dashboards/dashboard.yaml
+++ b/monitoring/grafana/provisioning/dashboards/dashboard.yaml
@@ -1,0 +1,14 @@
+apiVersion: 1
+
+providers:
+  - name: 'default'
+    orgId: 1
+    folder: ''
+    type: file
+    disableDeletion: false
+    updateIntervalSeconds: 10
+    options:
+      path: /etc/grafana/provisioning/dashboards
+
+# 4701 대시보드는 자동 import 미지원 (JSON 파일 필요).
+# Grafana UI에서 수동 import: Dashboards → New → Import → ID: 4701 → Load → Import

--- a/monitoring/grafana/provisioning/datasources/prometheus.yaml
+++ b/monitoring/grafana/provisioning/datasources/prometheus.yaml
@@ -1,0 +1,8 @@
+apiVersion: 1
+
+datasources:
+  - name: Prometheus
+    type: prometheus
+    access: proxy
+    url: http://prometheus:9090
+    isDefault: true

--- a/monitoring/prometheus.yml
+++ b/monitoring/prometheus.yml
@@ -1,0 +1,9 @@
+global:
+  scrape_interval: 15s
+  evaluation_interval: 15s
+
+scrape_configs:
+  - job_name: 'groute-spring'
+    metrics_path: '/actuator/prometheus'
+    static_configs:
+      - targets: ['host.docker.internal:8080']

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -239,6 +239,15 @@ notification:
   copy-json: ${NOTIFICATION_COPY_JSON:}
   deep-link-url: ${NOTIFICATION_DEEP_LINK_URL:}
 
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health,prometheus
+  metrics:
+    tags:
+      application: ${spring.application.name}
+
 logging:
   level:
     com.groute: DEBUG


### PR DESCRIPTION
## 요약
- 로컬 개발 환경에서 Spring JVM 메트릭을 시각화하기 위한 Prometheus + Grafana 모니터링 스택을 추가한다.

## 상세 내용
Micrometer가 이미 설정되어 있어 수집/시각화 레이어만 구성했다.
`docker compose up` 한 번으로 Prometheus + Grafana가 실행되며, Grafana에서 4701 대시보드 import 시 JVM 메트릭을 시각화할 수 있다.

- `build.gradle`: `micrometer-registry-prometheus` 의존성 추가
- `application.yaml`: local 프로파일에 `/actuator/prometheus` 엔드포인트 노출 및 `application` 공통 태그 추가
- `monitoring/docker-compose.yml`: Prometheus + Grafana 컨테이너 구성
- `monitoring/prometheus.yml`: Spring 메트릭 수집 설정 (15초 간격)
- `monitoring/grafana/provisioning/datasources/prometheus.yaml`: Grafana 데이터소스 자동 연결
- `monitoring/grafana/provisioning/dashboards/dashboard.yaml`: 대시보드 provider 설정
- `monitoring/README.md`: 팀원용 실행 가이드

## 변경 사항
- [ ] 기능
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 문서
- [ ] 테스트
- [x] 기타

## 테스트
- [x] 로컬 테스트 완료
- 테스트 방법:
    - [x] `http://localhost:8080/actuator/prometheus` 메트릭 정상 노출 확인
    - [x] Prometheus Targets에서 `groute-spring` UP 상태 확인
    - [x] Grafana 4701 대시보드 import 후 HTTP Rate, Duration 데이터 확인

### 커버리지 (JaCoCo)


## 롤백/리스크
- 리스크 포인트:
- 롤백 방법:

## 관련 이슈
Closes #226 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * 모니터링 스택 추가: Prometheus와 Grafana를 통한 시스템 메트릭 수집 및 시각화 지원
  * 애플리케이션 메트릭 노출 활성화로 실시간 성능 모니터링 가능
  * Grafana 대시보드 자동 프로비저닝으로 즉시 사용 가능한 모니터링 환경 구성

<!-- end of auto-generated comment: release notes by coderabbit.ai -->