### PR TITLE
test: DataJpaTestBase Flyway 플레이스홀더 추가 및 ScrumJpaRepositoryTest 소유권 오류 수정 (#231)

### DIFF
--- a/src/test/java/com/groute/groute_server/record/adapter/out/persistence/ScrumJpaRepositoryTest.java
+++ b/src/test/java/com/groute/groute_server/record/adapter/out/persistence/ScrumJpaRepositoryTest.java
@@ -88,7 +88,16 @@ class ScrumJpaRepositoryTest extends DataJpaTestBase {
             Scrum mine2 = em.persistAndFlush(Scrum.create(user, title, "내꺼2", DATE));
 
             User other = em.persistAndFlush(User.createForSocialLogin());
-            Scrum othersScrum = em.persistAndFlush(Scrum.create(other, title, "남꺼", DATE));
+            Project otherProject =
+                    em.persistAndFlush(Project.builder().user(other).name("다른프로젝트").build());
+            ScrumTitle otherTitle =
+                    em.persistAndFlush(
+                            ScrumTitle.builder()
+                                    .user(other)
+                                    .project(otherProject)
+                                    .freeText("다른제목")
+                                    .build());
+            Scrum othersScrum = em.persistAndFlush(Scrum.create(other, otherTitle, "남꺼", DATE));
             em.clear();
 
             // when
@@ -179,7 +188,16 @@ class ScrumJpaRepositoryTest extends DataJpaTestBase {
             em.flush();
 
             User other = em.persistAndFlush(User.createForSocialLogin());
-            Scrum othersScrum = em.persistAndFlush(Scrum.create(other, title, "다른유저", DATE));
+            Project otherProject =
+                    em.persistAndFlush(Project.builder().user(other).name("다른프로젝트").build());
+            ScrumTitle otherTitle =
+                    em.persistAndFlush(
+                            ScrumTitle.builder()
+                                    .user(other)
+                                    .project(otherProject)
+                                    .freeText("다른제목")
+                                    .build());
+            Scrum othersScrum = em.persistAndFlush(Scrum.create(other, otherTitle, "다른유저", DATE));
             em.clear();
 
             // when

--- a/src/test/java/com/groute/groute_server/support/DataJpaTestBase.java
+++ b/src/test/java/com/groute/groute_server/support/DataJpaTestBase.java
@@ -27,7 +27,11 @@ import com.groute.groute_server.common.config.OffsetDateTimeProvider;
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
 @Testcontainers
 @Import(OffsetDateTimeProvider.class)
-@TestPropertySource(properties = "spring.flyway.enabled=true")
+@TestPropertySource(
+        properties = {
+            "spring.flyway.enabled=true",
+            "spring.flyway.placeholders.social_email_hash_pepper=test-pepper-must-be-at-least-32-bytes-for-hmac-sha256"
+        })
 public abstract class DataJpaTestBase {
 
     @Container @ServiceConnection


### PR DESCRIPTION
## 요약
- Testcontainers 기반 JPA 테스트에서 Flyway 플레이스홀더 미설정 및 도메인 소유권 검증 오류로 인한 테스트 실패 수정

## 변경 사항
- [ ] 기능
- [x] 버그 수정
- [ ] 리팩토링
- [ ] 문서
- [x] 테스트
- [ ] 기타

## 테스트
- [x] 로컬 테스트 완료
- 테스트 방법:
    - ./gradlew test
    - ScrumJpaRepositoryTest 7개 → 전체 통과 확인

### 커버리지 (JaCoCo)
- 라인 커버리지: 68%  (기준: 60% 이상)
- [x] `./gradlew test` 실행 후 `build/reports/jacoco/index.html`에서 수치 확인

## 롤백/리스크
- 리스크 포인트: 없음 (테스트 코드 및 테스트 설정만 변경)
- 롤백 방법: PR revert

## 관련 이슈
Closes #231 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# 릴리스 노트

* **Tests**
  * 테스트 데이터 설정 개선으로 저장소 소유권 쿼리 검증 강화
  * 테스트 환경 구성 최적화

<!-- end of auto-generated comment: release notes by coderabbit.ai -->