### PR TITLE
build: 배포 이미지 멀티스테이지 레이어드 슬림화 (#228)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -69,7 +69,8 @@ jobs:
                 ("aws s3 cp s3://glit-images/deploy/" + $sha + "/docker-compose.yml /home/ssm-user/glit/docker-compose.yml"),
                 "docker stop groute-server 2>/dev/null || true",
                 "docker rm   groute-server 2>/dev/null || true",
-                "cd /home/ssm-user/glit && docker compose up -d --pull always --wait"
+                "cd /home/ssm-user/glit && docker compose up -d --pull always --wait",
+                "docker image prune -af 2>/dev/null || true"
               ]
             },
             TimeoutSeconds: 300

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,15 @@
-FROM eclipse-temurin:21-jdk-jammy
+FROM eclipse-temurin:21-jre-jammy AS builder
+WORKDIR /builder
+ARG JAR_FILE=build/libs/*.jar
+COPY ${JAR_FILE} application.jar
+RUN java -Djarmode=tools -jar application.jar extract --layers --destination extracted
+
+FROM eclipse-temurin:21-jre-jammy
 RUN apt-get update && apt-get install -y --no-install-recommends curl && rm -rf /var/lib/apt/lists/*
 WORKDIR /app
-COPY build/libs/*.jar app.jar
+COPY --from=builder /builder/extracted/dependencies/ ./
+COPY --from=builder /builder/extracted/spring-boot-loader/ ./
+COPY --from=builder /builder/extracted/snapshot-dependencies/ ./
+COPY --from=builder /builder/extracted/application/ ./
 EXPOSE 8080
-ENTRYPOINT ["java", "-jar", "app.jar"]
+ENTRYPOINT ["java", "-jar", "application.jar"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,6 +18,11 @@ services:
       retries: 5
       start_period: 30s
     restart: unless-stopped
+    logging:
+      driver: json-file
+      options:
+        max-size: "10m"
+        max-file: "3"
 
   redis:
     image: redis:7.2-alpine
@@ -34,3 +39,8 @@ services:
       timeout: 5s
       retries: 3
     restart: unless-stopped
+    logging:
+      driver: json-file
+      options:
+        max-size: "10m"
+        max-file: "3"


### PR DESCRIPTION
## 배경
배포 시 도커 이미지(약 938MB)가 커서 작은 인스턴스(디스크 8GB, RAM 1GB)에서 디스크/메모리 부족으로 배포가 반복 실패했다. 무중단 배포 시 옛 이미지와 새 이미지를 동시에 보유하면서 디스크가 가득 차거나(`no space left on device`), 이미지 추출과 JVM 기동이 겹쳐 메모리가 부족해 인스턴스가 멈추고 SSM 명령이 실패했다(`ipc messaging received timeout`).

## 변경 사항
- Dockerfile을 멀티스테이지 + JRE 베이스 + Spring Boot layered jar 구조로 변경
  - `eclipse-temurin:21-jdk-jammy` 에서 `21-jre-jammy` 로 전환
  - layered jar 추출(`-Djarmode=tools ... extract --layers`)로 dependencies/spring-boot-loader/snapshot-dependencies/application 레이어 분리
  - 의존성 레이어가 배포 간 공유되어 재배포 시 변경된 application 레이어만 내려받음
- deploy.yml: 배포 성공 후 `docker image prune -af`로 미사용 이미지 정리(디스크 누적 방지)
- docker-compose.yml: app/redis 컨테이너 로그 회전(max-size 10m, max-file 3) 설정

## 효과
- JDK 제거와 레이어 분리로 이미지 용량이 줄어 추출 부담 감소
- 재배포 시 공유 레이어 재사용으로 디스크/네트워크/추출 비용 대폭 감소
- 미사용 이미지와 로그 자동 정리로 디스크 점유 누적 방지

## 검증
- layered jar 추출 레이아웃과 launcher 클래스(`org.springframework.boot.loader.launch.JarLauncher`, Boot 3.5.13) 확인
- 추출한 레이어를 컨테이너와 동일하게 펼쳐 `java -jar`로 기동 확인(Spring Boot 배너, JPA 리포지토리 19개 스캔, Tomcat 8080 초기화까지 정상 진행)

## base를 master로 둔 이유
이미지/배포 설정 변경은 prod(master)와 stg(master에서 dev 동기화) 양쪽 배포에 반영되어야 해서 master를 base로 하는 hotfix로 올린다.

## 참고
- 첫 배포는 새 베이스/의존성 레이어를 받으므로 한 번은 전체 이미지를 내려받는다. 이후 배포부터 레이어 공유 효과가 적용된다.
- 인스턴스 디스크/스왑 여유 확보는 별도 운영 조치로 진행했다.

Closes #228


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Chores**
  * 배포 워크플로우 개선으로 배포 후 사용하지 않는 컨테이너 이미지를 자동으로 정리합니다.
  * 멀티스테이지 빌드 방식을 적용하여 컨테이너 이미지 효율성을 개선했습니다.
  * 애플리케이션 및 Redis 서비스의 로그 로테이션을 설정하여 디스크 공간 관리를 개선했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->