### PR TITLE
perf: 조회 hot-path Redis 응답 캐싱 도입

### DIFF
--- a/src/main/java/com/groute/groute_server/calendar/service/CalendarHomeService.java
+++ b/src/main/java/com/groute/groute_server/calendar/service/CalendarHomeService.java
@@ -12,11 +12,13 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.groute.groute_server.calendar.repository.CalendarHomeRepository;
 import com.groute.groute_server.calendar.repository.StarDailyRow;
+import com.groute.groute_server.common.config.CacheConfig;
 import com.groute.groute_server.record.domain.Scrum;
 import com.groute.groute_server.record.domain.ScrumTitle;
 import com.groute.groute_server.record.domain.enums.CompetencyCategory;
@@ -43,6 +45,7 @@ public class CalendarHomeService {
      * @param userId 조회 대상 사용자
      * @param month 조회 연월
      */
+    @Cacheable(cacheNames = CacheConfig.CACHE_CALENDAR_MONTHLY, key = "#userId + ':' + #month")
     public CalendarMonthlyView getMonthly(Long userId, YearMonth month) {
         LocalDate start = month.atDay(1);
         LocalDate end = month.atEndOfMonth();

--- a/src/main/java/com/groute/groute_server/common/config/CacheConfig.java
+++ b/src/main/java/com/groute/groute_server/common/config/CacheConfig.java
@@ -1,0 +1,61 @@
+package com.groute.groute_server.common.config;
+
+import java.time.Duration;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.cache.RedisCacheConfiguration;
+import org.springframework.data.redis.cache.RedisCacheManager;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.RedisSerializationContext;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+
+/**
+ * Redis 기반 캐시 설정.
+ *
+ * <p>refresh token용 {@link org.springframework.data.redis.core.StringRedisTemplate}과 완전히 분리된 {@link
+ * RedisCacheManager}를 구성한다. {@link JavaTimeModule}을 주입한 {@link ObjectMapper}로 {@code LocalDate} 등
+ * JSR-310 타입 직렬화를 보장한다.
+ */
+@Configuration
+@EnableCaching
+public class CacheConfig {
+
+    public static final String CACHE_HOME_RADAR = "home:radar";
+    public static final String CACHE_HOME_COMPETENCY_STATS = "home:competency-stats";
+    public static final String CACHE_CALENDAR_MONTHLY = "calendar:monthly";
+    public static final String CACHE_USERS_ME = "users:me";
+    public static final String CACHE_REPORTS_DETAIL = "reports:detail";
+
+    @Bean
+    public RedisCacheManager cacheManager(RedisConnectionFactory cf) {
+        Map<String, RedisCacheConfiguration> configs = new HashMap<>();
+        configs.put(CACHE_HOME_RADAR, defaultConfig().entryTtl(Duration.ofHours(1)));
+        configs.put(CACHE_HOME_COMPETENCY_STATS, defaultConfig().entryTtl(Duration.ofHours(1)));
+        configs.put(CACHE_CALENDAR_MONTHLY, defaultConfig().entryTtl(Duration.ofMinutes(30)));
+        configs.put(CACHE_USERS_ME, defaultConfig().entryTtl(Duration.ofMinutes(10)));
+        configs.put(CACHE_REPORTS_DETAIL, defaultConfig().entryTtl(Duration.ofHours(24)));
+
+        return RedisCacheManager.builder(cf).withInitialCacheConfigurations(configs).build();
+    }
+
+    private RedisCacheConfiguration defaultConfig() {
+        ObjectMapper om =
+                new ObjectMapper()
+                        .registerModule(new JavaTimeModule())
+                        .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+
+        return RedisCacheConfiguration.defaultCacheConfig()
+                .disableCachingNullValues()
+                .serializeValuesWith(
+                        RedisSerializationContext.SerializationPair.fromSerializer(
+                                new GenericJackson2JsonRedisSerializer(om)));
+    }
+}

--- a/src/main/java/com/groute/groute_server/home/service/HomeCompetencyStatsService.java
+++ b/src/main/java/com/groute/groute_server/home/service/HomeCompetencyStatsService.java
@@ -5,9 +5,11 @@ import java.time.YearMonth;
 import java.util.Map;
 import java.util.stream.Collectors;
 
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.groute.groute_server.common.config.CacheConfig;
 import com.groute.groute_server.home.repository.CompetencyStatsQueryRepository;
 import com.groute.groute_server.home.repository.CompetencyStatsQueryRepository.DateCountRow;
 
@@ -40,6 +42,7 @@ public class HomeCompetencyStatsService {
      * @param month 조회 월(KST)
      * @return 일자(KST) → STAR 완료 건수 맵. 0건 일자는 미포함.
      */
+    @Cacheable(cacheNames = CacheConfig.CACHE_HOME_COMPETENCY_STATS, key = "#userId + ':' + #month")
     public Map<LocalDate, Long> getCompletedStarCountsByMonth(Long userId, YearMonth month) {
         LocalDate startInclusive = month.atDay(1);
         LocalDate endExclusive = month.plusMonths(1).atDay(1);

--- a/src/main/java/com/groute/groute_server/home/service/HomeService.java
+++ b/src/main/java/com/groute/groute_server/home/service/HomeService.java
@@ -5,9 +5,11 @@ import java.util.EnumMap;
 import java.util.List;
 import java.util.Map;
 
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.groute.groute_server.common.config.CacheConfig;
 import com.groute.groute_server.common.exception.BusinessException;
 import com.groute.groute_server.common.exception.ErrorCode;
 import com.groute.groute_server.home.dto.RadarResult;
@@ -27,6 +29,7 @@ public class HomeService {
     private final StarRecordRepositoryPort starRecordRepositoryPort;
     private final UserRepository userRepository;
 
+    @Cacheable(cacheNames = CacheConfig.CACHE_HOME_RADAR, key = "#userId")
     public RadarResult getRadar(Long userId) {
         List<CompetencyCount> rows =
                 starRecordRepositoryPort.countCompletedByCompetency(
@@ -45,6 +48,7 @@ public class HomeService {
         return new RadarResult(min, max, Collections.unmodifiableMap(categories));
     }
 
+    @Cacheable(cacheNames = CacheConfig.CACHE_USERS_ME, key = "'branding:' + #userId")
     public String getBrandingTitle(Long userId) {
         return userRepository
                 .findById(userId)

--- a/src/main/java/com/groute/groute_server/record/application/service/AiTaggingService.java
+++ b/src/main/java/com/groute/groute_server/record/application/service/AiTaggingService.java
@@ -13,6 +13,7 @@ import org.springframework.transaction.support.TransactionSynchronizationManager
 import com.groute.groute_server.common.config.CacheConfig;
 import com.groute.groute_server.common.exception.BusinessException;
 import com.groute.groute_server.common.exception.ErrorCode;
+import com.groute.groute_server.common.transaction.AfterCommitExecutor;
 import com.groute.groute_server.record.adapter.in.web.dto.AiTaggingResultResponse;
 import com.groute.groute_server.record.adapter.in.web.dto.AiTaggingStatusResponse;
 import com.groute.groute_server.record.application.port.in.CompleteAiTaggingUseCase;
@@ -53,6 +54,7 @@ public class AiTaggingService
     private final StarTagSavePort starTagSavePort;
     private final AiTaggingAsyncExecutor aiTaggingAsyncExecutor;
     private final CacheManager cacheManager;
+    private final AfterCommitExecutor afterCommitExecutor;
 
     /**
      * REC-005: AI 태깅 트리거.
@@ -219,14 +221,17 @@ public class AiTaggingService
             }
         }
 
-        // 캐시 evict — STAR 완료로 home/calendar 집계가 변경되므로 무효화
+        // 캐시 evict — STAR 완료로 home/calendar 집계가 변경되므로 커밋 후 무효화
         Long userId = record.getUser().getId();
         YearMonth month = YearMonth.from(record.getScrum().getScrumDate());
         String monthKey = userId + ":" + month;
 
-        evict(CacheConfig.CACHE_HOME_RADAR, String.valueOf(userId));
-        evict(CacheConfig.CACHE_HOME_COMPETENCY_STATS, monthKey);
-        evict(CacheConfig.CACHE_CALENDAR_MONTHLY, monthKey);
+        afterCommitExecutor.execute(
+                () -> {
+                    evict(CacheConfig.CACHE_HOME_RADAR, String.valueOf(userId));
+                    evict(CacheConfig.CACHE_HOME_COMPETENCY_STATS, monthKey);
+                    evict(CacheConfig.CACHE_CALENDAR_MONTHLY, monthKey);
+                });
     }
 
     private void evict(String cacheName, String key) {

--- a/src/main/java/com/groute/groute_server/record/application/service/AiTaggingService.java
+++ b/src/main/java/com/groute/groute_server/record/application/service/AiTaggingService.java
@@ -1,12 +1,16 @@
 package com.groute.groute_server.record.application.service;
 
+import java.time.YearMonth;
 import java.util.List;
 
+import org.springframework.cache.Cache;
+import org.springframework.cache.CacheManager;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.transaction.support.TransactionSynchronization;
 import org.springframework.transaction.support.TransactionSynchronizationManager;
 
+import com.groute.groute_server.common.config.CacheConfig;
 import com.groute.groute_server.common.exception.BusinessException;
 import com.groute.groute_server.common.exception.ErrorCode;
 import com.groute.groute_server.record.adapter.in.web.dto.AiTaggingResultResponse;
@@ -48,6 +52,7 @@ public class AiTaggingService
     private final StarTagQueryPort starTagPort;
     private final StarTagSavePort starTagSavePort;
     private final AiTaggingAsyncExecutor aiTaggingAsyncExecutor;
+    private final CacheManager cacheManager;
 
     /**
      * REC-005: AI 태깅 트리거.
@@ -172,9 +177,10 @@ public class AiTaggingService
     }
 
     /**
-     * FastAPI 태깅 완료 시 호출. StarRecord를 TAGGED로 전환하고, 세션 내 전체 완료 시 ScrumTitle을 COMMITTED로 전환한다.
+     * FastAPI 태깅 완료 시 호출. StarRecord를 TAGGED로 전환하고, star_tags를 저장한다.
      *
-     * <p>FastAPI 연동 구현 후 {@code AiTaggingClientAdapter}에서 이 메서드를 호출하도록 연결한다.
+     * <p>태깅 완료 시 home:radar / home:competency-stats / calendar:monthly 캐시를 수동 evict한다.
+     * {@code @CacheEvict} SpEL은 void 메서드에서 #result를 참조할 수 없어 {@link CacheManager}를 직접 사용한다.
      */
     @Override
     @Transactional
@@ -211,6 +217,22 @@ public class AiTaggingService
                                 .toList();
                 starTagSavePort.saveAll(tags);
             }
+        }
+
+        // 캐시 evict — STAR 완료로 home/calendar 집계가 변경되므로 무효화
+        Long userId = record.getUser().getId();
+        YearMonth month = YearMonth.from(record.getScrum().getScrumDate());
+        String monthKey = userId + ":" + month;
+
+        evict(CacheConfig.CACHE_HOME_RADAR, String.valueOf(userId));
+        evict(CacheConfig.CACHE_HOME_COMPETENCY_STATS, monthKey);
+        evict(CacheConfig.CACHE_CALENDAR_MONTHLY, monthKey);
+    }
+
+    private void evict(String cacheName, String key) {
+        Cache cache = cacheManager.getCache(cacheName);
+        if (cache != null) {
+            cache.evict(key);
         }
     }
 }

--- a/src/main/java/com/groute/groute_server/record/application/service/DeleteScrumService.java
+++ b/src/main/java/com/groute/groute_server/record/application/service/DeleteScrumService.java
@@ -1,11 +1,15 @@
 package com.groute.groute_server.record.application.service;
 
+import java.time.YearMonth;
 import java.util.List;
 import java.util.Set;
 
+import org.springframework.cache.Cache;
+import org.springframework.cache.CacheManager;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.groute.groute_server.common.config.CacheConfig;
 import com.groute.groute_server.common.exception.BusinessException;
 import com.groute.groute_server.common.exception.ErrorCode;
 import com.groute.groute_server.record.application.port.in.scrum.DeleteScrumCommand;
@@ -35,6 +39,7 @@ public class DeleteScrumService implements DeleteScrumUseCase {
     private final ScrumTitleRepositoryPort scrumTitleRepositoryPort;
     private final StarRecordCascadePort starRecordCascadePort;
     private final StarImageCascadeCleaner starImageCascadeCleaner;
+    private final CacheManager cacheManager;
 
     @Override
     public void deleteScrum(DeleteScrumCommand command) {
@@ -50,5 +55,11 @@ public class DeleteScrumService implements DeleteScrumUseCase {
         scrumWritePort.softDeleteAllByIdIn(scrumIds);
         starRecordCascadePort.cascadeDeleteByScrumIdIn(scrumIds);
         scrumTitleRepositoryPort.applyScrumCountIncrement(titleId, -1);
+
+        // calendar:monthly 캐시 무효화
+        Cache cache = cacheManager.getCache(CacheConfig.CACHE_CALENDAR_MONTHLY);
+        if (cache != null) {
+            cache.evict(command.userId() + ":" + YearMonth.from(owned.get(0).getScrumDate()));
+        }
     }
 }

--- a/src/main/java/com/groute/groute_server/record/application/service/DeleteScrumService.java
+++ b/src/main/java/com/groute/groute_server/record/application/service/DeleteScrumService.java
@@ -12,6 +12,7 @@ import org.springframework.transaction.annotation.Transactional;
 import com.groute.groute_server.common.config.CacheConfig;
 import com.groute.groute_server.common.exception.BusinessException;
 import com.groute.groute_server.common.exception.ErrorCode;
+import com.groute.groute_server.common.transaction.AfterCommitExecutor;
 import com.groute.groute_server.record.application.port.in.scrum.DeleteScrumCommand;
 import com.groute.groute_server.record.application.port.in.scrum.DeleteScrumUseCase;
 import com.groute.groute_server.record.application.port.out.scrum.ScrumQueryPort;
@@ -40,6 +41,7 @@ public class DeleteScrumService implements DeleteScrumUseCase {
     private final StarRecordCascadePort starRecordCascadePort;
     private final StarImageCascadeCleaner starImageCascadeCleaner;
     private final CacheManager cacheManager;
+    private final AfterCommitExecutor afterCommitExecutor;
 
     @Override
     public void deleteScrum(DeleteScrumCommand command) {
@@ -56,10 +58,15 @@ public class DeleteScrumService implements DeleteScrumUseCase {
         starRecordCascadePort.cascadeDeleteByScrumIdIn(scrumIds);
         scrumTitleRepositoryPort.applyScrumCountIncrement(titleId, -1);
 
-        // calendar:monthly 캐시 무효화
-        Cache cache = cacheManager.getCache(CacheConfig.CACHE_CALENDAR_MONTHLY);
-        if (cache != null) {
-            cache.evict(command.userId() + ":" + YearMonth.from(owned.get(0).getScrumDate()));
-        }
+        // calendar:monthly 캐시 무효화 (커밋 후)
+        final Long userId = command.userId();
+        final YearMonth month = YearMonth.from(owned.get(0).getScrumDate());
+        afterCommitExecutor.execute(
+                () -> {
+                    Cache cache = cacheManager.getCache(CacheConfig.CACHE_CALENDAR_MONTHLY);
+                    if (cache != null) {
+                        cache.evict(userId + ":" + month);
+                    }
+                });
     }
 }

--- a/src/main/java/com/groute/groute_server/record/application/service/ScrumBulkWriteService.java
+++ b/src/main/java/com/groute/groute_server/record/application/service/ScrumBulkWriteService.java
@@ -1,13 +1,17 @@
 package com.groute.groute_server.record.application.service;
 
+import java.time.YearMonth;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
+import org.springframework.cache.Cache;
+import org.springframework.cache.CacheManager;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.groute.groute_server.common.config.CacheConfig;
 import com.groute.groute_server.common.exception.BusinessException;
 import com.groute.groute_server.common.exception.ErrorCode;
 import com.groute.groute_server.record.application.port.in.scrum.BulkWriteScrumCommand;
@@ -48,6 +52,7 @@ public class ScrumBulkWriteService implements BulkWriteScrumUseCase {
     private final StarImageCascadeCleaner starImageCascadeCleaner;
     private final UserReferencePort userReferencePort;
     private final UserStreakPort userStreakPort;
+    private final CacheManager cacheManager;
 
     @Override
     public BulkWriteScrumResult bulkWrite(BulkWriteScrumCommand command) {
@@ -137,7 +142,18 @@ public class ScrumBulkWriteService implements BulkWriteScrumUseCase {
                     new BulkWriteScrumResult.GroupResult(
                             projects.get(i).getName(), savedTitles.get(i).getFreeText(), items));
         }
+
+        // 9. calendar:monthly 캐시 무효화
+        evictCalendarMonthly(command.userId(), command.date());
+
         return new BulkWriteScrumResult(results);
+    }
+
+    private void evictCalendarMonthly(Long userId, java.time.LocalDate date) {
+        Cache cache = cacheManager.getCache(CacheConfig.CACHE_CALENDAR_MONTHLY);
+        if (cache != null) {
+            cache.evict(userId + ":" + YearMonth.from(date));
+        }
     }
 
     private void cleanupPendingSession(List<Scrum> scrums) {

--- a/src/main/java/com/groute/groute_server/record/application/service/ScrumBulkWriteService.java
+++ b/src/main/java/com/groute/groute_server/record/application/service/ScrumBulkWriteService.java
@@ -14,6 +14,7 @@ import org.springframework.transaction.annotation.Transactional;
 import com.groute.groute_server.common.config.CacheConfig;
 import com.groute.groute_server.common.exception.BusinessException;
 import com.groute.groute_server.common.exception.ErrorCode;
+import com.groute.groute_server.common.transaction.AfterCommitExecutor;
 import com.groute.groute_server.record.application.port.in.scrum.BulkWriteScrumCommand;
 import com.groute.groute_server.record.application.port.in.scrum.BulkWriteScrumResult;
 import com.groute.groute_server.record.application.port.in.scrum.BulkWriteScrumUseCase;
@@ -53,6 +54,7 @@ public class ScrumBulkWriteService implements BulkWriteScrumUseCase {
     private final UserReferencePort userReferencePort;
     private final UserStreakPort userStreakPort;
     private final CacheManager cacheManager;
+    private final AfterCommitExecutor afterCommitExecutor;
 
     @Override
     public BulkWriteScrumResult bulkWrite(BulkWriteScrumCommand command) {
@@ -150,10 +152,14 @@ public class ScrumBulkWriteService implements BulkWriteScrumUseCase {
     }
 
     private void evictCalendarMonthly(Long userId, java.time.LocalDate date) {
-        Cache cache = cacheManager.getCache(CacheConfig.CACHE_CALENDAR_MONTHLY);
-        if (cache != null) {
-            cache.evict(userId + ":" + YearMonth.from(date));
-        }
+        final YearMonth month = YearMonth.from(date);
+        afterCommitExecutor.execute(
+                () -> {
+                    Cache cache = cacheManager.getCache(CacheConfig.CACHE_CALENDAR_MONTHLY);
+                    if (cache != null) {
+                        cache.evict(userId + ":" + month);
+                    }
+                });
     }
 
     private void cleanupPendingSession(List<Scrum> scrums) {

--- a/src/main/java/com/groute/groute_server/record/application/service/ScrumSyncService.java
+++ b/src/main/java/com/groute/groute_server/record/application/service/ScrumSyncService.java
@@ -1,6 +1,7 @@
 package com.groute.groute_server.record.application.service;
 
 import java.time.LocalDate;
+import java.time.YearMonth;
 import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -10,9 +11,12 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import org.springframework.cache.Cache;
+import org.springframework.cache.CacheManager;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.groute.groute_server.common.config.CacheConfig;
 import com.groute.groute_server.common.exception.BusinessException;
 import com.groute.groute_server.common.exception.ErrorCode;
 import com.groute.groute_server.common.util.DateTimeFormatters;
@@ -51,6 +55,7 @@ public class ScrumSyncService implements SyncDailyScrumUseCase {
     private final StarImageCascadeCleaner starImageCascadeCleaner;
     private final UserReferencePort userReferencePort;
     private final UserStreakPort userStreakPort;
+    private final CacheManager cacheManager;
 
     /**
      * 일자별 스크럼을 요청 payload 상태로 동기화.
@@ -168,6 +173,12 @@ public class ScrumSyncService implements SyncDailyScrumUseCase {
         int survivingCount = currentScrums.size() - toDelete.size() + toCreate.size();
         if (survivingCount > 0) {
             userStreakPort.recordOnDate(command.userId(), command.date());
+        }
+
+        // 10. calendar:monthly 캐시 무효화
+        Cache cache = cacheManager.getCache(CacheConfig.CACHE_CALENDAR_MONTHLY);
+        if (cache != null) {
+            cache.evict(command.userId() + ":" + YearMonth.from(command.date()));
         }
     }
 

--- a/src/main/java/com/groute/groute_server/record/application/service/ScrumSyncService.java
+++ b/src/main/java/com/groute/groute_server/record/application/service/ScrumSyncService.java
@@ -19,6 +19,7 @@ import org.springframework.transaction.annotation.Transactional;
 import com.groute.groute_server.common.config.CacheConfig;
 import com.groute.groute_server.common.exception.BusinessException;
 import com.groute.groute_server.common.exception.ErrorCode;
+import com.groute.groute_server.common.transaction.AfterCommitExecutor;
 import com.groute.groute_server.common.util.DateTimeFormatters;
 import com.groute.groute_server.record.application.port.in.scrum.SyncDailyScrumCommand;
 import com.groute.groute_server.record.application.port.in.scrum.SyncDailyScrumUseCase;
@@ -56,6 +57,7 @@ public class ScrumSyncService implements SyncDailyScrumUseCase {
     private final UserReferencePort userReferencePort;
     private final UserStreakPort userStreakPort;
     private final CacheManager cacheManager;
+    private final AfterCommitExecutor afterCommitExecutor;
 
     /**
      * 일자별 스크럼을 요청 payload 상태로 동기화.
@@ -175,11 +177,16 @@ public class ScrumSyncService implements SyncDailyScrumUseCase {
             userStreakPort.recordOnDate(command.userId(), command.date());
         }
 
-        // 10. calendar:monthly 캐시 무효화
-        Cache cache = cacheManager.getCache(CacheConfig.CACHE_CALENDAR_MONTHLY);
-        if (cache != null) {
-            cache.evict(command.userId() + ":" + YearMonth.from(command.date()));
-        }
+        // 10. calendar:monthly 캐시 무효화 (커밋 후)
+        final Long userId = command.userId();
+        final YearMonth evictMonth = YearMonth.from(command.date());
+        afterCommitExecutor.execute(
+                () -> {
+                    Cache cache = cacheManager.getCache(CacheConfig.CACHE_CALENDAR_MONTHLY);
+                    if (cache != null) {
+                        cache.evict(userId + ":" + evictMonth);
+                    }
+                });
     }
 
     /** 14일 초과 또는 hasStar=true인 변경 대상이면 예외. */

--- a/src/main/java/com/groute/groute_server/report/application/service/ReportQueryService.java
+++ b/src/main/java/com/groute/groute_server/report/application/service/ReportQueryService.java
@@ -79,7 +79,7 @@ public class ReportQueryService
      *
      * <p>소유자 검증 후 MINI/CAREER 타입별 content를 반환한다.
      */
-    @Cacheable(cacheNames = CacheConfig.CACHE_REPORTS_DETAIL, key = "#reportId")
+    @Cacheable(cacheNames = CacheConfig.CACHE_REPORTS_DETAIL, key = "#userId + ':' + #reportId")
     @Override
     public ReportDetailView getDetail(Long reportId, Long userId) {
         Report report =

--- a/src/main/java/com/groute/groute_server/report/application/service/ReportQueryService.java
+++ b/src/main/java/com/groute/groute_server/report/application/service/ReportQueryService.java
@@ -4,9 +4,11 @@ import java.time.OffsetDateTime;
 import java.util.List;
 import java.util.Objects;
 
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.groute.groute_server.common.config.CacheConfig;
 import com.groute.groute_server.common.exception.BusinessException;
 import com.groute.groute_server.common.exception.ErrorCode;
 import com.groute.groute_server.report.application.port.in.GetReportDetailUseCase;
@@ -77,6 +79,7 @@ public class ReportQueryService
      *
      * <p>소유자 검증 후 MINI/CAREER 타입별 content를 반환한다.
      */
+    @Cacheable(cacheNames = CacheConfig.CACHE_REPORTS_DETAIL, key = "#reportId")
     @Override
     public ReportDetailView getDetail(Long reportId, Long userId) {
         Report report =

--- a/src/main/java/com/groute/groute_server/user/service/UserService.java
+++ b/src/main/java/com/groute/groute_server/user/service/UserService.java
@@ -78,6 +78,7 @@ public class UserService {
      * 존재 여부로 {@link ErrorCode#USER_NOT_FOUND}와 {@link ErrorCode#ONBOARDING_ALREADY_COMPLETED}를
      * 구분한다.
      */
+    @CacheEvict(cacheNames = CacheConfig.CACHE_USERS_ME, key = "#userId")
     @Transactional
     public User completeOnboarding(
             Long userId, String nickname, String jobRoleLabel, String userStatusLabel) {

--- a/src/main/java/com/groute/groute_server/user/service/UserService.java
+++ b/src/main/java/com/groute/groute_server/user/service/UserService.java
@@ -3,10 +3,13 @@ package com.groute.groute_server.user.service;
 import java.time.Clock;
 import java.time.Duration;
 
+import org.springframework.cache.annotation.CacheEvict;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.groute.groute_server.auth.repository.RefreshTokenRepository;
+import com.groute.groute_server.common.config.CacheConfig;
 import com.groute.groute_server.common.exception.BusinessException;
 import com.groute.groute_server.common.exception.ErrorCode;
 import com.groute.groute_server.user.config.UserProperties;
@@ -41,6 +44,7 @@ public class UserService {
     }
 
     /** 내 프로필 조회 — 존재하지 않으면 {@link ErrorCode#USER_NOT_FOUND}. */
+    @Cacheable(cacheNames = CacheConfig.CACHE_USERS_ME, key = "#userId")
     public User getMyProfile(Long userId) {
         return userRepository
                 .findById(userId)
@@ -54,6 +58,7 @@ public class UserService {
      * ErrorCode#INVALID_USER_STATUS}. enum에서 던지는 {@link IllegalArgumentException}을 {@link
      * BusinessException}으로 래핑해 일관된 에러 포맷을 유지한다.
      */
+    @CacheEvict(cacheNames = CacheConfig.CACHE_USERS_ME, key = "#userId")
     @Transactional
     public User updateMyProfile(Long userId, String jobRoleLabel, String userStatusLabel) {
         JobRole jobRole = parseJobRole(jobRoleLabel);
@@ -109,6 +114,7 @@ public class UserService {
      *
      * @param userId 탈퇴할 사용자 ID
      */
+    @CacheEvict(cacheNames = CacheConfig.CACHE_USERS_ME, key = "#userId")
     @Transactional
     public void deleteMyAccount(Long userId) {
         User user =

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -252,6 +252,7 @@ logging:
     com.groute: DEBUG
     org.hibernate.SQL: DEBUG
     org.hibernate.orm.jdbc.bind: TRACE
+    org.springframework.cache: TRACE
 
 ---
 # ===== Staging 환경 =====

--- a/src/test/java/com/groute/groute_server/record/application/service/DeleteScrumServiceTest.java
+++ b/src/test/java/com/groute/groute_server/record/application/service/DeleteScrumServiceTest.java
@@ -24,6 +24,7 @@ import org.springframework.test.util.ReflectionTestUtils;
 
 import com.groute.groute_server.common.exception.BusinessException;
 import com.groute.groute_server.common.exception.ErrorCode;
+import com.groute.groute_server.common.transaction.AfterCommitExecutor;
 import com.groute.groute_server.record.application.port.in.scrum.DeleteScrumCommand;
 import com.groute.groute_server.record.application.port.out.scrum.ScrumQueryPort;
 import com.groute.groute_server.record.application.port.out.scrum.ScrumWritePort;
@@ -48,6 +49,7 @@ class DeleteScrumServiceTest {
     @Mock StarRecordCascadePort starRecordCascadePort;
     @Mock StarImageCascadeCleaner starImageCascadeCleaner;
     @Mock CacheManager cacheManager;
+    @Mock AfterCommitExecutor afterCommitExecutor;
 
     @InjectMocks DeleteScrumService service;
 

--- a/src/test/java/com/groute/groute_server/record/application/service/DeleteScrumServiceTest.java
+++ b/src/test/java/com/groute/groute_server/record/application/service/DeleteScrumServiceTest.java
@@ -19,6 +19,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.cache.CacheManager;
 import org.springframework.test.util.ReflectionTestUtils;
 
 import com.groute.groute_server.common.exception.BusinessException;
@@ -46,6 +47,7 @@ class DeleteScrumServiceTest {
     @Mock ScrumTitleRepositoryPort scrumTitleRepositoryPort;
     @Mock StarRecordCascadePort starRecordCascadePort;
     @Mock StarImageCascadeCleaner starImageCascadeCleaner;
+    @Mock CacheManager cacheManager;
 
     @InjectMocks DeleteScrumService service;
 

--- a/src/test/java/com/groute/groute_server/record/application/service/ScrumBulkWriteServiceTest.java
+++ b/src/test/java/com/groute/groute_server/record/application/service/ScrumBulkWriteServiceTest.java
@@ -27,6 +27,7 @@ import org.springframework.test.util.ReflectionTestUtils;
 
 import com.groute.groute_server.common.exception.BusinessException;
 import com.groute.groute_server.common.exception.ErrorCode;
+import com.groute.groute_server.common.transaction.AfterCommitExecutor;
 import com.groute.groute_server.record.application.port.in.scrum.BulkWriteScrumCommand;
 import com.groute.groute_server.record.application.port.in.scrum.BulkWriteScrumResult;
 import com.groute.groute_server.record.application.port.out.ProjectPort;
@@ -57,6 +58,7 @@ class ScrumBulkWriteServiceTest {
     @Mock UserReferencePort userReferencePort;
     @Mock UserStreakPort userStreakPort;
     @Mock CacheManager cacheManager;
+    @Mock AfterCommitExecutor afterCommitExecutor;
 
     @InjectMocks ScrumBulkWriteService service;
 

--- a/src/test/java/com/groute/groute_server/record/application/service/ScrumBulkWriteServiceTest.java
+++ b/src/test/java/com/groute/groute_server/record/application/service/ScrumBulkWriteServiceTest.java
@@ -22,6 +22,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.cache.CacheManager;
 import org.springframework.test.util.ReflectionTestUtils;
 
 import com.groute.groute_server.common.exception.BusinessException;
@@ -55,6 +56,7 @@ class ScrumBulkWriteServiceTest {
     @Mock StarImageCascadeCleaner starImageCascadeCleaner;
     @Mock UserReferencePort userReferencePort;
     @Mock UserStreakPort userStreakPort;
+    @Mock CacheManager cacheManager;
 
     @InjectMocks ScrumBulkWriteService service;
 

--- a/src/test/java/com/groute/groute_server/record/application/service/ScrumSyncServiceTest.java
+++ b/src/test/java/com/groute/groute_server/record/application/service/ScrumSyncServiceTest.java
@@ -26,6 +26,7 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.cache.CacheManager;
 import org.springframework.test.util.ReflectionTestUtils;
 
 import com.groute.groute_server.common.exception.BusinessException;
@@ -58,6 +59,7 @@ class ScrumSyncServiceTest {
     @Mock StarImageCascadeCleaner starImageCascadeCleaner;
     @Mock UserReferencePort userReferencePort;
     @Mock UserStreakPort userStreakPort;
+    @Mock CacheManager cacheManager;
 
     @InjectMocks ScrumSyncService service;
 

--- a/src/test/java/com/groute/groute_server/record/application/service/ScrumSyncServiceTest.java
+++ b/src/test/java/com/groute/groute_server/record/application/service/ScrumSyncServiceTest.java
@@ -31,6 +31,7 @@ import org.springframework.test.util.ReflectionTestUtils;
 
 import com.groute.groute_server.common.exception.BusinessException;
 import com.groute.groute_server.common.exception.ErrorCode;
+import com.groute.groute_server.common.transaction.AfterCommitExecutor;
 import com.groute.groute_server.record.application.port.in.scrum.SyncDailyScrumCommand;
 import com.groute.groute_server.record.application.port.in.scrum.SyncDailyScrumCommand.GroupCommand;
 import com.groute.groute_server.record.application.port.in.scrum.SyncDailyScrumCommand.ItemCommand;
@@ -60,6 +61,7 @@ class ScrumSyncServiceTest {
     @Mock UserReferencePort userReferencePort;
     @Mock UserStreakPort userStreakPort;
     @Mock CacheManager cacheManager;
+    @Mock AfterCommitExecutor afterCommitExecutor;
 
     @InjectMocks ScrumSyncService service;
 

--- a/src/test/java/com/groute/groute_server/record/service/AiTaggingServiceTest.java
+++ b/src/test/java/com/groute/groute_server/record/service/AiTaggingServiceTest.java
@@ -27,6 +27,7 @@ import org.springframework.transaction.support.TransactionSynchronizationManager
 
 import com.groute.groute_server.common.exception.BusinessException;
 import com.groute.groute_server.common.exception.ErrorCode;
+import com.groute.groute_server.common.transaction.AfterCommitExecutor;
 import com.groute.groute_server.record.adapter.in.web.dto.AiTaggingResultResponse;
 import com.groute.groute_server.record.adapter.in.web.dto.AiTaggingStatusResponse;
 import com.groute.groute_server.record.application.port.out.AiTaggingJobPort;
@@ -67,6 +68,7 @@ class AiTaggingServiceTest {
     @Mock private UserPort userPort;
     @Mock private AiTaggingAsyncExecutor aiTaggingAsyncExecutor;
     @Mock private CacheManager cacheManager;
+    @Mock private AfterCommitExecutor afterCommitExecutor;
 
     @InjectMocks private AiTaggingService aiTaggingService;
 

--- a/src/test/java/com/groute/groute_server/record/service/AiTaggingServiceTest.java
+++ b/src/test/java/com/groute/groute_server/record/service/AiTaggingServiceTest.java
@@ -21,6 +21,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.cache.CacheManager;
 import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.transaction.support.TransactionSynchronizationManager;
 
@@ -65,6 +66,7 @@ class AiTaggingServiceTest {
     @Mock private ScrumTitleRepositoryPort scrumTitleRepositoryPort;
     @Mock private UserPort userPort;
     @Mock private AiTaggingAsyncExecutor aiTaggingAsyncExecutor;
+    @Mock private CacheManager cacheManager;
 
     @InjectMocks private AiTaggingService aiTaggingService;
 


### PR DESCRIPTION
## 요약
- 읽기 경로 캐싱 부재로 인한 반복 DB 조회를 Redis 캐싱으로 개선 (home/calendar/user/report 조회 hot-path)

## 세부내용
RedisCacheManager TTL 설정 추가 및 @EnableCaching 활성화
조회 hot-path 5개 경로에 @Cacheable 적용 (radar, competency-stats, calendar:monthly, users:me, reports:detail)
데이터 변경 시 캐시 무효화 — STAR 태깅 완료/스크럼 쓰기·삭제/프로필 수정 시 evict 처리
void 반환 메서드(completeTagging)는 CacheManager 직접 주입해 수동 evict
테스트 CacheManager Mock 추가

## 변경 사항
- [x] 기능
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 문서
- [x] 테스트
- [ ] 기타

## 테스트
- [x] 로컬 테스트 완료
- 테스트 방법:
- ./gradlew check
- 로컬 서버 기동 후 Swagger에서 GET /api/home/competency-stats?month=2026-06 2회 호출
- 1차 호출: No cache entry for key 로그 + DB 쿼리 발생
- 2차 호출: Cache entry for key found 로그 + DB 쿼리 없음
- redis-cli KEYS * 로 캐시 키 생성 확인 (home:competency-stats::1:2026-06)

### 커버리지 (JaCoCo)
- 라인 커버리지: 71%  (기준: 60% 이상)
- [x] `./gradlew test` 실행 후 `build/reports/jacoco/index.html`에서 수치 확인

## 스크린샷/로그 (선택)
- 필요한 경우 첨부

## 롤백/리스크
- 리스크 포인트:
- 롤백 방법:

## 관련 이슈
Closes #249

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **성능 개선**
  * 자주 조회하는 데이터(월간 캘린더, 홈 대시보드, 사용자 프로필, 리포트)에 대한 캐싱 시스템을 도입하여 데이터베이스 조회를 줄이고 응답 속도를 개선했습니다.
  * 데이터 생성, 수정, 삭제 시 자동으로 관련 캐시를 무효화하여 데이터 일관성을 유지하도록 개선했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->