### PR TITLE
Fix/#263 revert create index concurrently

### DIFF
--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -48,7 +48,6 @@ spring:
     baseline-version: 1
     baseline-on-migrate: true
     out-of-order: true
-    execute-in-transaction: false
     placeholders:
       social_email_hash_pepper: ${SOCIAL_EMAIL_HASH_PEPPER}
 

--- a/src/main/resources/db/migration/V20260605034500__add_star_records_user_status_deleted_index.sql
+++ b/src/main/resources/db/migration/V20260605034500__add_star_records_user_status_deleted_index.sql
@@ -1,6 +1,4 @@
 -- radar 집계 쿼리(countCompletedByCompetency) 최적화용 복합 인덱스
 -- WHERE sr.user_id = ? AND sr.status = 'TAGGED' AND sr.is_deleted = false
--- CONCURRENTLY: 인덱스 빌드 중 쓰기 락 없이 운영 트래픽 영향 최소화
--- Flyway non-transactional migration 필요 (executeInTransaction=false)
-CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_star_records_user_status_deleted
+CREATE INDEX IF NOT EXISTS idx_star_records_user_status_deleted
     ON star_records (user_id, status, is_deleted);


### PR DESCRIPTION
## 요약
- CREATE INDEX CONCURRENTLY 사용으로 인한 stg 배포 실패 수정

## 상세 내용
CodeRabbit 지적으로 CREATE INDEX → CREATE INDEX CONCURRENTLY 변경했으나 Flyway 마이그레이션 시 커넥션 2개 점유 → HikariCP leak 감지 → 타임아웃 → 배포 실패
CREATE INDEX CONCURRENTLY → CREATE INDEX로 롤백
execute-in-transaction: false 설정 제거

## 변경 사항
- [ ] 기능
- [x] 버그 수정
- [ ] 리팩토링
- [ ] 문서
- [ ] 테스트
- [ ] 기타

## 테스트
- [x] 로컬 테스트 완료
- 테스트 방법:
    - ./gradlew check

### 커버리지 (JaCoCo)
- 라인 커버리지: __%  (기준: 60% 이상)
- [ ] `./gradlew test` 실행 후 `build/reports/jacoco/index.html`에서 수치 확인
- (선택) 리포트 스크린샷 또는 60% 미달/특이사항 공유:

## 스크린샷/로그 (선택)
- 필요한 경우 첨부

## 롤백/리스크
- 리스크 포인트:
- 롤백 방법:

## 관련 이슈
Closes #263 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# Release Notes

* **New Features**
  * Redis 캐싱 시스템 도입으로 홈 대시보드, 캘린더, 레포트 조회 성능 개선

* **Bug Fixes**
  * AI 태깅 실패 시 심화기록 상태 롤백 처리 개선

* **Performance**
  * 주요 데이터 조회 쿼리 최적화로 응답 속도 향상
  * 캐시 기반 조회로 데이터베이스 부하 감소

* **Tests**
  * 전체 사용자 플로우 E2E 테스트 추가 (인증, 온보딩, 기록, 리포트, 캘린더)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->