### PR TITLE
fix: GET /api/home/branding — null 브랜딩 캐시 저장 시 500 에러 (#261)

### DIFF
--- a/src/main/java/com/groute/groute_server/home/service/HomeService.java
+++ b/src/main/java/com/groute/groute_server/home/service/HomeService.java
@@ -48,7 +48,10 @@ public class HomeService {
         return new RadarResult(min, max, Collections.unmodifiableMap(categories));
     }
 
-    @Cacheable(cacheNames = CacheConfig.CACHE_USERS_ME, key = "'branding:' + #userId")
+    @Cacheable(
+            cacheNames = CacheConfig.CACHE_USERS_ME,
+            key = "'branding:' + #userId",
+            unless = "#result == null")
     public String getBrandingTitle(Long userId) {
         return userRepository
                 .findById(userId)


### PR DESCRIPTION
## 요약
- CAREER 리포트가 없는 유저의 브랜딩 문구 조회 시 null을 Redis에 캐싱하려다 500 발생하는 버그 수정

## 변경 사항
- [ ] 기능
- [x] 버그 수정
- [ ] 리팩토링
- [ ] 문서
- [ ] 테스트
- [ ] 기타

## 테스트
- [x] 로컬 테스트 완료
- 테스트 방법:
    - ./gradlew test

### 커버리지 (JaCoCo)
- 라인 커버리지: 85%  (기준: 60% 이상)
- [x] `./gradlew test` 실행 후 `build/reports/jacoco/index.html`에서 수치 확인

## 롤백/리스크
- 리스크 포인트: 없음 (null 결과만 캐싱 스킵, 기존 동작 변화 없음)
- 롤백 방법: `unless = "#result == null"` 제거

## 관련 이슈
Closes #261 