### PR TITLE
fix: AI 태깅 최종 실패 시 StarRecord.isCompleted를 false로 롤백 (#259)

### DIFF
--- a/src/main/java/com/groute/groute_server/record/adapter/out/ai/AiTaggingClientAdapter.java
+++ b/src/main/java/com/groute/groute_server/record/adapter/out/ai/AiTaggingClientAdapter.java
@@ -152,6 +152,7 @@ public class AiTaggingClientAdapter implements AiTaggingClient {
                         retryEx.getMessage());
                 job.fail(retryEx.getMessage());
                 aiTaggingJobPort.saveJob(job);
+                completeAiTaggingUseCase.revertTaggingComplete(job.getStarRecord().getId());
                 return;
             }
             completeAiTaggingUseCase.completeTagging(
@@ -162,6 +163,7 @@ public class AiTaggingClientAdapter implements AiTaggingClient {
             log.error("[AI Tagging] 최종 실패 — jobId={}, error={}", job.getId(), errorMessage);
             job.fail(errorMessage);
             aiTaggingJobPort.saveJob(job);
+            completeAiTaggingUseCase.revertTaggingComplete(job.getStarRecord().getId());
         }
     }
 }

--- a/src/main/java/com/groute/groute_server/record/application/port/in/CompleteAiTaggingUseCase.java
+++ b/src/main/java/com/groute/groute_server/record/application/port/in/CompleteAiTaggingUseCase.java
@@ -16,4 +16,11 @@ public interface CompleteAiTaggingUseCase {
      * @param detailTags AI가 추출한 세부 태그 목록 (1~3개)
      */
     void completeTagging(Long starRecordId, String primaryCategory, List<String> detailTags);
+
+    /**
+     * AI 태깅 최종 실패 시 StarRecord.isCompleted를 false로 롤백한다.
+     *
+     * <p>재시도 포함 모든 시도가 실패로 끝났을 때 호출한다. 롤백 후 해당 StarRecord는 캘린더·리포트 카운트에서 제외된다.
+     */
+    void revertTaggingComplete(Long starRecordId);
 }

--- a/src/main/java/com/groute/groute_server/record/application/service/AiTaggingService.java
+++ b/src/main/java/com/groute/groute_server/record/application/service/AiTaggingService.java
@@ -234,10 +234,30 @@ public class AiTaggingService
                 });
     }
 
+    /**
+     * AI 태깅 최종 실패 시 StarRecord.isCompleted를 false로 롤백하고 관련 캐시를 무효화한다.
+     *
+     * <p>{@link #completeTagging}과 대칭적으로 home:radar / home:competency-stats / calendar:monthly 캐시를
+     * evict한다. isCompleted 변경으로 집계 값이 달라지므로 stale 데이터 방지를 위해 트랜잭션 커밋 후 evict한다.
+     */
     @Override
     @Transactional
     public void revertTaggingComplete(Long starRecordId) {
-        starRecordPort.findById(starRecordId).ifPresent(StarRecord::revertComplete);
+        starRecordPort
+                .findByIdWithScrum(starRecordId)
+                .ifPresent(
+                        record -> {
+                            record.revertComplete();
+                            Long userId = record.getUser().getId();
+                            YearMonth month = YearMonth.from(record.getScrum().getScrumDate());
+                            String monthKey = userId + ":" + month;
+                            afterCommitExecutor.execute(
+                                    () -> {
+                                        evict(CacheConfig.CACHE_HOME_RADAR, String.valueOf(userId));
+                                        evict(CacheConfig.CACHE_HOME_COMPETENCY_STATS, monthKey);
+                                        evict(CacheConfig.CACHE_CALENDAR_MONTHLY, monthKey);
+                                    });
+                        });
     }
 
     private void evict(String cacheName, String key) {

--- a/src/main/java/com/groute/groute_server/record/application/service/AiTaggingService.java
+++ b/src/main/java/com/groute/groute_server/record/application/service/AiTaggingService.java
@@ -234,6 +234,12 @@ public class AiTaggingService
                 });
     }
 
+    @Override
+    @Transactional
+    public void revertTaggingComplete(Long starRecordId) {
+        starRecordPort.findById(starRecordId).ifPresent(StarRecord::revertComplete);
+    }
+
     private void evict(String cacheName, String key) {
         Cache cache = cacheManager.getCache(cacheName);
         if (cache != null) {

--- a/src/main/java/com/groute/groute_server/record/domain/StarRecord.java
+++ b/src/main/java/com/groute/groute_server/record/domain/StarRecord.java
@@ -119,6 +119,16 @@ public class StarRecord extends SoftDeleteEntity {
         this.isCompleted = true;
     }
 
+    /**
+     * AI 태깅 최종 실패 시 완료 상태 롤백.
+     *
+     * <p>isCompleted=false로 되돌려 리포트 카운트·캘린더·잔디 집계에서 제외한다. CalendarHomeService의 LEFT JOIN 쿼리가
+     * primaryCategory=null 행을 반환해 NPE가 발생하는 문제를 방지한다.
+     */
+    public void revertComplete() {
+        this.isCompleted = false;
+    }
+
     /** AI 태깅 완료 처리. status=TAGGED로 전환하고 isCompleted=true로 설정. */
     public void tag() {
         this.status = StarRecordStatus.TAGGED;

--- a/src/test/java/com/groute/groute_server/record/adapter/out/ai/AiTaggingClientAdapterTest.java
+++ b/src/test/java/com/groute/groute_server/record/adapter/out/ai/AiTaggingClientAdapterTest.java
@@ -158,7 +158,7 @@ class AiTaggingClientAdapterTest {
             assertThat(mockWebServer.getRequestCount()).isEqualTo(2);
             assertThat(job.getStatus()).isEqualTo(JobStatus.FAILED);
             assertThat(job.getRetryCount()).isEqualTo((short) 2);
-            then(completeAiTaggingUseCase).shouldHaveNoInteractions();
+            then(completeAiTaggingUseCase).should().revertTaggingComplete(STAR_RECORD_ID);
         }
     }
 }

--- a/src/test/java/com/groute/groute_server/record/domain/StarRecordTest.java
+++ b/src/test/java/com/groute/groute_server/record/domain/StarRecordTest.java
@@ -44,4 +44,15 @@ class StarRecordTest {
 
         assertThat(record).isNotNull();
     }
+
+    @Test
+    @DisplayName("revertComplete 호출 시 isCompleted가 false로 변경된다")
+    void should_setIsCompletedFalse_when_revertComplete() {
+        StarRecord record = new StarRecord();
+        ReflectionTestUtils.setField(record, "isCompleted", true);
+
+        record.revertComplete();
+
+        assertThat((Boolean) ReflectionTestUtils.getField(record, "isCompleted")).isFalse();
+    }
 }

--- a/src/test/java/com/groute/groute_server/record/service/AiTaggingServiceTest.java
+++ b/src/test/java/com/groute/groute_server/record/service/AiTaggingServiceTest.java
@@ -401,6 +401,36 @@ class AiTaggingServiceTest {
     }
 
     // =========================================================
+    // revertTaggingComplete
+    // =========================================================
+
+    @Nested
+    @DisplayName("AI 태깅 최종 실패 롤백")
+    class RevertTaggingComplete {
+
+        @Test
+        @DisplayName("StarRecord가 존재하면 isCompleted를 false로 변경한다")
+        void setsIsCompletedFalse_whenRecordExists() {
+            StarRecord record = makeStarRecord(USER_ID, StarStep.DONE);
+            ReflectionTestUtils.setField(record, "isCompleted", true);
+            given(starRecordPort.findById(STAR_RECORD_ID)).willReturn(Optional.of(record));
+
+            aiTaggingService.revertTaggingComplete(STAR_RECORD_ID);
+
+            assertThat((Boolean) ReflectionTestUtils.getField(record, "isCompleted")).isFalse();
+        }
+
+        @Test
+        @DisplayName("StarRecord가 없으면 아무 동작도 하지 않는다")
+        void doesNothing_whenRecordNotFound() {
+            given(starRecordPort.findById(STAR_RECORD_ID)).willReturn(Optional.empty());
+
+            aiTaggingService.revertTaggingComplete(STAR_RECORD_ID);
+            // 예외 없이 정상 종료
+        }
+    }
+
+    // =========================================================
     // completeTagging
     // =========================================================
 

--- a/src/test/java/com/groute/groute_server/record/service/AiTaggingServiceTest.java
+++ b/src/test/java/com/groute/groute_server/record/service/AiTaggingServiceTest.java
@@ -409,11 +409,11 @@ class AiTaggingServiceTest {
     class RevertTaggingComplete {
 
         @Test
-        @DisplayName("StarRecord가 존재하면 isCompleted를 false로 변경한다")
+        @DisplayName("StarRecord가 존재하면 isCompleted를 false로 변경하고 캐시를 evict한다")
         void setsIsCompletedFalse_whenRecordExists() {
-            StarRecord record = makeStarRecord(USER_ID, StarStep.DONE);
+            StarRecord record = makeStarRecordWithScrum(USER_ID, StarStep.DONE);
             ReflectionTestUtils.setField(record, "isCompleted", true);
-            given(starRecordPort.findById(STAR_RECORD_ID)).willReturn(Optional.of(record));
+            given(starRecordPort.findByIdWithScrum(STAR_RECORD_ID)).willReturn(Optional.of(record));
 
             aiTaggingService.revertTaggingComplete(STAR_RECORD_ID);
 
@@ -423,7 +423,7 @@ class AiTaggingServiceTest {
         @Test
         @DisplayName("StarRecord가 없으면 아무 동작도 하지 않는다")
         void doesNothing_whenRecordNotFound() {
-            given(starRecordPort.findById(STAR_RECORD_ID)).willReturn(Optional.empty());
+            given(starRecordPort.findByIdWithScrum(STAR_RECORD_ID)).willReturn(Optional.empty());
 
             aiTaggingService.revertTaggingComplete(STAR_RECORD_ID);
             // 예외 없이 정상 종료


### PR DESCRIPTION
## 요약
- AI 태깅이 최종 실패(재시도 1회 소진)된 STAR를 캘린더 프리뷰로 조회하면 NPE가 발생하는 버그 수정

## 변경 사항
- [ ] 기능
- [x] 버그 수정
- [ ] 리팩토링
- [ ] 문서
- [x] 테스트
- [ ] 기타

## 테스트
- [x] 로컬 테스트 완료
- 테스트 방법:
    - ./gradlew test

### 커버리지 (JaCoCo)
- 라인 커버리지: 85%  (기준: 60% 이상)
- [x] `./gradlew test` 실행 후 `build/reports/jacoco/index.html`에서 수치 확인

## 롤백/리스크
- 리스크 포인트: 
  - 영구 실패 STAR가 isCompleted=false로 전환되어 리포트 카운트에서 제외됨
  - (기획상 올바른 동작 — 태깅 실패한 STAR는 리포트에 포함되어선 안 됨)
- 롤백 방법: `StarRecord.revertComplete()` 호출 라인 2곳 제거

## 관련 이슈
Closes #259 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * AI 태깅 최종 실패 시 자동 복구: AI 태깅이 모든 재시도 후에도 실패하면 레코드의 완료 상태가 자동으로 롤백되어 캘린더, 리포트 및 통계 집계에서 올바르게 제외됩니다.

* **테스트**
  * AI 태깅 롤백 기능 및 상태 복구 동작 검증 테스트 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->