### PR TITLE
fix: 캐시 히트 시 조회 API 500 수정 (캐시별 타입 지정 직렬화)

### DIFF
--- a/src/main/java/com/groute/groute_server/common/config/CacheConfig.java
+++ b/src/main/java/com/groute/groute_server/common/config/CacheConfig.java
@@ -1,7 +1,9 @@
 package com.groute.groute_server.common.config;
 
 import java.time.Duration;
+import java.time.LocalDate;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 
 import org.springframework.cache.annotation.EnableCaching;
@@ -10,19 +12,30 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.data.redis.cache.RedisCacheConfiguration;
 import org.springframework.data.redis.cache.RedisCacheManager;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
-import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.Jackson2JsonRedisSerializer;
 import org.springframework.data.redis.serializer.RedisSerializationContext;
+import org.springframework.data.redis.serializer.RedisSerializer;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import com.groute.groute_server.calendar.service.CalendarMonthlyView;
+import com.groute.groute_server.home.dto.RadarResult;
+import com.groute.groute_server.report.application.port.in.dto.ReportDetailView;
 
 /**
  * Redis 기반 캐시 설정.
  *
  * <p>refresh token용 {@link org.springframework.data.redis.core.StringRedisTemplate}과 완전히 분리된 {@link
- * RedisCacheManager}를 구성한다. {@link JavaTimeModule}을 주입한 {@link ObjectMapper}로 {@code LocalDate} 등
- * JSR-310 타입 직렬화를 보장한다.
+ * RedisCacheManager}를 구성한다.
+ *
+ * <p>캐시마다 반환 타입을 못박은 {@link Jackson2JsonRedisSerializer}를 사용한다. default typing(@class) 없이 직렬화하던 기존
+ * 방식은 역직렬화 시 타입정보가 없어 {@code LinkedHashMap}으로 복원되어 record/엔티티 캐스팅 실패(500)를 유발했다. 타입을 명시하면 해당 타입으로
+ * 정확히 복원되어 왕복이 안전하다. {@link JavaTimeModule}로 {@code LocalDate}/{@code YearMonth} 등 JSR-310 타입 직렬화를
+ * 보장한다.
+ *
+ * <p>{@code users:me} 캐시는 직군 브랜딩 문구(String)만 담는다. 마이페이지 프로필은 JPA 엔티티를 그대로 캐싱하면 역직렬화가 취약해 캐싱하지
+ * 않는다(필요 시 별도 DTO 캐싱으로 후속 도입).
  */
 @Configuration
 @EnableCaching
@@ -36,26 +49,52 @@ public class CacheConfig {
 
     @Bean
     public RedisCacheManager cacheManager(RedisConnectionFactory cf) {
+        ObjectMapper om = cacheObjectMapper();
+
         Map<String, RedisCacheConfiguration> configs = new HashMap<>();
-        configs.put(CACHE_HOME_RADAR, defaultConfig().entryTtl(Duration.ofHours(1)));
-        configs.put(CACHE_HOME_COMPETENCY_STATS, defaultConfig().entryTtl(Duration.ofHours(1)));
-        configs.put(CACHE_CALENDAR_MONTHLY, defaultConfig().entryTtl(Duration.ofMinutes(30)));
-        configs.put(CACHE_USERS_ME, defaultConfig().entryTtl(Duration.ofMinutes(10)));
-        configs.put(CACHE_REPORTS_DETAIL, defaultConfig().entryTtl(Duration.ofHours(24)));
+        configs.put(
+                CACHE_HOME_RADAR,
+                typedConfig(new Jackson2JsonRedisSerializer<>(om, RadarResult.class))
+                        .entryTtl(Duration.ofHours(1)));
+        configs.put(
+                CACHE_HOME_COMPETENCY_STATS,
+                typedConfig(
+                                new Jackson2JsonRedisSerializer<>(
+                                        om,
+                                        om.getTypeFactory()
+                                                .constructMapType(
+                                                        LinkedHashMap.class,
+                                                        LocalDate.class,
+                                                        Long.class)))
+                        .entryTtl(Duration.ofHours(1)));
+        configs.put(
+                CACHE_CALENDAR_MONTHLY,
+                typedConfig(new Jackson2JsonRedisSerializer<>(om, CalendarMonthlyView.class))
+                        .entryTtl(Duration.ofMinutes(30)));
+        configs.put(
+                CACHE_USERS_ME,
+                typedConfig(new Jackson2JsonRedisSerializer<>(om, String.class))
+                        .entryTtl(Duration.ofMinutes(10)));
+        configs.put(
+                CACHE_REPORTS_DETAIL,
+                typedConfig(new Jackson2JsonRedisSerializer<>(om, ReportDetailView.class))
+                        .entryTtl(Duration.ofHours(24)));
 
         return RedisCacheManager.builder(cf).withInitialCacheConfigurations(configs).build();
     }
 
-    private RedisCacheConfiguration defaultConfig() {
-        ObjectMapper om =
-                new ObjectMapper()
-                        .registerModule(new JavaTimeModule())
-                        .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+    /** JSR-310 타입(LocalDate/YearMonth 등) 직렬화를 보장하는 캐시 전용 ObjectMapper. */
+    ObjectMapper cacheObjectMapper() {
+        return new ObjectMapper()
+                .registerModule(new JavaTimeModule())
+                .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+    }
 
+    private RedisCacheConfiguration typedConfig(RedisSerializer<?> valueSerializer) {
         return RedisCacheConfiguration.defaultCacheConfig()
                 .disableCachingNullValues()
                 .serializeValuesWith(
                         RedisSerializationContext.SerializationPair.fromSerializer(
-                                new GenericJackson2JsonRedisSerializer(om)));
+                                valueSerializer));
     }
 }

--- a/src/main/java/com/groute/groute_server/user/service/UserService.java
+++ b/src/main/java/com/groute/groute_server/user/service/UserService.java
@@ -3,13 +3,10 @@ package com.groute.groute_server.user.service;
 import java.time.Clock;
 import java.time.Duration;
 
-import org.springframework.cache.annotation.CacheEvict;
-import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.groute.groute_server.auth.repository.RefreshTokenRepository;
-import com.groute.groute_server.common.config.CacheConfig;
 import com.groute.groute_server.common.exception.BusinessException;
 import com.groute.groute_server.common.exception.ErrorCode;
 import com.groute.groute_server.user.config.UserProperties;
@@ -44,7 +41,6 @@ public class UserService {
     }
 
     /** 내 프로필 조회 — 존재하지 않으면 {@link ErrorCode#USER_NOT_FOUND}. */
-    @Cacheable(cacheNames = CacheConfig.CACHE_USERS_ME, key = "#userId")
     public User getMyProfile(Long userId) {
         return userRepository
                 .findById(userId)
@@ -58,7 +54,6 @@ public class UserService {
      * ErrorCode#INVALID_USER_STATUS}. enum에서 던지는 {@link IllegalArgumentException}을 {@link
      * BusinessException}으로 래핑해 일관된 에러 포맷을 유지한다.
      */
-    @CacheEvict(cacheNames = CacheConfig.CACHE_USERS_ME, key = "#userId")
     @Transactional
     public User updateMyProfile(Long userId, String jobRoleLabel, String userStatusLabel) {
         JobRole jobRole = parseJobRole(jobRoleLabel);
@@ -78,7 +73,6 @@ public class UserService {
      * 존재 여부로 {@link ErrorCode#USER_NOT_FOUND}와 {@link ErrorCode#ONBOARDING_ALREADY_COMPLETED}를
      * 구분한다.
      */
-    @CacheEvict(cacheNames = CacheConfig.CACHE_USERS_ME, key = "#userId")
     @Transactional
     public User completeOnboarding(
             Long userId, String nickname, String jobRoleLabel, String userStatusLabel) {
@@ -115,7 +109,6 @@ public class UserService {
      *
      * @param userId 탈퇴할 사용자 ID
      */
-    @CacheEvict(cacheNames = CacheConfig.CACHE_USERS_ME, key = "#userId")
     @Transactional
     public void deleteMyAccount(Long userId) {
         User user =

--- a/src/test/java/com/groute/groute_server/common/config/CacheConfigSerializationTest.java
+++ b/src/test/java/com/groute/groute_server/common/config/CacheConfigSerializationTest.java
@@ -1,0 +1,95 @@
+package com.groute.groute_server.common.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.LocalDate;
+import java.time.YearMonth;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.data.redis.serializer.Jackson2JsonRedisSerializer;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.groute.groute_server.calendar.service.CalendarMonthlyView;
+import com.groute.groute_server.home.dto.RadarResult;
+import com.groute.groute_server.record.domain.enums.CompetencyCategory;
+import com.groute.groute_server.report.application.port.in.dto.ReportDetailView;
+import com.groute.groute_server.report.domain.enums.ReportType;
+
+/**
+ * 캐시 값 직렬화 왕복 검증.
+ *
+ * <p>각 캐시가 쓰는 타입 지정 직렬화기로 직렬화 후 역직렬화했을 때 원본과 동일하게 복원되는지 확인한다. 기존에는 타입정보 없이 직렬화해 역직렬화 시 {@code
+ * LinkedHashMap}으로 풀려 record/엔티티 캐스팅에 실패(500)했다. 캐시 단위 테스트가 CacheManager를 Mock 처리하느라 잡지 못한 실제 직렬화
+ * 왕복을 여기서 검증한다.
+ */
+class CacheConfigSerializationTest {
+
+    private final ObjectMapper om = new CacheConfig().cacheObjectMapper();
+
+    private <T> void assertRoundTrips(Jackson2JsonRedisSerializer<T> serializer, T value) {
+        byte[] bytes = serializer.serialize(value);
+        T restored = serializer.deserialize(bytes);
+        assertThat(restored).isEqualTo(value);
+    }
+
+    @Test
+    void radarResult_roundTrips() {
+        RadarResult value =
+                new RadarResult(
+                        0,
+                        5,
+                        Map.of(
+                                CompetencyCategory.PLANNING_EXECUTION, 5,
+                                CompetencyCategory.COLLABORATION, 2));
+        assertRoundTrips(new Jackson2JsonRedisSerializer<>(om, RadarResult.class), value);
+    }
+
+    @Test
+    void competencyStatsMap_roundTrips() {
+        Jackson2JsonRedisSerializer<Map<LocalDate, Long>> serializer =
+                new Jackson2JsonRedisSerializer<>(
+                        om,
+                        om.getTypeFactory()
+                                .constructMapType(
+                                        LinkedHashMap.class, LocalDate.class, Long.class));
+        Map<LocalDate, Long> value = new LinkedHashMap<>();
+        value.put(LocalDate.of(2026, 5, 1), 3L);
+        value.put(LocalDate.of(2026, 5, 2), 1L);
+        assertRoundTrips(serializer, value);
+    }
+
+    @Test
+    void calendarMonthlyView_roundTrips() {
+        CalendarMonthlyView value =
+                new CalendarMonthlyView(
+                        YearMonth.of(2026, 5),
+                        List.of(
+                                new CalendarMonthlyView.DayAggregate(
+                                        LocalDate.of(2026, 5, 1),
+                                        true,
+                                        true,
+                                        CompetencyCategory.COLLABORATION,
+                                        2),
+                                new CalendarMonthlyView.DayAggregate(
+                                        LocalDate.of(2026, 5, 2), false, false, null, 0)));
+        assertRoundTrips(new Jackson2JsonRedisSerializer<>(om, CalendarMonthlyView.class), value);
+    }
+
+    @Test
+    void reportDetailView_roundTrips() {
+        Map<String, Object> content = new LinkedHashMap<>();
+        content.put("title", "성장 리포트");
+        content.put("scores", List.of(1, 2, 3));
+        ReportDetailView value =
+                new ReportDetailView(1L, ReportType.MINI, "2026.05.01", 3, content);
+        assertRoundTrips(new Jackson2JsonRedisSerializer<>(om, ReportDetailView.class), value);
+    }
+
+    @Test
+    void brandingString_roundTrips() {
+        assertRoundTrips(new Jackson2JsonRedisSerializer<>(om, String.class), "백엔드 빌더");
+    }
+}


### PR DESCRIPTION
## 요약
- 캐시 히트 시 record/엔티티가 역직렬화되지 않아 조회 API가 500나던 문제를 캐시별 타입 지정 직렬화로 수정

## 변경 사항
- [ ] 기능
- [x] 버그 수정
- [ ] 리팩토링
- [ ] 문서
- [x] 테스트
- [ ] 기타

세부:
- CacheConfig를 default typing 없는 GenericJackson2JsonRedisSerializer에서 캐시별 Jackson2JsonRedisSerializer<반환타입>로 교체 (radar/competency-stats/monthly/reports:detail)
- users:me는 User 엔티티 캐싱을 제거(엔티티 JSON 캐싱이 역직렬화에 취약). 직군 브랜딩 문구(String)만 캐싱하도록 정리. 마이프로필은 PK 단건이라 캐싱 가치도 낮음(필요 시 DTO 캐싱으로 후속)

## 테스트
- [x] 로컬 테스트 완료
- 테스트 방법:
    - ./gradlew test --tests "*CacheConfigSerializationTest" (캐시 타입별 직렬화 왕복 검증)
    - 스테이징 재현: GET /api/reports/{id} 또는 /api/calendar/monthly 연속 2회. 수정 전 1st 200 / 2nd 500, 수정 후 둘 다 200

### 커버리지 (JaCoCo)
- config/dto는 커버리지 제외 대상이라 수치 영향 미미
- [x] ./gradlew test 후 build/reports/jacoco/index.html 확인

## 스크린샷/로그 (선택)
- 증상: {"success":false,"code":"COMMON_003","message":"서버 내부 오류가 발생했습니다."} HTTP 500
- 원인: default typing 없는 ObjectMapper로 직렬화 -> 역직렬화 시 @class 부재로 LinkedHashMap 복원 -> record/엔티티 캐스팅 실패. competency-stats만 정상이던 건 반환이 Map이라 우연히 들어맞았기 때문
- 누락 경위: 캐시 단위 테스트가 CacheManager를 Mock 처리해 실제 직렬화 왕복이 검증되지 않음. 본 PR에서 직렬화 왕복 테스트 추가

## 롤백/리스크
- 리스크: 캐시 값 직렬화 방식 변경. 기존 캐시 항목은 plain JSON이라 신규 타입 지정 직렬화기로 그대로 읽혀 추가 flush 없이 정상화됨. 배포 직후 해당 엔드포인트 200 여부 모니터링 권장
- 롤백 방법: 본 커밋 revert

## 관련 이슈
Closes #256


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **개선 사항**
  * 캐시 직렬화 설정을 최적화하여 데이터 무결성을 강화했습니다.

* **버그 수정**
  * 사용자 프로필 관련 기능의 캐시 처리 로직을 조정했습니다.

* **Tests**
  * 캐시 직렬화 동작을 검증하는 테스트를 추가했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->