### PR TITLE
perf: 역량 레이더 집계 복합 인덱스 추가 및 실행계획 검증

### DIFF
--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -48,6 +48,7 @@ spring:
     baseline-version: 1
     baseline-on-migrate: true
     out-of-order: true
+    execute-in-transaction: false
     placeholders:
       social_email_hash_pepper: ${SOCIAL_EMAIL_HASH_PEPPER}
 

--- a/src/main/resources/db/migration/V20260605034500__add_star_records_user_status_deleted_index.sql
+++ b/src/main/resources/db/migration/V20260605034500__add_star_records_user_status_deleted_index.sql
@@ -1,4 +1,6 @@
 -- radar 집계 쿼리(countCompletedByCompetency) 최적화용 복합 인덱스
 -- WHERE sr.user_id = ? AND sr.status = 'TAGGED' AND sr.is_deleted = false
-CREATE INDEX idx_star_records_user_status_deleted
+-- CONCURRENTLY: 인덱스 빌드 중 쓰기 락 없이 운영 트래픽 영향 최소화
+-- Flyway non-transactional migration 필요 (executeInTransaction=false)
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_star_records_user_status_deleted
     ON star_records (user_id, status, is_deleted);

--- a/src/main/resources/db/migration/V20260605034500__add_star_records_user_status_deleted_index.sql
+++ b/src/main/resources/db/migration/V20260605034500__add_star_records_user_status_deleted_index.sql
@@ -1,0 +1,4 @@
+-- radar 집계 쿼리(countCompletedByCompetency) 최적화용 복합 인덱스
+-- WHERE sr.user_id = ? AND sr.status = 'TAGGED' AND sr.is_deleted = false
+CREATE INDEX idx_star_records_user_status_deleted
+    ON star_records (user_id, status, is_deleted);


### PR DESCRIPTION
## 요약
- radar 집계 쿼리(countCompletedByCompetency) 성능 개선을 위해 star_records (user_id, status, is_deleted) 복합 인덱스 추가

## 상세 내용

기존 star_records 인덱스: (user_id, completed_at), (user_id, is_completed) 만 존재
radar 쿼리 WHERE 조건 user_id + status + is_deleted 조합 인덱스 없어 Seq Scan 발생
Flyway 마이그레이션으로 반영 (stg/prod 배포 시 자동 적용)
로컬 데이터 부족해 실행계획 변화 확인 불가, 데이터 성장 시 Index Scan 전환 예상

## 변경 사항
- [ ] 기능
- [ ] 버그 수정
- [x] 리팩토링
- [ ] 문서
- [ ] 테스트
- [x] 기타

## 테스트
- [x] 로컬 테스트 완료
- 테스트 방법:
    - 예) ./gradlew check
    - Seq Scan 유지 (데이터 볼륨 소량이라 PG 옵티마이저 판단, 데이터 성장 시 Index Scan으로 전환 예상)

### 커버리지 (JaCoCo)
- 라인 커버리지: 71%  (기준: 60% 이상)
- [x] `./gradlew test` 실행 후 `build/reports/jacoco/index.html`에서 수치 확인

## 스크린샷/로그 (선택)
- 필요한 경우 첨부

## 롤백/리스크
- 리스크 포인트:
- 롤백 방법:

## 관련 이슈
Closes #251 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **성능 최적화**
  * 데이터베이스 쿼리 성능 개선을 위한 인덱스 최적화를 적용했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->