### PR TITLE
refactor: 리포트 목록 조회 중복 User 쿼리 제거

### DIFF
--- a/src/main/java/com/groute/groute_server/report/adapter/out/persistence/ReportJpaRepository.java
+++ b/src/main/java/com/groute/groute_server/report/adapter/out/persistence/ReportJpaRepository.java
@@ -19,8 +19,13 @@ import com.groute.groute_server.report.domain.enums.ReportType;
  */
 public interface ReportJpaRepository extends JpaRepository<Report, Long> {
 
-    /** 유저의 리포트 목록을 생성일 기준 내림차순으로 조회한다. */
-    List<Report> findAllByUserIdOrderByCreatedAtDesc(Long userId);
+    /** 유저의 리포트 목록을 생성일 기준 내림차순으로 조회한다. user를 fetch join해 추가 쿼리를 방지한다. */
+    @Query(
+            "SELECT r FROM Report r "
+                    + "JOIN FETCH r.user "
+                    + "WHERE r.user.id = :userId "
+                    + "ORDER BY r.createdAt DESC")
+    List<Report> findAllByUserIdOrderByCreatedAtDesc(@Param("userId") Long userId);
 
     /** 유저의 가장 최근 성공한 리포트를 조회한다. 게이지 계산 기준점으로 사용한다. */
     Optional<Report> findTopByUserIdAndStatusOrderByCreatedAtDesc(Long userId, ReportStatus status);

--- a/src/main/java/com/groute/groute_server/report/application/service/ReportQueryService.java
+++ b/src/main/java/com/groute/groute_server/report/application/service/ReportQueryService.java
@@ -15,7 +15,6 @@ import com.groute.groute_server.report.application.port.in.GetReportListUseCase;
 import com.groute.groute_server.report.application.port.in.dto.ReportDetailView;
 import com.groute.groute_server.report.application.port.in.dto.ReportGaugeView;
 import com.groute.groute_server.report.application.port.in.dto.ReportListView;
-import com.groute.groute_server.report.application.port.out.LoadUserPort;
 import com.groute.groute_server.report.application.port.out.ReportQueryPort;
 import com.groute.groute_server.report.application.port.out.StarRecordCountQueryPort;
 import com.groute.groute_server.report.domain.Report;
@@ -39,7 +38,6 @@ public class ReportQueryService
 
     private final ReportQueryPort reportQueryPort;
     private final StarRecordCountQueryPort starRecordCountQueryPort;
-    private final LoadUserPort loadUserPort;
 
     /**
      * RPT-001: 리포트 게이지 조회.
@@ -68,7 +66,7 @@ public class ReportQueryService
     @Override
     public ReportListView getList(Long userId) {
         List<Report> reports = reportQueryPort.findAllByUserIdOrderByCreatedAtDesc(userId);
-        User user = loadUserPort.findUserById(userId);
+        User user = reports.isEmpty() ? null : reports.get(0).getUser();
         return ReportListView.from(reports, user);
     }
 

--- a/src/test/java/com/groute/groute_server/report/application/service/ReportQueryServiceTest.java
+++ b/src/test/java/com/groute/groute_server/report/application/service/ReportQueryServiceTest.java
@@ -22,7 +22,6 @@ import com.groute.groute_server.common.exception.ErrorCode;
 import com.groute.groute_server.report.application.port.in.dto.ReportDetailView;
 import com.groute.groute_server.report.application.port.in.dto.ReportGaugeView;
 import com.groute.groute_server.report.application.port.in.dto.ReportListView;
-import com.groute.groute_server.report.application.port.out.LoadUserPort;
 import com.groute.groute_server.report.application.port.out.ReportQueryPort;
 import com.groute.groute_server.report.application.port.out.StarRecordCountQueryPort;
 import com.groute.groute_server.report.domain.Report;
@@ -39,7 +38,6 @@ class ReportQueryServiceTest {
 
     @Mock ReportQueryPort reportQueryPort;
     @Mock StarRecordCountQueryPort starRecordCountQueryPort;
-    @Mock LoadUserPort loadUserPort;
 
     @InjectMocks ReportQueryService service;
 
@@ -139,7 +137,6 @@ class ReportQueryServiceTest {
                             OffsetDateTime.now());
             given(reportQueryPort.findAllByUserIdOrderByCreatedAtDesc(USER_ID))
                     .willReturn(List.of(career, mini));
-            given(loadUserPort.findUserById(USER_ID)).willReturn(user(USER_ID));
 
             ReportListView view = service.getList(USER_ID);
 
@@ -153,7 +150,6 @@ class ReportQueryServiceTest {
         void should_returnEmptyList_when_noReports() {
             given(reportQueryPort.findAllByUserIdOrderByCreatedAtDesc(USER_ID))
                     .willReturn(List.of());
-            given(loadUserPort.findUserById(USER_ID)).willReturn(user(USER_ID));
 
             ReportListView view = service.getList(USER_ID);
 


### PR DESCRIPTION
## 요약
- 리포트 목록 조회 시 불필요한 유저 별도 쿼리 제거 (2건 → 1건)

## 상세 내용
- findAllByUserIdOrderByCreatedAtDesc에 JOIN FETCH r.user 추가해 리포트 조회 시 유저 함께 로드
- getList에서 loadUserPort.findUserById 호출 제거, reports.get(0).getUser() 재사용
- LoadUserPort 의존성 ReportQueryService에서 완전 제거

## 변경 사항
- [x] 기능
- [ ] 버그 수정
- [x] 리팩토링
- [ ] 문서
- [x] 테스트
- [ ] 기타

## 테스트
- [ ] 로컬 테스트 완료
- 테스트 방법:
    - ./gradlew check
    - 로컬 서버 기동 후 GET /api/v1/reports 호출, 서버 로그에서 쿼리 1건만 발생 확인

### 커버리지 (JaCoCo)
- 라인 커버리지: 71%  (기준: 60% 이상)
- [x] `./gradlew test` 실행 후 `build/reports/jacoco/index.html`에서 수치 확인

## 스크린샷/로그 (선택)
- 필요한 경우 첨부

## 롤백/리스크
- 리스크 포인트:
- 롤백 방법:

## 관련 이슈
Closes #250 